### PR TITLE
feat(E-003): host version, health sync, and multi-replica SID fix

### DIFF
--- a/app/database/hosts.py
+++ b/app/database/hosts.py
@@ -133,6 +133,7 @@ class HostDB:
         disk_total_gb: float | None = None,
         disk_used_gb: float | None = None,
         disk_available_gb: float | None = None,
+        version: str | None = None,
     ) -> bool:
         values: dict[str, Any] = {
             "memory": memory,
@@ -147,6 +148,8 @@ class HostDB:
             values["disk_used_gb"] = disk_used_gb
         if disk_available_gb is not None:
             values["disk_available_gb"] = disk_available_gb
+        if version is not None:
+            values["version"] = version
 
         async with self._session() as session:
             result = await session.execute(

--- a/app/database/hosts.py
+++ b/app/database/hosts.py
@@ -39,6 +39,7 @@ class HostDB:
             disk_used_gb=row.disk_used_gb,
             disk_available_gb=row.disk_available_gb,
             memory_available_gb=row.memory_available_gb,
+            version=row.version,
             created_at=row.created_at,
         )
 
@@ -57,6 +58,7 @@ class HostDB:
             "disk_used_gb": host.disk_used_gb,
             "disk_available_gb": host.disk_available_gb,
             "memory_available_gb": host.memory_available_gb,
+            "version": host.version,
             "created_at": host.created_at,
         }
 
@@ -175,13 +177,16 @@ class HostDB:
         *,
         gpu_type: str | None = None,
         roles: list[str] | None = None,
+        version: str | None = None,
     ) -> bool:
-        """Persist gpu_type and roles from a registration event in a single UPDATE."""
+        """Persist gpu_type, roles, and version from a registration event."""
         values: dict[str, Any] = {}
         if gpu_type is not None:
             values["gpu_type"] = gpu_type
         if roles is not None:
             values["roles"] = roles
+        if version is not None:
+            values["version"] = version
         if not values:
             return True
 

