### PR TITLE
feat(api): add GET /api/models/availability for cross-host model inventory

### DIFF
--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -34,6 +34,59 @@ class DistributeResult(BaseModel):
     cached: bool
 
 
+class HostModelInfo(BaseModel):
+    """Info about a model on a specific host."""
+
+    host_id: str
+    host_name: str
+    size_bytes: int
+    path: str
+
+
+class ModelAvailabilityResponse(BaseModel):
+    """Aggregate view of model availability across hosts."""
+
+    models: dict[str, list[HostModelInfo]]
+
+
+@router.get("/availability", response_model=ModelAvailabilityResponse)
+async def get_model_availability(
+    model_name: str | None = None,
+) -> ModelAvailabilityResponse:
+    """
+    Returns an aggregated view of model availability across all hosts.
+    Optional model_name filter returns only hosts that have that specific model.
+    """
+    hosts = await host_db.get_all_hosts()
+    results = await asyncio.gather(*[_fetch_host_models(h) for h in hosts])
+
+    # model_name -> list[HostModelInfo]
+    availability: dict[str, list[HostModelInfo]] = {}
+
+    for host, host_models in zip(hosts, results):
+        for m in host_models:
+            name = m.get("name")
+            if not name:
+                continue
+
+            if model_name and name != model_name:
+                continue
+
+            if name not in availability:
+                availability[name] = []
+
+            availability[name].append(
+                HostModelInfo(
+                    host_id=host.id,
+                    host_name=host.name,
+                    size_bytes=m.get("size_bytes", 0),
+                    path=m.get("path", ""),
+                )
+            )
+
+    return ModelAvailabilityResponse(models=availability)
+
+
 async def _check_disk_space(host: Host) -> float | None:
     """
     Best-effort check of available disk space on the target host.
@@ -142,6 +195,32 @@ async def _pull_on_host(parsed: Any, source_uri: str, host: Host) -> tuple[str, 
             status_code=502,
             detail=f"Unexpected error during model distribution to host '{host.name}': {e}",
         )
+
+
+async def _fetch_host_models(host: Host) -> list[dict]:
+    """
+    Fetches the list of models from a single host.
+    Returns a list of dicts with {name, size_bytes, path}, or [] on any error.
+    """
+    url = f"{host.url.rstrip('/')}/models"
+    headers = {"X-API-Key": host.api_key}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=5)
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json()
+                else:
+                    logger.warning(
+                        "Host %s (%s) returned %d for GET /models",
+                        host.id,
+                        host.url,
+                        resp.status,
+                    )
+    except Exception as e:
+        logger.warning("Failed to fetch models from host %s: %s", host.id, e)
+    return []
 
 
 @router.post("/distribute", response_model=list[DistributeResult])

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,0 +1,178 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, patch
+from app.models import Host, HostStatus
+from app.routes.management.models import (
+    _fetch_host_models,
+    get_model_availability,
+    ModelAvailabilityResponse,
+)
+
+
+@pytest.fixture
+def mock_host():
+    return Host(
+        id="host-1",
+        name="Test Host",
+        url="http://test-host:8000",
+        api_key="test-key",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.fixture
+def mock_host_2():
+    return Host(
+        id="host-2",
+        name="Test Host 2",
+        url="http://test-host-2:8000",
+        api_key="test-key-2",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.mark.anyio
+async def test_fetch_host_models_success(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = [
+            {"name": "model-a", "size_bytes": 1000, "path": "/path/a"},
+            {"name": "model-b", "size_bytes": 2000, "path": "/path/b"},
+        ]
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        models = await _fetch_host_models(mock_host)
+        assert len(models) == 2
+        assert models[0]["name"] == "model-a"
+        assert models[1]["name"] == "model-b"
+
+
+@pytest.mark.anyio
+async def test_fetch_host_models_non200(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        models = await _fetch_host_models(mock_host)
+        assert models == []
+
+
+@pytest.mark.anyio
+async def test_fetch_host_models_connection_error(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        import aiohttp
+
+        mock_get.side_effect = aiohttp.ClientConnectionError("Refused")
+
+        models = await _fetch_host_models(mock_host)
+        assert models == []
+
+
+@pytest.mark.anyio
+async def test_fetch_host_models_timeout(mock_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_get.side_effect = asyncio.TimeoutError()
+
+        models = await _fetch_host_models(mock_host)
+        assert models == []
+
+
+@pytest.mark.anyio
+async def test_get_model_availability_aggregates(mock_host, mock_host_2):
+    hosts = [mock_host, mock_host_2]
+
+    # host-1 has model-a, model-b
+    # host-2 has model-a, model-c
+    mock_results = [
+        [
+            {"name": "model-a", "size_bytes": 1000, "path": "/path/a1"},
+            {"name": "model-b", "size_bytes": 2000, "path": "/path/b1"},
+        ],
+        [
+            {"name": "model-a", "size_bytes": 1000, "path": "/path/a2"},
+            {"name": "model-c", "size_bytes": 3000, "path": "/path/c2"},
+        ],
+    ]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch("app.routes.management.models._fetch_host_models") as mock_fetch,
+    ):
+        mock_fetch.side_effect = mock_results
+
+        resp = await get_model_availability()
+        assert isinstance(resp, ModelAvailabilityResponse)
+        assert "model-a" in resp.models
+        assert len(resp.models["model-a"]) == 2
+        assert resp.models["model-a"][0].host_id == "host-1"
+        assert resp.models["model-a"][1].host_id == "host-2"
+
+        assert "model-b" in resp.models
+        assert len(resp.models["model-b"]) == 1
+        assert resp.models["model-b"][0].host_id == "host-1"
+
+        assert "model-c" in resp.models
+        assert len(resp.models["model-c"]) == 1
+        assert resp.models["model-c"][0].host_id == "host-2"
+
+
+@pytest.mark.anyio
+async def test_get_model_availability_filter_found(mock_host, mock_host_2):
+    hosts = [mock_host, mock_host_2]
+    mock_results = [
+        [{"name": "model-a", "size_bytes": 1000, "path": "/path/a1"}],
+        [{"name": "model-b", "size_bytes": 2000, "path": "/path/b2"}],
+    ]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch("app.routes.management.models._fetch_host_models") as mock_fetch,
+    ):
+        mock_fetch.side_effect = mock_results
+
+        resp = await get_model_availability(model_name="model-a")
+        assert "model-a" in resp.models
+        assert "model-b" not in resp.models
+        assert len(resp.models) == 1
+
+
+@pytest.mark.anyio
+async def test_get_model_availability_filter_not_found(mock_host):
+    hosts = [mock_host]
+    mock_results = [[{"name": "model-a", "size_bytes": 1000, "path": "/path/a1"}]]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch("app.routes.management.models._fetch_host_models") as mock_fetch,
+    ):
+        mock_fetch.side_effect = mock_results
+
+        resp = await get_model_availability(model_name="non-existent")
+        assert resp.models == {}
+
+
+@pytest.mark.anyio
+async def test_get_model_availability_no_hosts():
+    with patch("app.database.hosts.host_db.get_all_hosts", return_value=[]):
+        resp = await get_model_availability()
+        assert resp.models == {}
+
+
+@pytest.mark.anyio
+async def test_get_model_availability_one_unreachable(mock_host, mock_host_2):
+    hosts = [mock_host, mock_host_2]
+    # host-1 succeeds, host-2 fails (returns [])
+    mock_results = [[{"name": "model-a", "size_bytes": 1000, "path": "/path/a1"}], []]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch("app.routes.management.models._fetch_host_models") as mock_fetch,
+    ):
+        mock_fetch.side_effect = mock_results
+
+        resp = await get_model_availability()
+        assert "model-a" in resp.models
+        assert len(resp.models["model-a"]) == 1
+        assert resp.models["model-a"][0].host_id == "host-1"


### PR DESCRIPTION
## Description

Adds an aggregated view of which managed models exist on which Solar hosts. For each registered host, Solar Control calls the host’s existing `GET /models` API (S-014), merges results by model name, and optionally filters to a single model. Unreachable hosts are skipped without failing the whole request, so migration planners and dashboards can rely on partial data.

## Changes

- New management endpoint `GET /api/models/availability` with optional query param `model_name`.
- Response shape: `models` map from model name to a list of `{ host_id, host_name, size_bytes, path }`.
- Helper `_fetch_host_models` performs `GET {host.url}/models` with per-host `X-API-Key`, 5s timeout; non-200 and transport errors return empty list and log a warning.
- Parallel fan-out via `asyncio.gather` over all hosts from `host_db.get_all_hosts()`.
- Unit tests in `tests/test_availability.py` (fetch helper, aggregation, filter, empty hosts, partial failure).

## Related Issues

Closes #13 