### PR TITLE
fix: harden gateway reliability

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     health_ttl_s: float = 3.0
     health_cooldown_s: float = 5.0
     route_connect_timeout_s: float = 0.5
+    route_total_timeout_s: float = 600.0
     route_max_attempts: int = 3
     route_retry_delay_s: float = 0.15
 
@@ -31,6 +32,9 @@ class Settings(BaseSettings):
 
     database_url: str = "postgresql://solar:solar@localhost:5432/solar_gateway"
     redis_url: str = "redis://localhost:6379/0"
+
+    db_pool_size: int = 20
+    db_max_overflow: int = 10
 
 
 settings = Settings()

--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -28,6 +28,8 @@ async def init_db(
     *,
     pool_size: int = 20,
     max_overflow: int = 10,
+    pool_recycle: int = 300,
+    pool_timeout: int = 30,
 ) -> AsyncEngine:
     global _engine, _session_factory
 
@@ -39,6 +41,9 @@ async def init_db(
         sa_url,
         pool_size=pool_size,
         max_overflow=max_overflow,
+        pool_pre_ping=True,
+        pool_recycle=pool_recycle,
+        pool_timeout=pool_timeout,
     )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
     return _engine

--- a/app/database/connection.py
+++ b/app/database/connection.py
@@ -23,14 +23,23 @@ def get_session_factory() -> async_sessionmaker[AsyncSession]:
     return _session_factory
 
 
-async def init_db(database_url: str) -> AsyncEngine:
+async def init_db(
+    database_url: str,
+    *,
+    pool_size: int = 20,
+    max_overflow: int = 10,
+) -> AsyncEngine:
     global _engine, _session_factory
 
     sa_url = database_url
     if sa_url.startswith("postgresql://"):
         sa_url = sa_url.replace("postgresql://", "postgresql+asyncpg://", 1)
 
-    _engine = create_async_engine(sa_url, pool_size=10, max_overflow=5)
+    _engine = create_async_engine(
+        sa_url,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+    )
     _session_factory = async_sessionmaker(_engine, expire_on_commit=False)
     return _engine
 

--- a/app/database/logs.py
+++ b/app/database/logs.py
@@ -9,17 +9,20 @@ Uses a write queue with periodic batch inserts for high throughput.
 
 import asyncio
 import logging
+import time
 from dataclasses import dataclass, asdict
 from typing import Any
 from datetime import datetime, timezone
 
-from sqlalchemy import select, and_
+from sqlalchemy import select, and_, func as sa_func
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from .connection import get_session_factory
 from .tables import GatewayEventRow, GatewayRequestRow
 
 logger = logging.getLogger(__name__)
+
+INFLIGHT_MAX_AGE_S = 900
 
 
 def _utc_now_iso() -> str:
@@ -72,6 +75,7 @@ class RequestInProgress:
     instance_id: str | None = None
     instance_url: str | None = None
     attempts: int = 0
+    created_at: float = 0.0
 
 
 @dataclass
@@ -140,6 +144,20 @@ class GatewayLogger:
             except asyncio.TimeoutError:
                 pass
             await self._flush_all()
+            self._reap_stale_inflight()
+
+    def _reap_stale_inflight(self) -> None:
+        """Remove _inflight entries older than INFLIGHT_MAX_AGE_S (leaked by client disconnects)."""
+        now = time.monotonic()
+        stale = [
+            rid
+            for rid, rip in self._inflight.items()
+            if rip.created_at > 0 and (now - rip.created_at) > INFLIGHT_MAX_AGE_S
+        ]
+        for rid in stale:
+            self._inflight.pop(rid, None)
+        if stale:
+            logger.warning("Reaped %d stale inflight request(s)", len(stale))
 
     async def _flush_all(self) -> None:
         async with self._buffer_lock:
@@ -230,7 +248,7 @@ class GatewayLogger:
             if len(self._event_buffer) >= self.MAX_BUFFER_SIZE:
                 should_flush = True
         if should_flush:
-            asyncio.create_task(self._flush_all())
+            asyncio.ensure_future(self._flush_all())
 
     async def _queue_request(self, summary_dict: dict[str, Any]) -> None:
         async with self._buffer_lock:
@@ -276,6 +294,7 @@ class GatewayLogger:
                         else None
                     ),
                     start_timestamp=timestamp,
+                    created_at=time.monotonic(),
                 )
 
             elif etype == "request_routed":
@@ -289,6 +308,7 @@ class GatewayLogger:
                         endpoint=ep,
                         endpoint_id=endpoint_id,
                         start_timestamp=timestamp,
+                        created_at=time.monotonic(),
                     )
                     self._inflight[request_id] = rip
 
@@ -400,7 +420,9 @@ class GatewayLogger:
             return "missed"
         return "error"
 
-    async def read_requests(
+    # ── SQL-level reads with server-side pagination ───────────
+
+    def _build_request_conditions(
         self,
         start: datetime,
         end: datetime,
@@ -410,17 +432,9 @@ class GatewayLogger:
         model: str | None = None,
         host_id: str | None = None,
         endpoint_id: str | None = None,
-    ) -> list[dict[str, Any]]:
-        await self._flush_all()
-
-        try:
-            session_factory = get_session_factory()
-        except RuntimeError:
-            return []
-
+    ) -> list:
         R = GatewayRequestRow
         conditions = [R.end_timestamp >= start, R.end_timestamp <= end]
-
         if status and status != "all":
             conditions.append(R.status == status)
         if request_type and request_type != "all":
@@ -431,46 +445,221 @@ class GatewayLogger:
             conditions.append(R.host_id == host_id)
         if endpoint_id:
             conditions.append(R.endpoint_id == endpoint_id)
+        return conditions
 