--- a/app/database/migrations/versions/0002_add_host_version.py
+++ b/app/database/migrations/versions/0002_add_host_version.py
@@ -1,0 +1,34 @@
+"""Add version column to hosts table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-31 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM information_schema.columns"
+            "  WHERE table_name = 'hosts' AND column_name = 'version'"
+            ")"
+        )
+    )
+    if not result.scalar():
+        op.add_column("hosts", sa.Column("version", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("hosts", "version")

--- a/app/database/tables.py
+++ b/app/database/tables.py
@@ -56,6 +56,7 @@ class HostRow(Base):
     disk_used_gb: Mapped[float | None] = mapped_column(Double, nullable=True)
     disk_available_gb: Mapped[float | None] = mapped_column(Double, nullable=True)
     memory_available_gb: Mapped[float | None] = mapped_column(Double, nullable=True)
+    version: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -40,6 +40,7 @@ class Host(BaseModel):
     disk_used_gb: float | None = None
     disk_available_gb: float | None = None
     memory_available_gb: float | None = None
+    version: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/app/models/socketio.py
+++ b/app/models/socketio.py
@@ -43,6 +43,7 @@ class WSRegistration(BaseModel):
     instances: list[dict[str, Any]] = Field(default_factory=list)
     gpu_type: str | None = None
     roles: list[str] = Field(default_factory=list)
+    version: str | None = None
 
 
 class WSLogMessage(BaseModel):
@@ -97,6 +98,7 @@ class HostStatusPayload(BaseModel):
     disk_used_gb: float | None = None
     disk_available_gb: float | None = None
     memory_available_gb: float | None = None
+    version: str | None = None
     connected: bool = False
     timestamp: str = ""
 
@@ -115,6 +117,7 @@ class HostStatusPayload(BaseModel):
             disk_used_gb=host.disk_used_gb,
             disk_available_gb=host.disk_available_gb,
             memory_available_gb=host.memory_available_gb,
+            version=host.version,
             connected=connected,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )

--- a/app/models/socketio.py
+++ b/app/models/socketio.py
@@ -38,7 +38,7 @@ class WSMessage(BaseModel):
 class WSRegistration(BaseModel):
     """Host registration message data."""
 
-    api_key: str
+    api_key: str | None = None
     host_name: str | None = None
     instances: list[dict[str, Any]] = Field(default_factory=list)
     gpu_type: str | None = None

--- a/app/redis_state/hosts.py
+++ b/app/redis_state/hosts.py
@@ -32,13 +32,20 @@ class HostConnectionStore:
         await pipe.execute()
 
     async def unregister_host_by_sid(self, sid: str) -> str | None:
+        """Remove a SID mapping. Only clears CONNECTED_MAP if this SID is
+        still the active one for the host, preventing a stale disconnect
+        from evicting a newer connection."""
         r = redis_client()
         host_id = await r.hget(SID_MAP, sid)
         if host_id:
+            current_sid = await r.hget(CONNECTED_MAP, host_id)
             pipe = r.pipeline()
             pipe.hdel(SID_MAP, sid)
-            pipe.hdel(CONNECTED_MAP, host_id)
+            if current_sid == sid:
+                pipe.hdel(CONNECTED_MAP, host_id)
             await pipe.execute()
+            if current_sid != sid:
+                return None
         else:
             await r.hdel(SID_MAP, sid)
         return host_id

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -86,6 +86,7 @@ async def approve_pending_host(pending_id: str, name: str, url: str) -> str | No
         status=HostStatus.ONLINE,
         gpu_type=gpu_type,
         roles=roles,
+        version=p.get("version"),
     )
     await host_db.add_host(host)
 
@@ -257,11 +258,12 @@ async def host_registration(sid: str, data: dict[str, Any]):
             reg.roles,
             len(reg.instances),
         )
-        if reg.gpu_type or reg.roles:
+        if reg.gpu_type or reg.roles or reg.version:
             await host_db.update_host_registration(
                 host_id,
                 gpu_type=reg.gpu_type,
                 roles=reg.roles or None,
+                version=reg.version,
             )
 
         payload = InstancesUpdatePayload(host_id=host_id, instances=reg.instances)
@@ -283,6 +285,7 @@ async def host_registration(sid: str, data: dict[str, Any]):
             p["instances"] = reg.instances
             p["gpu_type"] = reg.gpu_type
             p["roles"] = reg.roles
+            p["version"] = reg.version
             await host_store.update_pending(pending_id, p)
 
             payload = HostPendingPayload(

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -265,9 +265,6 @@ async def host_registration(sid: str, data: dict[str, Any]):
                 roles=reg.roles or None,
                 version=reg.version,
             )
-            host = await host_db.get_host(host_id)
-            if host:
-                await _emit_host_status(host, connected=True)
 
         payload = InstancesUpdatePayload(host_id=host_id, instances=reg.instances)
         await sio.emit("instances_update", payload.model_dump(), namespace="/webui")

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -399,6 +399,7 @@ async def host_health(sid: str, data: dict[str, Any]):
     disk_total_gb = health_data.get("disk_total_gb")
     disk_used_gb = health_data.get("disk_used_gb")
     disk_available_gb = health_data.get("disk_available_gb")
+    version = health_data.get("version")
 
     if memory:
         await host_db.update_host_memory(
@@ -408,6 +409,7 @@ async def host_health(sid: str, data: dict[str, Any]):
             disk_total_gb=disk_total_gb,
             disk_used_gb=disk_used_gb,
             disk_available_gb=disk_available_gb,
+            version=version,
         )
     elif gpu_type:
         await host_db.update_host_gpu_type(host_id, gpu_type)

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -265,6 +265,9 @@ async def host_registration(sid: str, data: dict[str, Any]):
                 roles=reg.roles or None,
                 version=reg.version,
             )
+            host = await host_db.get_host(host_id)
+            if host:
+                await _emit_host_status(host, connected=True)
 
         payload = InstancesUpdatePayload(host_id=host_id, instances=reg.instances)
         await sio.emit("instances_update", payload.model_dump(), namespace="/webui")


### PR DESCRIPTION
## Description
Persists solar-host package version from Socket.IO registration and from periodic `host_health` updates so control-plane state and the WebUI stay accurate behind multi-replica deployments. Fixes a Redis race where a stale Engine.IO SID disconnect removed the host from `CONNECTED_MAP` while a newer SID was still active (false disconnects and unnecessary `/reconnect` nudges).

## Changes
- Add `version` column on `hosts` (Alembic `0002`) and thread it through `Host`, `HostRow`, CRUD, and REST.
- Extend `WSRegistration` with optional `version`; make `api_key` optional on registration payloads (auth is on connect).
- Persist `version` from `host_registration` and from `host_health` via `update_host_memory`.
- Include `version` in `HostStatusPayload` for WebUI / initial status.
- Store `version` on pending hosts and when approving pending hosts.
- Guard `unregister_host_by_sid`: only delete `CONNECTED_MAP[host_id]` when the disconnecting SID matches the current active SID; return `None` for stale disconnects so `host_disconnect` does not mark the host offline.

## Related Issues
Closes DamitDev/solar-webui/issues/16