### PR TITLE
feat(control): model source URI parser and resolver dispatcher (S-011)

### DIFF
--- a/app/model_resolvers/__init__.py
+++ b/app/model_resolvers/__init__.py
@@ -1,0 +1,3 @@
+from .dispatcher import resolve
+
+__all__ = ["resolve"]

--- a/app/model_resolvers/dispatcher.py
+++ b/app/model_resolvers/dispatcher.py
@@ -1,0 +1,25 @@
+from .parser import parse, RepoURI, HuggingFaceURI, LocalURI
+from .huggingface import resolve_huggingface
+from .repo import resolve_repo
+
+
+async def resolve(uri_str: str, host_url: str, host_api_key: str) -> str:
+    """
+    Parses a URI and dispatches to the correct resolver.
+    Returns a resolved local:// URI.
+    """
+    parsed = parse(uri_str)
+
+    if isinstance(parsed, LocalURI):
+        # local:// is passed through to the host to be validated there
+        return uri_str
+
+    elif isinstance(parsed, HuggingFaceURI):
+        return await resolve_huggingface(parsed, uri_str, host_url, host_api_key)
+
+    elif isinstance(parsed, RepoURI):
+        return await resolve_repo(parsed, uri_str, host_url, host_api_key)
+
+    else:
+        # Should not happen if parser is correct
+        return uri_str

--- a/app/model_resolvers/huggingface.py
+++ b/app/model_resolvers/huggingface.py
@@ -1,0 +1,60 @@
+import aiohttp
+import asyncio
+from fastapi import HTTPException
+from .parser import HuggingFaceURI
+
+
+async def resolve_huggingface(
+    uri: HuggingFaceURI, source_uri: str, host_url: str, host_api_key: str
+) -> str:
+    """
+    Resolves a huggingface:// URI by telling the Solar Host to pull it.
+    Returns the resolved local:// path.
+    """
+    url = f"{host_url.rstrip('/')}/models/pull"
+    headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
+    payload = {
+        "source": "huggingface",
+        "model_id": uri.model_id,
+        "source_uri": source_uri,
+    }
+
+    try:
+        # Long timeout for model pull as it might involve downloading GBs
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    path = data.get("path")
+                    if not path:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=f"Host '{host_url}' returned success but no path for model pull.",
+                        )
+                    return f"local://{path}"
+
+                text = await response.text()
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Model pull failed on host '{host_url}': {text}",
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host_url}' is unreachable during model pull: {e}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502, detail=f"Unexpected error during model pull on host: {e}"
+        )

--- a/app/model_resolvers/parser.py
+++ b/app/model_resolvers/parser.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import Union
+from fastapi import HTTPException
+
+
+@dataclass(frozen=True)
+class RepoURI:
+    name: str
+    version: str
+    scheme: str = "repo"
+
+
+@dataclass(frozen=True)
+class HuggingFaceURI:
+    model_id: str
+    scheme: str = "huggingface"
+
+
+@dataclass(frozen=True)
+class LocalURI:
+    path: str
+    scheme: str = "local"
+
+
+ParsedURI = Union[RepoURI, HuggingFaceURI, LocalURI]
+
+
+def parse(uri: str) -> ParsedURI:
+    """
+    Parses a model source URI according to the spec Section 2.4.
+
+    repo://{name}:{version}
+    huggingface://{model_id}
+    local://{path}
+    """
+    if not uri:
+        raise HTTPException(status_code=400, detail="Empty model source URI")
+
+    if uri.startswith("repo://"):
+        content = uri[len("repo://") :]
+        if ":" not in content:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid repo URI: '{uri}'. Missing version. Expected 'repo://name:version'",
+            )
+        name, version = content.split(":", 1)
+        if not name or not version:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid repo URI: '{uri}'. Name and version must be non-empty.",
+            )
+        return RepoURI(name=name, version=version)
+
+    elif uri.startswith("huggingface://"):
+        model_id = uri[len("huggingface://") :]
+        if not model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid huggingface URI: '{uri}'. Missing model_id.",
+            )
+        return HuggingFaceURI(model_id=model_id)
+
+    elif uri.startswith("local://"):
+        # triple slash for absolute, double slash for relative per spec
+        # we just capture the path part
+        path = uri[len("local://") :]
+        if not path:
+            raise HTTPException(
+                status_code=400, detail=f"Invalid local URI: '{uri}'. Missing path."
+            )
+        return LocalURI(path=path)
+
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported model source scheme in URI: '{uri}'. Supported: repo://, huggingface://, local://",
+        )

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -1,0 +1,14 @@
+from fastapi import HTTPException
+from .parser import RepoURI
+
+
+async def resolve_repo(
+    uri: RepoURI, source_uri: str, host_url: str, host_api_key: str
+) -> str:
+    """
+    Stub for repo:// resolver. Will be implemented in S-013.
+    """
+    raise HTTPException(
+        status_code=502,
+        detail=f"repo:// resolver not yet available (S-013 pending). URI: {source_uri}",
+    )

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from app.models import Host, HostCreate, HostResponse, HostStatus
 from app.database.hosts import host_db
