### PR TITLE
feat(resolvers): implement repo:// stub resolver (S-013)

### DIFF
--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -6,9 +6,19 @@ async def resolve_repo(
     uri: RepoURI, source_uri: str, host_url: str, host_api_key: str
 ) -> str:
     """
-    Stub for repo:// resolver. Will be implemented in S-013.
+    Stub for repo:// resolver.
+
+    Expected behavior in Phase 1 (D-016):
+    1. Call Data Repository GET /api/resolve?uri={source_uri} to obtain a harbor_ref.
+    2. Pull the OCI artifact from Harbor using ORAS (harbor-oci-client) into the
+       host's managed models directory.
+    3. Return the resolved local:// path.
     """
     raise HTTPException(
-        status_code=502,
-        detail=f"repo:// resolver not yet available (S-013 pending). URI: {source_uri}",
+        status_code=501,
+        detail=(
+            f"repo:// resolver not yet available. Data Repository integration "
+            f"will be completed in Phase 1. Use local:// or huggingface:// for now. "
+            f"URI: {source_uri}"
+        ),
     )

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -193,5 +193,49 @@ async def test_resolve_repo_stub():
     with pytest.raises(HTTPException) as exc:
         await resolve(uri, "http://host:8000", "key")
 
-    assert exc.value.status_code == 502
-    assert "repo:// resolver not yet available" in exc.value.detail
+    assert exc.value.status_code == 501
+    assert (
+        "repo:// resolver not yet available. Data Repository integration will be completed in Phase 1."
+        in exc.value.detail
+    )
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_stub_includes_uri():
+    uri = "repo://my-model:v1.2.3"
+    with pytest.raises(HTTPException) as exc:
+        await resolve(uri, "http://host:8000", "key")
+
+    assert exc.value.status_code == 501
+    assert f"URI: {uri}" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_invalid_missing_version():
+    # Dispatcher calls parse first, which raises 400
+    uri = "repo://iris-osl"
+    with pytest.raises(HTTPException) as exc:
+        await resolve(uri, "http://host:8000", "key")
+
+    assert exc.value.status_code == 400
+    assert "Missing version" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_invalid_empty_name():
+    uri = "repo://:v3"
+    with pytest.raises(HTTPException) as exc:
+        await resolve(uri, "http://host:8000", "key")
+
+    assert exc.value.status_code == 400
+    assert "Name and version must be non-empty" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_invalid_empty_version():
+    uri = "repo://iris-osl:"
+    with pytest.raises(HTTPException) as exc:
+        await resolve(uri, "http://host:8000", "key")
+
+    assert exc.value.status_code == 400
+    assert "Name and version must be non-empty" in exc.value.detail


### PR DESCRIPTION
## Description
Implements a proper stub for the `repo://` URI scheme in Solar Control. The resolver returns a clear `501 Not Implemented` error message explaining that Data Repository integration is planned for Phase 1.

## Changes
- Updated `app/model_resolvers/repo.py` with the specified error message, `501` status code, and Phase 1 docstring.
- Extended `tests/test_model_resolvers.py` with updated stub tests and new invalid-URI rejection tests.

## Related Issues
Fixes #11 