-        stmt = select(R).where(and_(*conditions)).order_by(R.end_timestamp.desc())
+    @staticmethod
+    def _row_to_dict(row: GatewayRequestRow) -> dict[str, Any]:
+        return {
+            "request_id": row.request_id,
+            "request_type": row.request_type,
+            "status": row.status,
+            "model": row.model,
+            "resolved_model": row.resolved_model,
+            "endpoint": row.endpoint,
+            "endpoint_id": str(row.endpoint_id) if row.endpoint_id else None,
+            "client_ip": row.client_ip,
+            "stream": row.stream,
+            "attempts": row.attempts,
+            "start_timestamp": (
+                row.start_timestamp.isoformat() if row.start_timestamp else None
+            ),
+            "end_timestamp": (
+                row.end_timestamp.isoformat() if row.end_timestamp else None
+            ),
+            "duration_s": row.duration_s,
+            "host_id": row.host_id,
+            "host_name": row.host_name,
+            "instance_id": row.instance_id,
+            "instance_url": row.instance_url,
+            "error_message": row.error_message,
+            "prompt_tokens": row.prompt_tokens,
+            "completion_tokens": row.completion_tokens,
+            "total_tokens": row.total_tokens,
+            "decode_tps": row.decode_tps,
+            "decode_ms_per_token": row.decode_ms_per_token,
+        }
+
+    async def read_requests_page(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        status: str | None = None,
+        request_type: str | None = None,
+        model: str | None = None,
+        host_id: str | None = None,
+        endpoint_id: str | None = None,
+        limit: int = 200,
+        offset: int = 0,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Read paginated requests. Returns (items, total_count)."""
+        await self._flush_all()
+
+        try:
+            session_factory = get_session_factory()
+        except RuntimeError:
+            return [], 0
+
+        conditions = self._build_request_conditions(
+            start,
+            end,
+            status=status,
+            request_type=request_type,
+            model=model,
+            host_id=host_id,
+            endpoint_id=endpoint_id,
+        )
 
         async with session_factory() as session:
+            count_stmt = select(sa_func.count()).select_from(
+                select(GatewayRequestRow.id).where(and_(*conditions)).subquery()
+            )
+            total = (await session.execute(count_stmt)).scalar() or 0
+
+            stmt = (
+                select(GatewayRequestRow)
+                .where(and_(*conditions))
+                .order_by(GatewayRequestRow.end_timestamp.desc())
+                .limit(limit)
+                .offset(offset)
+            )
             result = await session.execute(stmt)
             rows = result.scalars().all()
 
-        results: list[dict[str, Any]] = []
-        for row in rows:
-            d: dict[str, Any] = {
-                "request_id": row.request_id,
-                "request_type": row.request_type,
-                "status": row.status,
-                "model": row.model,
-                "resolved_model": row.resolved_model,
-                "endpoint": row.endpoint,
-                "endpoint_id": str(row.endpoint_id) if row.endpoint_id else None,
-                "client_ip": row.client_ip,
-                "stream": row.stream,
-                "attempts": row.attempts,
-                "start_timestamp": (
-                    row.start_timestamp.isoformat() if row.start_timestamp else None
-                ),
-                "end_timestamp": (
-                    row.end_timestamp.isoformat() if row.end_timestamp else None
-                ),
-                "duration_s": row.duration_s,
-                "host_id": row.host_id,
-                "host_name": row.host_name,
-                "instance_id": row.instance_id,
-                "instance_url": row.instance_url,
-                "error_message": row.error_message,
-                "prompt_tokens": row.prompt_tokens,
-                "completion_tokens": row.completion_tokens,
-                "total_tokens": row.total_tokens,
-                "decode_tps": row.decode_tps,
-                "decode_ms_per_token": row.decode_ms_per_token,
-            }
-            results.append(d)
-        return results
+        return [self._row_to_dict(row) for row in rows], total
+
+    async def read_stats(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        request_type: str | None = None,
+        endpoint_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Compute gateway stats entirely in SQL -- no full result set in memory."""
+        await self._flush_all()
+
+        try:
+            session_factory = get_session_factory()
+        except RuntimeError:
+            return {"completed": 0, "missed": 0, "error": 0}
+
+        R = GatewayRequestRow
+        conditions = self._build_request_conditions(
+            start,
+            end,
+            request_type=request_type,
+            endpoint_id=endpoint_id,
+        )
+
+        async with session_factory() as session:
+            agg_stmt = select(
+                sa_func.count().filter(R.status == "success").label("completed"),
+                sa_func.count().filter(R.status == "missed").label("missed"),
+                sa_func.count().filter(R.status == "error").label("error"),
+                sa_func.sum(R.prompt_tokens)
+                .filter(R.status == "success")
+                .label("token_in_total"),
+                sa_func.sum(R.completion_tokens)
+                .filter(R.status == "success")
+                .label("token_out_total"),
+                sa_func.count()
+                .filter(R.status == "success", R.prompt_tokens.isnot(None))
+                .label("p_count"),
+                sa_func.count()
+                .filter(R.status == "success", R.completion_tokens.isnot(None))
+                .label("c_count"),
+            ).where(and_(*conditions))
+            row = (await session.execute(agg_stmt)).one()
+
+            completed = row.completed or 0
+            missed = row.missed or 0
+            error = row.error or 0
+            token_in_total = int(row.token_in_total or 0)
+            token_out_total = int(row.token_out_total or 0)
+            p_count = row.p_count or 0
+            c_count = row.c_count or 0
+
+            model_key = sa_func.coalesce(R.resolved_model, R.model, "unknown")
+            model_stmt = (
+                select(
+                    model_key.label("model_key"),
+                    sa_func.count().label("completed"),
+                    sa_func.coalesce(sa_func.sum(R.prompt_tokens), 0).label("token_in"),
+                    sa_func.coalesce(sa_func.sum(R.completion_tokens), 0).label(
+                        "token_out"
+                    ),
+                    sa_func.coalesce(sa_func.avg(R.duration_s), 0).label(
+                        "avg_duration_s"
+                    ),
+                )
+                .where(and_(*conditions, R.status == "success"))
+                .group_by(model_key)
+            )
+            model_rows = (await session.execute(model_stmt)).all()
+
+            host_stmt = (
+                select(
+                    R.host_id,
+                    sa_func.max(R.host_name).label("host_name"),
+                    sa_func.count().label("completed"),
+                    sa_func.coalesce(sa_func.sum(R.prompt_tokens), 0).label("token_in"),
+                    sa_func.coalesce(sa_func.sum(R.completion_tokens), 0).label(
+                        "token_out"
+                    ),
+                    sa_func.coalesce(sa_func.avg(R.duration_s), 0).label(
+                        "avg_duration_s"
+                    ),
+                )
+                .where(and_(*conditions, R.host_id.isnot(None)))
+                .group_by(R.host_id)
+            )
+            host_rows = (await session.execute(host_stmt)).all()
+
+            E = GatewayEventRow
+            ev_conditions = [
+                E.timestamp >= start,
+                E.timestamp <= end,
+                E.event_type == "request_reroute",
+            ]
+            if endpoint_id:
+                ev_conditions.append(E.endpoint_id == endpoint_id)
+            reroute_stmt = select(sa_func.count(sa_func.distinct(E.request_id))).where(
+                and_(*ev_conditions)
+            )
+            rerouted_unique = (await session.execute(reroute_stmt)).scalar() or 0
+
+        return {
+            "completed": completed,
+            "missed": missed,
+            "error": error,
+            "rerouted_requests": rerouted_unique,
+            "token_in_total": token_in_total,
+            "token_out_total": token_out_total,
+            "avg_tokens_in": (token_in_total / p_count) if p_count else 0,
+            "avg_tokens_out": (token_out_total / c_count) if c_count else 0,
+            "models": [
+                {
+                    "model": r.model_key,
+                    "completed": r.completed,
+                    "token_in": int(r.token_in),
+                    "token_out": int(r.token_out),
+                    "avg_duration_s": float(r.avg_duration_s),
+                }
+                for r in model_rows
+            ],
+            "hosts": [
+                {
+                    "host_id": r.host_id,
+                    "host_name": r.host_name or r.host_id,
+                    "completed": r.completed,
+                    "token_in": int(r.token_in),
+                    "token_out": int(r.token_out),
+                    "avg_duration_s": float(r.avg_duration_s),
+                }
+                for r in host_rows
+            ],
+        }
 
     async def read_events(
         self,
@@ -479,6 +668,7 @@ class GatewayLogger:
         *,
         types: list[str] | None = None,
         endpoint_id: str | None = None,
+        limit: int = 1000,
     ) -> list[dict[str, Any]]:
         await self._flush_all()
 
@@ -495,14 +685,16 @@ class GatewayLogger:
         if endpoint_id:
             conditions.append(E.endpoint_id == endpoint_id)
 
-        stmt = select(E).where(and_(*conditions)).order_by(E.timestamp.asc())
+        stmt = (
+            select(E).where(and_(*conditions)).order_by(E.timestamp.desc()).limit(limit)
+        )
 
         async with session_factory() as session:
             result = await session.execute(stmt)
             rows = result.scalars().all()
 
         results: list[dict[str, Any]] = []
-        for row in rows:
+        for row in reversed(rows):
             evt: dict[str, Any] = {
                 "type": row.event_type,
                 "data": row.data if isinstance(row.data, dict) else {},

--- a/app/database/logs.py
+++ b/app/database/logs.py
@@ -248,7 +248,7 @@ class GatewayLogger:
             if len(self._event_buffer) >= self.MAX_BUFFER_SIZE:
                 should_flush = True
         if should_flush:
-            asyncio.ensure_future(self._flush_all())
+            asyncio.create_task(self._flush_all())
 
     async def _queue_request(self, summary_dict: dict[str, Any]) -> None:
         async with self._buffer_lock:

--- a/app/gateway.py
+++ b/app/gateway.py
@@ -23,20 +23,45 @@ from app.redis_state import registry_store, health_store, routing_store, host_st
 logger = logging.getLogger(__name__)
 
 
+def _task_done_callback(task: asyncio.Task) -> None:
+    """Log exceptions from fire-and-forget tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.error("Background task %s failed: %s", task.get_name(), exc)
+
+
 class OpenAIGateway:
 
     def __init__(self) -> None:
         self.session: aiohttp.ClientSession | None = None
+        self._session_lock = asyncio.Lock()
         self._bg_tasks: list[asyncio.Task[None]] = []
+        self._pending_tasks: set[asyncio.Task] = set()
         self._stop_event: asyncio.Event | None = None
 
     async def _ensure_session(self) -> None:
-        if self.session is None or self.session.closed:
-            self.session = aiohttp.ClientSession()
+        if self.session is not None and not self.session.closed:
+            return
+        async with self._session_lock:
+            if self.session is None or self.session.closed:
+                self.session = aiohttp.ClientSession()
 
     async def close(self) -> None:
         if self.session and not self.session.closed:
             await self.session.close()
+        for t in self._pending_tasks:
+            t.cancel()
+        self._pending_tasks.clear()
+
+    def _spawn_task(self, coro, *, name: str | None = None) -> asyncio.Task:
+        """Create a tracked fire-and-forget task with error logging."""
+        task = asyncio.create_task(coro, name=name)
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+        task.add_done_callback(_task_done_callback)
+        return task
 
     # ── Model registry ────────────────────────────────────────
 
@@ -90,7 +115,10 @@ class OpenAIGateway:
                     if dc_ts is not None:
                         last_req = await host_store.get_reconnect_request_time(host.id)
                         if last_req is None or (now - last_req) >= reconnect_interval:
-                            asyncio.create_task(self._request_host_reconnect(host))
+                            self._spawn_task(
+                                self._request_host_reconnect(host),
+                                name=f"reconnect-{host.id[:8]}",
+                            )
                     poll_hosts.append(host)
 
             for host in grace_hosts:
@@ -234,7 +262,7 @@ class OpenAIGateway:
             try:
                 await self.refresh_model_registry()
             except Exception:
-                pass
+                logger.exception("Registry refresh failed")
             try:
                 await asyncio.wait_for(
                     self._stop_event.wait(),
@@ -249,7 +277,7 @@ class OpenAIGateway:
             try:
                 await self._probe_all_instances_once()
             except Exception:
-                pass
+                logger.exception("Health probe failed")
             try:
                 await asyncio.wait_for(
                     self._stop_event.wait(),
@@ -469,13 +497,15 @@ class OpenAIGateway:
                 free_hosts.append(hid)
 
         if free_hosts:
-
-            async def host_name(hid: str) -> str:
-                h = await host_db.get_host(hid)
-                return h.name if h and h.name else hid
-
-            names = {hid: await host_name(hid) for hid in free_hosts}
-            chosen_host = sorted(free_hosts, key=lambda h: names.get(h, h))[0]
+            host_names = dict(
+                zip(
+                    free_hosts,
+                    await asyncio.gather(
+                        *[self._get_host_name(hid) for hid in free_hosts]
+                    ),
+                )
+            )
+            chosen_host = sorted(free_hosts, key=lambda h: host_names.get(h, h))[0]
         else:
             host_weights: dict[str, float] = {}
             for hid in candidate_host_ids:
@@ -484,12 +514,15 @@ class OpenAIGateway:
             min_weight = min(host_weights.values()) if host_weights else 0.0
             min_hosts = [hid for hid, w in host_weights.items() if w == min_weight]
 
-            async def host_name(hid: str) -> str:
-                h = await host_db.get_host(hid)
-                return h.name if h and h.name else hid
-
-            names = {hid: await host_name(hid) for hid in min_hosts}
-            chosen_host = sorted(min_hosts, key=lambda h: names.get(h, h))[0]
+            host_names = dict(
+                zip(
+                    min_hosts,
+                    await asyncio.gather(
+                        *[self._get_host_name(hid) for hid in min_hosts]
+                    ),
+                )
+            )
+            chosen_host = sorted(min_hosts, key=lambda h: host_names.get(h, h))[0]
 
         host_insts = host_to_instances[chosen_host]
         if len(host_insts) == 1:
@@ -510,6 +543,10 @@ class OpenAIGateway:
 
         rr_idx = await routing_store.next_rr_index(resolved_model)
         return best[rr_idx % len(best)]
+
+    async def _get_host_name(self, host_id: str) -> str:
+        h = await host_db.get_host(host_id)
+        return h.name if h and h.name else host_id
 
     # ── Routing infrastructure ────────────────────────────────
 
@@ -639,7 +676,11 @@ class OpenAIGateway:
                 if weight is not None:
                     await routing_store.remove_weight(instance.host_id, weight)
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to decrement routing counters for %s/%s",
+                    instance.host_id,
+                    instance.instance_id,
+                )
 
     async def _find_instance_or_retry(
         self,
@@ -669,6 +710,12 @@ class OpenAIGateway:
                 model, exclude_keys=attempted, required_endpoint=filter_endpoint
             )
         return None
+
+    def _make_route_timeout(self) -> aiohttp.ClientTimeout:
+        return aiohttp.ClientTimeout(
+            total=settings.route_total_timeout_s,
+            connect=settings.route_connect_timeout_s,
+        )
 
     # ── Public routing API ────────────────────────────────────
 
@@ -747,9 +794,7 @@ class OpenAIGateway:
                         "Authorization": f"Bearer {instance.api_key}",
                         "Content-Type": "application/json",
                     }
-                    timeout = aiohttp.ClientTimeout(
-                        total=None, connect=settings.route_connect_timeout_s
-                    )
+                    timeout = self._make_route_timeout()
 
                     async with self.session.post(
                         url, json=data, headers=headers, timeout=timeout
@@ -848,6 +893,7 @@ class OpenAIGateway:
     ):
         request_id = str(uuid.uuid4())
         start_time = time.time()
+        completed = False
 
         await self._broadcast_routing_event(
             {
@@ -913,9 +959,7 @@ class OpenAIGateway:
                         "Authorization": f"Bearer {instance.api_key}",
                         "Content-Type": "application/json",
                     }
-                    timeout = aiohttp.ClientTimeout(
-                        total=None, connect=settings.route_connect_timeout_s
-                    )
+                    timeout = self._make_route_timeout()
 
                     async with self.session.post(
                         url, json=data, headers=headers, timeout=timeout
@@ -929,6 +973,7 @@ class OpenAIGateway:
                             async for line in response.content:
                                 yield line
 
+                            completed = True
                             duration = time.time() - start_time
                             usage_fields = await self._fetch_last_generation_metrics(
                                 instance.host_id, instance.instance_id
@@ -966,6 +1011,21 @@ class OpenAIGateway:
                     await self._emit_reroute(
                         request_id, model, instance, attempt + 1, endpoint_id
                     )
+                except GeneratorExit:
+                    if not completed:
+                        try:
+                            await self._emit_error(
+                                request_id,
+                                model,
+                                "Client disconnected",
+                                time.time() - start_time,
+                                endpoint_id,
+                                instance=instance,
+                                client_ip=client_ip,
+                            )
+                        except Exception:
+                            pass
+                    return
                 except Exception as e:
                     duration = time.time() - start_time
                     await self._emit_error(

--- a/app/gateway.py
+++ b/app/gateway.py
@@ -32,6 +32,9 @@ def _task_done_callback(task: asyncio.Task) -> None:
         logger.error("Background task %s failed: %s", task.get_name(), exc)
 
 
+_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+
+
 class OpenAIGateway:
 
     def __init__(self) -> None:
@@ -672,15 +675,27 @@ class OpenAIGateway:
                 await routing_store.decrement_active(
                     instance.host_id, instance.instance_id
                 )
-                await routing_store.decrement_host_active(instance.host_id)
-                if weight is not None:
-                    await routing_store.remove_weight(instance.host_id, weight)
             except Exception:
                 logger.warning(
-                    "Failed to decrement routing counters for %s/%s",
+                    "Failed to decrement instance active for %s/%s",
                     instance.host_id,
                     instance.instance_id,
                 )
+            try:
+                await routing_store.decrement_host_active(instance.host_id)
+            except Exception:
+                logger.warning(
+                    "Failed to decrement host active for %s",
+                    instance.host_id,
+                )
+            if weight is not None:
+                try:
+                    await routing_store.remove_weight(instance.host_id, weight)
+                except Exception:
+                    logger.warning(
+                        "Failed to remove weight for %s",
+                        instance.host_id,
+                    )
 
     async def _find_instance_or_retry(
         self,
@@ -829,6 +844,28 @@ class OpenAIGateway:
                                 endpoint_id,
                             )
                             return result
+                        elif response.status in _RETRYABLE_STATUSES:
+                            error_text = await response.text()
+                            logger.warning(
+                                "Retryable %d from %s: %s",
+                                response.status,
+                                instance.url,
+                                error_text[:200],
+                            )
+                            await health_store.mark_failed(
+                                instance.host_id,
+                                instance.instance_id,
+                                cooldown_s=settings.health_cooldown_s,
+                            )
+                            last_error = Exception(f"Upstream {response.status}")
+                            await self._emit_reroute(
+                                request_id,
+                                model,
+                                instance,
+                                attempt + 1,
+                                endpoint_id,
+                            )
+                            continue
                         else:
                             error_text = await response.text()
                             duration = time.time() - start_time
@@ -987,6 +1024,28 @@ class OpenAIGateway:
                                 endpoint_id,
                             )
                             return
+                        elif response.status in _RETRYABLE_STATUSES:
+                            error_text = await response.text()
+                            logger.warning(
+                                "Retryable %d from %s: %s",
+                                response.status,
+                                instance.url,
+                                error_text[:200],
+                            )
+                            await health_store.mark_failed(
+                                instance.host_id,
+                                instance.instance_id,
+                                cooldown_s=settings.health_cooldown_s,
+                            )
+                            last_error = Exception(f"Upstream {response.status}")
+                            await self._emit_reroute(
+                                request_id,
+                                model,
+                                instance,
+                                attempt + 1,
+                                endpoint_id,
+                            )
+                            continue
                         else:
                             error_text = await response.text()
                             duration = time.time() - start_time

--- a/app/main.py
+++ b/app/main.py
@@ -42,8 +42,12 @@ async def lifespan(app: FastAPI):
 
     logger.info("Starting Solar Control v%s ...", __version__)
 
-    await init_db(settings.database_url)
-    logger.info("PostgreSQL connected")
+    await init_db(
+        settings.database_url,
+        pool_size=settings.db_pool_size,
+        max_overflow=settings.db_max_overflow,
+    )
+    logger.info("PostgreSQL connected (pool_size=%d)", settings.db_pool_size)
 
     # Initialize Redis
     await init_redis(settings.redis_url)

--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -1,6 +1,7 @@
 """Gateway-specific models for the model registry and routing."""
 
 from typing import Any, ClassVar
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field
 
@@ -43,11 +44,12 @@ class RegistryEntry(BaseModel):
         port = instance.get("port")
         if not port:
             return None
-        host_base = host_url.rsplit(":", 1)[0]
+        parsed = urlparse(host_url)
+        instance_url = f"{parsed.scheme}://{parsed.hostname}:{port}"
         return cls(
             host_id=host_id,
             instance_id=instance["id"],
-            url=f"{host_base}:{port}",
+            url=instance_url,
             api_key=host_api_key,
             model_alias=instance.get("alias", "unknown"),
             supported_endpoints=instance.get(
@@ -72,11 +74,12 @@ class RegistryEntry(BaseModel):
         if not port:
             return None
         config = instance.get("config", {})
-        host_base = host_url.rsplit(":", 1)[0]
+        parsed = urlparse(host_url)
+        instance_url = f"{parsed.scheme}://{parsed.hostname}:{port}"
         return cls(
             host_id=host_id,
             instance_id=instance["id"],
-            url=f"{host_base}:{port}",
+            url=instance_url,
             api_key=config.get("api_key", ""),
             model_alias=config.get("alias", "unknown"),
             supported_endpoints=instance.get(

--- a/app/redis_state/hosts.py
+++ b/app/redis_state/hosts.py
@@ -24,6 +24,23 @@ PENDING_SID_MAP = "solar:hosts:pending_sids"
 class HostConnectionStore:
     """Host Socket.IO connection state in Redis."""
 
+    # Atomic compare-and-delete: only remove from CONNECTED_MAP if the
+    # current SID still matches, preventing a stale disconnect on one
+    # replica from evicting a newer connection registered on another.
+    _UNREGISTER_SCRIPT = """
+    local host_id = redis.call('hget', KEYS[1], ARGV[1])
+    if not host_id then
+        return nil
+    end
+    redis.call('hdel', KEYS[1], ARGV[1])
+    local current_sid = redis.call('hget', KEYS[2], host_id)
+    if current_sid == ARGV[1] then
+        redis.call('hdel', KEYS[2], host_id)
+        return host_id
+    end
+    return nil
+    """
+
     async def register_host(self, sid: str, host_id: str) -> None:
         r = redis_client()
         pipe = r.pipeline()
@@ -32,23 +49,17 @@ class HostConnectionStore:
         await pipe.execute()
 
     async def unregister_host_by_sid(self, sid: str) -> str | None:
-        """Remove a SID mapping. Only clears CONNECTED_MAP if this SID is
-        still the active one for the host, preventing a stale disconnect
-        from evicting a newer connection."""
+        """Atomically remove a SID mapping. Only clears CONNECTED_MAP if
+        this SID is still the active one for the host (Lua CAS)."""
         r = redis_client()
-        host_id = await r.hget(SID_MAP, sid)
-        if host_id:
-            current_sid = await r.hget(CONNECTED_MAP, host_id)
-            pipe = r.pipeline()
-            pipe.hdel(SID_MAP, sid)
-            if current_sid == sid:
-                pipe.hdel(CONNECTED_MAP, host_id)
-            await pipe.execute()
-            if current_sid != sid:
-                return None
-        else:
-            await r.hdel(SID_MAP, sid)
-        return host_id
+        result = await r.eval(
+            self._UNREGISTER_SCRIPT,
+            2,
+            SID_MAP,
+            CONNECTED_MAP,
+            sid,
+        )
+        return result
 
     async def get_host_id_for_sid(self, sid: str) -> str | None:
         r = redis_client()

--- a/app/redis_state/routing.py
+++ b/app/redis_state/routing.py
@@ -87,7 +87,12 @@ class RoutingStore:
 
     # --- Round-robin per model ---
 
+    RR_TTL_S = 3600
+
     async def next_rr_index(self, model: str) -> int:
         """Get and increment the round-robin index for a model."""
         r = redis_client()
-        return await r.incr(f"{RR_PREFIX}{model}")
+        key = f"{RR_PREFIX}{model}"
+        val = await r.incr(key)
+        await r.expire(key, self.RR_TTL_S)
+        return val

--- a/app/redis_state/routing.py
+++ b/app/redis_state/routing.py
@@ -21,8 +21,10 @@ class RoutingStore:
     async def increment_active(self, host_id: str, instance_id: str) -> int:
         r = redis_client()
         key = f"{ACTIVE_PREFIX}{host_id}:{instance_id}"
-        val = await r.incr(key)
-        await r.expire(key, ACTIVE_TTL_S)
+        pipe = r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, ACTIVE_TTL_S)
+        val, _ = await pipe.execute()
         return val
 
     async def decrement_active(self, host_id: str, instance_id: str) -> int:
@@ -44,8 +46,10 @@ class RoutingStore:
     async def add_weight(self, host_id: str, weight: float) -> float:
         r = redis_client()
         key = f"{WEIGHT_PREFIX}{host_id}"
-        val = await r.incrbyfloat(key, weight)
-        await r.expire(key, ACTIVE_TTL_S)
+        pipe = r.pipeline()
+        pipe.incrbyfloat(key, weight)
+        pipe.expire(key, ACTIVE_TTL_S)
+        val, _ = await pipe.execute()
         return val
 
     async def remove_weight(self, host_id: str, weight: float) -> float:
@@ -67,8 +71,10 @@ class RoutingStore:
     async def increment_host_active(self, host_id: str) -> int:
         r = redis_client()
         key = f"{ACTIVE_PREFIX}host:{host_id}"
-        val = await r.incr(key)
-        await r.expire(key, ACTIVE_TTL_S)
+        pipe = r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, ACTIVE_TTL_S)
+        val, _ = await pipe.execute()
         return val
 
     async def decrement_host_active(self, host_id: str) -> int:
@@ -93,6 +99,8 @@ class RoutingStore:
         """Get and increment the round-robin index for a model."""
         r = redis_client()
         key = f"{RR_PREFIX}{model}"
-        val = await r.incr(key)
-        await r.expire(key, self.RR_TTL_S)
+        pipe = r.pipeline()
+        pipe.incr(key)
+        pipe.expire(key, self.RR_TTL_S)
+        val, _ = await pipe.execute()
         return val

--- a/app/routes/management/gateway.py
+++ b/app/routes/management/gateway.py
@@ -34,116 +34,17 @@ async def get_stats(
     )
     end = _parse_iso(to_ts) or now
 
-    summaries = await gateway_logger.read_requests(
+    stats = await gateway_logger.read_stats(
         start,
         end,
         request_type=request_type if request_type and request_type != "all" else None,
         endpoint_id=endpoint_id,
     )
 
-    completed = sum(1 for s in summaries if s.get("status") == "success")
-    missed = sum(1 for s in summaries if s.get("status") == "missed")
-    error = sum(1 for s in summaries if s.get("status") == "error")
-
-    events = await gateway_logger.read_events(
-        start, end, types=["request_reroute"], endpoint_id=endpoint_id
-    )
-    rerouted_unique = len(
-        {
-            e.get("data", {}).get("request_id")
-            for e in events
-            if e.get("data", {}).get("request_id")
-        }
-    )
-
-    succ = [s for s in summaries if s.get("status") == "success"]
-    p_vals = [
-        int(s["prompt_tokens"])
-        for s in succ
-        if isinstance(s.get("prompt_tokens"), (int, float))
-    ]
-    c_vals = [
-        int(s["completion_tokens"])
-        for s in succ
-        if isinstance(s.get("completion_tokens"), (int, float))
-    ]
-    token_in_total = sum(p_vals) if p_vals else 0
-    token_out_total = sum(c_vals) if c_vals else 0
-
-    by_model: dict[str, dict[str, Any]] = {}
-    for s in succ:
-        key = s.get("resolved_model") or s.get("model") or "unknown"
-        rec = by_model.setdefault(
-            key,
-            {
-                "model": key,
-                "completed": 0,
-                "token_in": 0,
-                "token_out": 0,
-                "dur_sum": 0.0,
-            },
-        )
-        rec["completed"] += 1
-        if isinstance(s.get("prompt_tokens"), (int, float)):
-            rec["token_in"] += int(s["prompt_tokens"])
-        if isinstance(s.get("completion_tokens"), (int, float)):
-            rec["token_out"] += int(s["completion_tokens"])
-        if isinstance(s.get("duration_s"), (int, float)):
-            rec["dur_sum"] += float(s["duration_s"])
-
-    model_rows = [
-        {**v, "avg_duration_s": v["dur_sum"] / v["completed"] if v["completed"] else 0}
-        for v in by_model.values()
-    ]
-    for r in model_rows:
-        r.pop("dur_sum", None)
-
-    by_host: dict[str, dict[str, Any]] = {}
-    for s in summaries:
-        hid = s.get("host_id")
-        if not hid:
-            continue
-        rec = by_host.setdefault(
-            hid,
-            {
-                "host_id": hid,
-                "host_name": s.get("host_name") or hid,
-                "completed": 0,
-                "token_in": 0,
-                "token_out": 0,
-                "dur_sum": 0.0,
-            },
-        )
-        if not rec["host_name"] or rec["host_name"] == hid:
-            rec["host_name"] = s.get("host_name") or hid
-        rec["completed"] += 1
-        if isinstance(s.get("prompt_tokens"), (int, float)):
-            rec["token_in"] += int(s["prompt_tokens"])
-        if isinstance(s.get("completion_tokens"), (int, float)):
-            rec["token_out"] += int(s["completion_tokens"])
-        if isinstance(s.get("duration_s"), (int, float)):
-            rec["dur_sum"] += float(s["duration_s"])
-
-    host_rows = [
-        {**v, "avg_duration_s": v["dur_sum"] / v["completed"] if v["completed"] else 0}
-        for v in by_host.values()
-    ]
-    for r in host_rows:
-        r.pop("dur_sum", None)
-
     return {
         "from": start.isoformat(),
         "to": end.isoformat(),
-        "completed": completed,
-        "missed": missed,
-        "error": error,
-        "rerouted_requests": rerouted_unique,
-        "token_in_total": token_in_total,
-        "token_out_total": token_out_total,
-        "avg_tokens_in": (token_in_total / len(p_vals)) if p_vals else 0,
-        "avg_tokens_out": (token_out_total / len(c_vals)) if c_vals else 0,
-        "models": model_rows,
-        "hosts": host_rows,
+        **stats,
     }
 
 
@@ -163,7 +64,10 @@ async def list_requests(
     start = _parse_iso(from_ts) or (now - timedelta(days=1))
     end = _parse_iso(to_ts) or now
 
-    items = await gateway_logger.read_requests(
+    safe_limit = max(1, min(limit, 1000))
+    offset = max(0, (page - 1) * safe_limit)
+
+    items, total = await gateway_logger.read_requests_page(
         start,
         end,
         status=status if status != "all" else None,
@@ -171,19 +75,17 @@ async def list_requests(
         model=model,
         host_id=host_id,
         endpoint_id=endpoint_id,
+        limit=safe_limit,
+        offset=offset,
     )
-
-    total = len(items)
-    start_idx = max(0, (page - 1) * max(1, limit))
-    page_items = items[start_idx : start_idx + max(1, limit)]
 
     return {
         "from": start.isoformat(),
         "to": end.isoformat(),
         "page": page,
-        "limit": limit,
+        "limit": safe_limit,
         "total": total,
-        "items": page_items,
+        "items": items,
     }
 
 
@@ -200,12 +102,18 @@ async def recent_events(
     end = _parse_iso(to_ts) or now
     wanted = [t.strip() for t in types.split(",") if t.strip()]
 
+    safe_limit = max(1, min(limit, 5000))
+
     events = await gateway_logger.read_events(
-        start, end, types=wanted, endpoint_id=endpoint_id
+        start,
+        end,
+        types=wanted,
+        endpoint_id=endpoint_id,
+        limit=safe_limit,
     )
     return {
         "from": start.isoformat(),
         "to": end.isoformat(),
         "types": wanted,
-        "items": events[-limit:] if len(events) > limit else events,
+        "items": events,
     }

--- a/app/routes/openai.py
+++ b/app/routes/openai.py
@@ -5,6 +5,7 @@ The resolved endpoint_id is stored in request.state by the auth middleware
 and passed through to the gateway for logging.
 """
 
+import json
 import logging
 
 from fastapi import APIRouter, HTTPException, Request
@@ -44,7 +45,8 @@ def _safe_stream(
             async for chunk in stream:
                 yield chunk
         except Exception as e:
-            yield f'data: {{"error": "{str(e)}"}}\n\n'.encode()
+            payload = json.dumps({"error": str(e)})
+            yield f"data: {payload}\n\n".encode()
         finally:
             await stream.aclose()
 

--- a/app/routes/openai.py
+++ b/app/routes/openai.py
@@ -5,6 +5,8 @@ The resolved endpoint_id is stored in request.state by the auth middleware
 and passed through to the gateway for logging.
 """
 
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
@@ -17,11 +19,36 @@ from app.models import (
 )
 from app.gateway import gateway
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1", tags=["openai"])
 
 
 def _get_endpoint_id(request: Request) -> str | None:
     return getattr(request.state, "endpoint_id", None)  # set by auth_middleware
+
+
+def _safe_stream(
+    model: str, endpoint: str, request_data: dict, client_ip: str, endpoint_id
+):
+    """Wrap gateway.stream_request so client disconnects emit a proper error event."""
+
+    async def generator():
+        stream = gateway.stream_request(
+            model,
+            endpoint,
+            request_data,
+            client_ip,
+            endpoint_id=endpoint_id,
+        )
+        try:
+            async for chunk in stream:
+                yield chunk
+        except Exception as e:
+            yield f'data: {{"error": "{str(e)}"}}\n\n'.encode()
+        finally:
+            await stream.aclose()
+
+    return StreamingResponse(generator(), media_type="text/event-stream")
 
 
 @router.get("/models")
@@ -41,21 +68,13 @@ async def chat_completions(request: ChatCompletionRequest, client: Request):
         request_data = request.model_dump(exclude_none=True)
 
         if request.stream:
-
-            async def stream_generator():
-                try:
-                    async for chunk in gateway.stream_request(
-                        request.model,
-                        "/v1/chat/completions",
-                        request_data,
-                        client_ip,
-                        endpoint_id=endpoint_id,
-                    ):
-                        yield chunk
-                except Exception as e:
-                    yield f'data: {{"error": "{str(e)}"}}\n\n'.encode()
-
-            return StreamingResponse(stream_generator(), media_type="text/event-stream")
+            return _safe_stream(
+                request.model,
+                "/v1/chat/completions",
+                request_data,
+                client_ip,
+                endpoint_id,
+            )
         else:
             response = await gateway.route_request(
                 request.model,
@@ -79,21 +98,13 @@ async def completions(request: CompletionRequest, client: Request):
         request_data = request.model_dump(exclude_none=True)
 
         if request.stream:
-
-            async def stream_generator():
-                try:
-                    async for chunk in gateway.stream_request(
-                        request.model,
-                        "/v1/completions",
-                        request_data,
-                        client_ip,
-                        endpoint_id=endpoint_id,
-                    ):
-                        yield chunk
-                except Exception as e:
-                    yield f'data: {{"error": "{str(e)}"}}\n\n'.encode()
-
-            return StreamingResponse(stream_generator(), media_type="text/event-stream")
+            return _safe_stream(
+                request.model,
+                "/v1/completions",
+                request_data,
+                client_ip,
+                endpoint_id,
+            )
         else:
             response = await gateway.route_request(
                 request.model,

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -120,7 +120,10 @@ async def approve_pending_host(pending_id: str, name: str, url: str) -> str | No
     try:
         from app.gateway import gateway
 
-        asyncio.create_task(gateway.refresh_model_registry())
+        gateway._spawn_task(
+            gateway.refresh_model_registry(),
+            name="registry-refresh-approve",
+        )
     except Exception:
         pass
 
@@ -272,7 +275,10 @@ async def host_registration(sid: str, data: dict[str, Any]):
         try:
             from app.gateway import gateway
 
-            asyncio.create_task(gateway.refresh_model_registry())
+            gateway._spawn_task(
+                gateway.refresh_model_registry(),
+                name="registry-refresh-registration",
+            )
         except Exception:
             pass
         return
@@ -346,8 +352,8 @@ async def host_log_batch(sid: str, data: dict[str, Any]):
     host = await host_db.get_host(host_id)
     host_name = host.name if host else None
 
-    for entry in entries:
-        payload = LogPayload(
+    payloads = [
+        LogPayload(
             host_id=host_id,
             host_name=host_name,
             instance_id=entry.get("instance_id"),
@@ -357,8 +363,13 @@ async def host_log_batch(sid: str, data: dict[str, Any]):
                 "line": entry.get("line"),
                 "level": entry.get("level", "info"),
             },
-        )
-        await sio.emit("log", payload.model_dump(), namespace="/webui")
+        ).model_dump()
+        for entry in entries
+    ]
+    await asyncio.gather(
+        *[sio.emit("log", p, namespace="/webui") for p in payloads],
+        return_exceptions=True,
+    )
 
 
 @sio.on("instance_state_batch", namespace="/hosts")
@@ -375,15 +386,20 @@ async def host_instance_state_batch(sid: str, data: dict[str, Any]):
     host = await host_db.get_host(host_id)
     host_name = host.name if host else None
 
-    for entry in entries:
-        payload = InstanceStatePayload(
+    payloads = [
+        InstanceStatePayload(
             host_id=host_id,
             host_name=host_name,
             instance_id=entry.get("instance_id"),
             timestamp=entry.get("timestamp", datetime.now(timezone.utc).isoformat()),
             data=entry.get("data", entry),
-        )
-        await sio.emit("instance_state", payload.model_dump(), namespace="/webui")
+        ).model_dump()
+        for entry in entries
+    ]
+    await asyncio.gather(
+        *[sio.emit("instance_state", p, namespace="/webui") for p in payloads],
+        return_exceptions=True,
+    )
 
 
 @sio.on("host_health", namespace="/hosts")
@@ -449,6 +465,9 @@ async def host_instances_update(sid: str, data: dict[str, Any]):
     try:
         from app.gateway import gateway
 
-        asyncio.create_task(gateway.refresh_model_registry())
+        gateway._spawn_task(
+            gateway.refresh_model_registry(),
+            name="registry-refresh-instances",
+        )
     except Exception:
         pass


### PR DESCRIPTION
# Summary

Comprehensive reliability hardening for solar-control, targeting observed OOMKills, health check
failures during long LLM requests, and multi-replica race conditions.

### Critical fixes
- **Memory leak (inflight tracking):** Handle `GeneratorExit` in stream generators so client
  disconnects properly clean up `_inflight` entries. Add a TTL reaper (15 min) in the flush loop
  to catch any remaining leaked entries.
- **Unbounded query OOM:** Stats and request list endpoints now perform aggregation and pagination
  in SQL (`GROUP BY`, `COUNT`, `SUM`, `LIMIT/OFFSET`) instead of loading entire result sets into
  Python memory. This was the root cause of the year-range query crash.
- **Total timeout for upstream requests:** Added a configurable `route_total_timeout_s` (default
  600s) so non-streaming requests to slow models don't hang indefinitely with `total=None`.

### Atomicity & race conditions
- **Host disconnect TOCTOU:** Replaced the multi-step HGET → HGET → conditional HDEL in
  `unregister_host_by_sid` with an atomic Lua CAS script, preventing stale disconnects on one
  replica from evicting newer connections on another.
- **Redis INCR/EXPIRE non-atomic:** All routing counter increments (`increment_active`,
  `add_weight`, `increment_host_active`, `next_rr_index`) now pipeline INCR + EXPIRE in a single
  round-trip, closing the crash-between-calls window.
- **Routing context partial cleanup:** Each decrement in `_routing_context` (`decrement_active`,
  `decrement_host_active`, `remove_weight`) now has independent `try/except` so a failure in one
  doesn't skip the others.

### Resilience
- **Retry on 502/503/504:** Both `route_request` and `stream_request` now treat upstream
  502/503/504 as retryable (mark instance failed, emit reroute, continue loop) instead of raising
  immediately.
- **DB connection pool health:** Added `pool_pre_ping=True` (auto-discard stale connections),
  `pool_recycle=300`, and `pool_timeout=30` to the SQLAlchemy engine.
- **Session init race:** Protected `_ensure_session` with `asyncio.Lock` to prevent concurrent
  `aiohttp.ClientSession` creation.

### Smaller improvements
- **Fire-and-forget tracking:** All `asyncio.create_task` calls replaced with `_spawn_task` which
  tracks references and logs exceptions via done callbacks.
- **Batch Socket.IO emits:** `host_log_batch` and `host_instance_state_batch` use
  `asyncio.gather` instead of sequential awaits.
- **N+1 host name queries:** `_get_next_instance` fetches host names in parallel with
  `asyncio.gather`.
- **URL parsing safety:** `RegistryEntry.from_ws_instance` / `from_http_instance` use
  `urlparse` instead of `rsplit(":", 1)` which broke on URLs without an explicit port.
- **SSE error JSON safety:** `_safe_stream` uses `json.dumps` instead of f-string interpolation.
- **Round-robin TTL:** Added 1-hour TTL to round-robin Redis keys.
- **Background loop logging:** Registry refresh and health probe loops now log exceptions instead
  of silently swallowing them.
- **Configurable DB pool size:** `db_pool_size` and `db_max_overflow` exposed as settings.

## Files changed (11)

| File | What changed |
|---|---|
| `app/gateway.py` | Session lock, task tracking, retryable 5xx, routing context safety, timeout helper, N+1 fix, exception logging |
| `app/database/logs.py` | Inflight reaper, `read_requests_page` with pagination, `read_stats` with SQL aggregation, event limit |
| `app/database/connection.py` | `pool_pre_ping`, `pool_recycle`, `pool_timeout`, configurable pool size |
| `app/redis_state/hosts.py` | Lua CAS script for atomic unregister |
| `app/redis_state/routing.py` | Pipeline INCR+EXPIRE, RR TTL |
| `app/routes/management/gateway.py` | Delegates to SQL-level `read_stats` / `read_requests_page` |
| `app/routes/openai.py` | `_safe_stream` wrapper with `json.dumps` error encoding |
| `app/models/gateway.py` | `urlparse` for instance URL construction |
| `app/socketio_app/host_handlers.py` | `_spawn_task`, `asyncio.gather` for batch emits |
| `app/config.py` | `route_total_timeout_s`, `db_pool_size`, `db_max_overflow` |
| `app/main.py` | Pass pool config to `init_db` |

## Backward compatibility

All changes are backward compatible. No API contract changes, no new required config, no
Socket.IO event schema changes. `solar-host` and `solar-webui` require no updates.