+from app.model_resolvers import resolve
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
 
@@ -271,6 +272,13 @@ async def restart_instance(host_id: str, instance_id: str):
 @router.post("/{host_id}/instances")
 async def create_instance(host_id: str, instance_data: dict[str, Any]):
     host = _require_host(await host_db.get_host(host_id))
+
+    # Resolve model_source if present
+    model_source = instance_data.get("model_source")
+    if model_source:
+        resolved = await resolve(model_source, host.url, host.api_key)
+        instance_data = {**instance_data, "model_source": resolved}
+
     try:
         async with aiohttp.ClientSession() as session:
             url = f"{host.url}/instances"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,7 @@ exclude = ["tests*"]
 target-version = ["py312"]
 line-length = 88
 
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi import HTTPException
+from app.model_resolvers.parser import parse, RepoURI, HuggingFaceURI, LocalURI
+from app.model_resolvers.dispatcher import resolve
+
+
+def test_parser_local():
+    # Absolute path
+    p = parse("local:///opt/models/iris.gguf")
+    assert isinstance(p, LocalURI)
+    assert p.path == "/opt/models/iris.gguf"
+
+    # Relative path
+    p = parse("local://relative/path")
+    assert isinstance(p, LocalURI)
+    assert p.path == "relative/path"
+
+
+def test_parser_huggingface():
+    p = parse("huggingface://microsoft/phi-3")
+    assert isinstance(p, HuggingFaceURI)
+    assert p.model_id == "microsoft/phi-3"
+
+    p = parse("huggingface://phi-3")
+    assert isinstance(p, HuggingFaceURI)
+    assert p.model_id == "phi-3"
+
+
+def test_parser_repo():
+    p = parse("repo://iris-osl:v3")
+    assert isinstance(p, RepoURI)
+    assert p.name == "iris-osl"
+    assert p.version == "v3"
+
+
+def test_parser_errors():
+    with pytest.raises(HTTPException) as exc:
+        parse("invalid://something")
+    assert exc.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc:
+        parse("repo://iris-osl")  # missing version
+    assert exc.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc:
+        parse("huggingface://")  # missing model_id
+    assert exc.value.status_code == 400
+
+    with pytest.raises(HTTPException) as exc:
+        parse("local://")  # missing path
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_resolve_local():
+    uri = "local:///opt/models/iris.gguf"
+    resolved = await resolve(uri, "http://host:8000", "key")
+    assert resolved == uri
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_success():
+    uri = "huggingface://microsoft/phi-3"
+    host_url = "http://host:8000"
+    host_key = "key"
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = {"path": "/opt/solar/models/hf--microsoft--phi-3"}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        resolved = await resolve(uri, host_url, host_key)
+
+        assert resolved == "local:///opt/solar/models/hf--microsoft--phi-3"
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        assert args[0] == f"{host_url}/models/pull"
+        assert kwargs["json"]["model_id"] == "microsoft/phi-3"
+        assert kwargs["json"]["source_uri"] == uri
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_error():
+    uri = "huggingface://microsoft/phi-3"
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 404
+        mock_resp.text.return_value = "Not Found"
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, "http://host:8000", "key")
+
+        assert exc.value.status_code == 502
+        assert "Model pull failed on host" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_stub():
+    uri = "repo://iris-osl:v3"
+    with pytest.raises(HTTPException) as exc:
+        await resolve(uri, "http://host:8000", "key")
+
+    assert exc.value.status_code == 502
+    assert "repo:// resolver not yet available" in exc.value.detail


### PR DESCRIPTION
## Description
Solar Control now parses `model_source` URIs and resolves non-local schemes before creating an instance on a host. `huggingface://` triggers `POST /models/pull` on the target Solar Host; the resolved absolute path is sent as `local://...`. `repo://` is stubbed until Data Repository integration. Plain `pytest` from the repo root works by setting `pythonpath` in `pyproject.toml`.

## Changes
- Add `app/model_resolvers/`: `parser.py` (repo / huggingface / local per spec §2.4), `dispatcher.py`, `huggingface.py` (pull + map response to `local://`), `repo.py` (502 stub), `__init__.py` re-exporting `resolve`.
- Wire `resolve()` into `create_instance` in `app/routes/management/hosts.py` when `model_source` is present; proxy uses resolved `local://` URI.
- Add `tests/test_model_resolvers.py` (parser + dispatcher; async tests via `@pytest.mark.anyio`).
- Configure `[tool.pytest.ini_options]` in `pyproject.toml` (`pythonpath = ["."]`, `testpaths = ["tests"]`) so `pytest` finds `app` without `PYTHONPATH`.
- Keep CI deps on `pytest` only (no `pytest-asyncio`); `requirements-ci.txt` aligned.

## Related Issues
Closes #9 