### PR TITLE
feat(api): add POST /api/models/distribute for model distribution (S-019)

### DIFF
--- a/app/models/gateway.py
+++ b/app/models/gateway.py
@@ -3,7 +3,7 @@
 from typing import Any, ClassVar
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RegistryEntry(BaseModel):
@@ -12,6 +12,8 @@ class RegistryEntry(BaseModel):
     Each entry represents one running model instance on one host,
     carrying everything the gateway needs to route a request to it.
     """
+
+    model_config = ConfigDict(protected_namespaces=())
 
     host_id: str
     instance_id: str

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
-from . import hosts, endpoints, gateway
+from . import hosts, endpoints, gateway, models
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)
 router.include_router(endpoints.router)
 router.include_router(gateway.router)
+router.include_router(models.router)

--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -1,0 +1,181 @@
+"""Model management API routes (under /api/models)."""
+
+import asyncio
+import logging
+from typing import Any
+
+import aiohttp
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.database.hosts import host_db
+from app.models import Host
+from app.model_resolvers.parser import parse, HuggingFaceURI, RepoURI, LocalURI
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+
+class DistributeRequest(BaseModel):
+    """Request to distribute a model to a target host."""
+
+    target_host_id: str
+    source_uri: str | list[str]
+
+
+class DistributeResult(BaseModel):
+    """Result of a model distribution operation."""
+
+    source_uri: str
+    target_host_id: str
+    target_host_name: str
+    path: str
+    cached: bool
+
+
+async def _check_disk_space(host: Host) -> float | None:
+    """
+    Best-effort check of available disk space on the target host.
+    Returns available GB, or None if the check fails.
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{host.url.rstrip('/')}/health"
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+                    # Expecting structure like {"disk": {"available_gb": 10.5, ...}, ...}
+                    return data.get("disk", {}).get("available_gb")
+    except Exception as e:
+        logger.warning("Failed to check disk space on host %s: %s", host.id, e)
+    return None
+
+
+async def _pull_on_host(parsed: Any, source_uri: str, host: Host) -> tuple[str, bool]:
+    """
+    Tells the target host to pull the model.
+    Returns (local_path, cached_bool).
+    """
+    if isinstance(parsed, LocalURI):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot distribute local:// URIs: {source_uri}",
+        )
+    if isinstance(parsed, RepoURI):
+        # Spec says repo:// is handled by Data Repository which is Phase 1
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"repo:// distribution requires Data Repository integration (Phase 1). "
+                f"URI: {source_uri}"
+            ),
+        )
+
+    if not isinstance(parsed, HuggingFaceURI):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported URI type for distribution: {type(parsed).__name__}",
+        )
+
+    url = f"{host.url.rstrip('/')}/models/pull"
+    headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
+    payload = {
+        "source": "huggingface",
+        "model_id": parsed.model_id,
+        "source_uri": source_uri,
+    }
+
+    try:
+        # Long timeout for model pull as it might involve downloading GBs
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    path = data.get("path")
+                    cached = data.get("cached", False)
+                    if not path:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=f"Host '{host.name}' ({host.url}) returned success but no path for model pull.",
+                        )
+                    return path, cached
+
+                # Propagate specific error codes, wrap others in 502
+                PROPAGATED_CODES = {404, 507}
+                try:
+                    err = await response.json()
+                    detail = (
+                        err.get("detail") or err.get("error") or await response.text()
+                    )
+                except Exception:
+                    detail = await response.text()
+
+                out_code = (
+                    response.status if response.status in PROPAGATED_CODES else 502
+                )
+                raise HTTPException(
+                    status_code=out_code,
+                    detail=f"Model pull failed on host '{host.name}' [{response.status}]: {detail}",
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host.name}' ({host.url}) is unreachable during model pull: {e}",
+        )
+    except Exception as e:
+        logger.exception(
+            "Unexpected error during model distribution to host %s", host.id
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during model distribution to host '{host.name}': {e}",
+        )
+
+
+@router.post("/distribute", response_model=list[DistributeResult])
+async def distribute_model(req: DistributeRequest) -> list[DistributeResult]:
+    """
+    Distribute one or more models to a target host.
+    """
+    uris = [req.source_uri] if isinstance(req.source_uri, str) else req.source_uri
+    host = await host_db.get_host(req.target_host_id)
+    if not host:
+        raise HTTPException(
+            status_code=404, detail=f"Host '{req.target_host_id}' not found"
+        )
+
+    # Optional disk check (best-effort)
+    available = await _check_disk_space(host)
+    DISK_WARN_THRESHOLD_GB = 5.0
+    if available is not None and available < DISK_WARN_THRESHOLD_GB:
+        raise HTTPException(
+            status_code=507,
+            detail=f"Insufficient disk on target host '{host.name}': {available:.2f} GB available",
+        )
+
+    results = []
+    for uri in uris:
+        parsed = parse(uri)  # Raises 400 on bad URI
+        path, cached = await _pull_on_host(parsed, uri, host)
+        results.append(
+            DistributeResult(
+                source_uri=uri,
+                target_host_id=host.id,
+                target_host_name=host.name,
+                path=path,
+                cached=cached,
+            )
+        )
+    return results

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -1,0 +1,221 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi import HTTPException
+from app.models import Host, HostStatus
+from app.routes.management.models import (
+    _pull_on_host,
+    _check_disk_space,
+    distribute_model,
+    DistributeRequest,
+)
+from app.model_resolvers.parser import parse
+
+
+@pytest.fixture
+def mock_host():
+    return Host(
+        id="host-1",
+        name="Test Host",
+        url="http://test-host:8000",
+        api_key="test-key",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.mark.anyio
+async def test_check_disk_space_success(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = {"disk": {"available_gb": 10.5}}
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        available = await _check_disk_space(mock_host)
+        assert available == 10.5
+
+
+@pytest.mark.anyio
+async def test_check_disk_space_failure(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_get.side_effect = Exception("Connection error")
+        available = await _check_disk_space(mock_host)
+        assert available is None
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_success(mock_host):
+    uri = "huggingface://microsoft/phi-3"
+    parsed = parse(uri)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = {"path": "/models/hf--phi3", "cached": True}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        path, cached = await _pull_on_host(parsed, uri, mock_host)
+        assert path == "/models/hf--phi3"
+        assert cached is True
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["source_uri"] == uri
+        assert kwargs["json"]["model_id"] == "microsoft/phi-3"
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_404_propagated(mock_host):
+    uri = "huggingface://microsoft/phi-3"
+    parsed = parse(uri)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 404
+        mock_resp.json.return_value = {"detail": "Model not found"}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await _pull_on_host(parsed, uri, mock_host)
+        assert exc.value.status_code == 404
+        assert "Model not found" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_507_propagated(mock_host):
+    uri = "huggingface://microsoft/phi-3"
+    parsed = parse(uri)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 507
+        mock_resp.json.return_value = {"error": "Disk full"}
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await _pull_on_host(parsed, uri, mock_host)
+        assert exc.value.status_code == 507
+        assert "Disk full" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_connection_error(mock_host):
+    uri = "huggingface://microsoft/phi-3"
+    parsed = parse(uri)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        import aiohttp
+
+        mock_post.side_effect = aiohttp.ClientConnectionError("Refused")
+
+        with pytest.raises(HTTPException) as exc:
+            await _pull_on_host(parsed, uri, mock_host)
+        assert exc.value.status_code == 502
+        assert "is unreachable" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_local_uri(mock_host):
+    uri = "local:///path/to/model"
+    parsed = parse(uri)
+
+    with pytest.raises(HTTPException) as exc:
+        await _pull_on_host(parsed, uri, mock_host)
+    assert exc.value.status_code == 400
+    assert "Cannot distribute local:// URIs" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_repo_uri(mock_host):
+    uri = "repo://model:v1"
+    parsed = parse(uri)
+
+    with pytest.raises(HTTPException) as exc:
+        await _pull_on_host(parsed, uri, mock_host)
+    assert exc.value.status_code == 501
+    assert "repo:// distribution requires Data Repository" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_distribute_model_route_success(mock_host):
+    req = DistributeRequest(target_host_id="host-1", source_uri="huggingface://phi-3")
+
+    with (
+        patch("app.database.hosts.host_db.get_host", return_value=mock_host),
+        patch("app.routes.management.models._check_disk_space", return_value=10.0),
+        patch(
+            "app.routes.management.models._pull_on_host", return_value=("/path", False)
+        ),
+    ):
+
+        results = await distribute_model(req)
+        assert len(results) == 1
+        assert results[0].source_uri == "huggingface://phi-3"
+        assert results[0].path == "/path"
+        assert results[0].cached is False
+
+
+@pytest.mark.anyio
+async def test_distribute_model_route_batch(mock_host):
+    req = DistributeRequest(
+        target_host_id="host-1",
+        source_uri=["huggingface://phi-3", "huggingface://phi-4"],
+    )
+
+    with (
+        patch("app.database.hosts.host_db.get_host", return_value=mock_host),
+        patch("app.routes.management.models._check_disk_space", return_value=10.0),
+        patch("app.routes.management.models._pull_on_host") as mock_pull,
+    ):
+
+        mock_pull.side_effect = [("/path1", True), ("/path2", False)]
+
+        results = await distribute_model(req)
+        assert len(results) == 2
+        assert results[0].source_uri == "huggingface://phi-3"
+        assert results[0].path == "/path1"
+        assert results[1].source_uri == "huggingface://phi-4"
+        assert results[1].path == "/path2"
+
+
+@pytest.mark.anyio
+async def test_distribute_model_host_not_found():
+    req = DistributeRequest(
+        target_host_id="non-existent", source_uri="huggingface://phi-3"
+    )
+
+    with patch("app.database.hosts.host_db.get_host", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            await distribute_model(req)
+        assert exc.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_distribute_model_insufficient_disk(mock_host):
+    req = DistributeRequest(target_host_id="host-1", source_uri="huggingface://phi-3")
+
+    with (
+        patch("app.database.hosts.host_db.get_host", return_value=mock_host),
+        patch("app.routes.management.models._check_disk_space", return_value=2.0),
+    ):  # Below 5.0 GB
+
+        with pytest.raises(HTTPException) as exc:
+            await distribute_model(req)
+        assert exc.value.status_code == 507
+        assert "Insufficient disk" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_distribute_model_disk_check_failure_proceeds(mock_host):
+    req = DistributeRequest(target_host_id="host-1", source_uri="huggingface://phi-3")
+
+    with (
+        patch("app.database.hosts.host_db.get_host", return_value=mock_host),
+        patch("app.routes.management.models._check_disk_space", return_value=None),
+        patch(
+            "app.routes.management.models._pull_on_host", return_value=("/path", True)
+        ),
+    ):
+
+        results = await distribute_model(req)
+        assert len(results) == 1
+        assert results[0].path == "/path"


### PR DESCRIPTION
## Description

Adds a management API that tells a target solar-host to pull one or more models from their authoritative sources (HuggingFace Hub; `repo://` remains gated until Data Repository integration). This matches the model-source URI architecture: control plane orchestrates, hosts pull—no host-to-host byte transfer. Also silences the Pydantic V2 protected-namespace warning on `RegistryEntry.model_alias` so test runs stay clean.

## Changes

- New `POST /api/models/distribute` under the management router (`/api/models/distribute`): body `target_host_id`, `source_uri` (string or list); resolves host from DB, optional `/health` disk check, proxies `POST /models/pull` on the target host with `X-API-Key`.
- Response: list of `{ source_uri, target_host_id, target_host_name, path, cached }`; maps host pull errors (404/507 propagated, others as 502; unreachable as 502); rejects `local://` (400), `repo://` (501 until Data Repository).
- Register models router in `app/routes/management/__init__.py`.
- Unit tests in `tests/test_distribute.py`.
- `RegistryEntry`: `model_config = ConfigDict(protected_namespaces=())` in `app/models/gateway.py` to remove Pydantic field-name warnings during imports/tests.

## Related Issues

Resolves #12 