### PR TITLE
feat(model-resolvers): propagate HF pull errors and extend resolver tests

### DIFF
--- a/app/model_resolvers/huggingface.py
+++ b/app/model_resolvers/huggingface.py
@@ -38,10 +38,22 @@ async def resolve_huggingface(
                         )
                     return f"local://{path}"
 
-                text = await response.text()
+                # Propagate specific error codes, wrap others in 502
+                PROPAGATED_CODES = {404, 507}
+                try:
+                    err = await response.json()
+                    detail = (
+                        err.get("detail") or err.get("error") or await response.text()
+                    )
+                except Exception:
+                    detail = await response.text()
+
+                out_code = (
+                    response.status if response.status in PROPAGATED_CODES else 502
+                )
                 raise HTTPException(
-                    status_code=502,
-                    detail=f"Model pull failed on host '{host_url}': {text}",
+                    status_code=out_code,
+                    detail=f"Model pull failed on host '{host_url}' [{response.status}]: {detail}",
                 )
     except HTTPException:
         raise

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -82,20 +82,106 @@ async def test_resolve_huggingface_success():
 
 
 @pytest.mark.anyio
-async def test_resolve_huggingface_error():
+async def test_resolve_huggingface_404():
     uri = "huggingface://microsoft/phi-3"
+    host_url = "http://host:8000"
 
     with patch("aiohttp.ClientSession.post") as mock_post:
         mock_resp = AsyncMock()
         mock_resp.status = 404
+        mock_resp.json.side_effect = Exception("Not JSON")
         mock_resp.text.return_value = "Not Found"
         mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 404
+        assert f"Model pull failed on host '{host_url}' [404]: Not Found" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_507():
+    uri = "huggingface://microsoft/phi-3"
+    host_url = "http://host:8000"
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 507
+        mock_resp.json.return_value = {"error": "Insufficient disk space"}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 507
+        assert "Insufficient disk space" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_no_path():
+    uri = "huggingface://microsoft/phi-3"
+    host_url = "http://host:8000"
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = {}  # Missing "path"
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 502
+        assert "no path for model pull" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_connection_error():
+    uri = "huggingface://microsoft/phi-3"
+    import aiohttp
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_post.side_effect = aiohttp.ClientConnectionError("Connection refused")
 
         with pytest.raises(HTTPException) as exc:
             await resolve(uri, "http://host:8000", "key")
 
         assert exc.value.status_code == 502
-        assert "Model pull failed on host" in exc.value.detail
+        assert "is unreachable" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_timeout():
+    uri = "huggingface://microsoft/phi-3"
+    import asyncio
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_post.side_effect = asyncio.TimeoutError()
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, "http://host:8000", "key")
+
+        assert exc.value.status_code == 502
+        assert "is unreachable" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_huggingface_structured_error():
+    uri = "huggingface://microsoft/phi-3"
+    host_url = "http://host:8000"
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 401
+        mock_resp.json.return_value = {"detail": "Invalid API Key"}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 502  # 401 is not in PROPAGATED_CODES
+        assert "Invalid API Key" in exc.value.detail
 
 
 @pytest.mark.anyio

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -97,7 +97,10 @@ async def test_resolve_huggingface_404():
             await resolve(uri, host_url, "key")
 
         assert exc.value.status_code == 404
-        assert f"Model pull failed on host '{host_url}' [404]: Not Found" in exc.value.detail
+        assert (
+            f"Model pull failed on host '{host_url}' [404]: Not Found"
+            in exc.value.detail
+        )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Solar Control resolves `huggingface://` URIs by calling `POST /models/pull` on the target Solar Host. This change improves how failures from that endpoint are surfaced to API callers: structured JSON bodies from the host are parsed for clearer messages, HTTP `404` and `507` from the host are forwarded as the same status codes, and other host errors are returned as `502` with host URL and upstream status in the detail. Unit tests were added for success-path edge cases, propagated statuses, structured errors, and transport failures.

## Changes

- **`app/model_resolvers/huggingface.py`**: On non-200 responses, parse JSON error payloads (`detail` or `error`), fall back to response text; propagate `404` and `507`; map remaining statuses to `502` with a message that includes the host URL and original status code.
- **`tests/test_model_resolvers.py`**: Add coverage for missing `path` on 200, `404`/`507` propagation, `aiohttp` connection errors and `asyncio.TimeoutError`, and structured JSON error bodies (e.g. `401` with `detail` wrapped as `502`).

## Related Issues

Resolves #10 