### PR TITLE
B-008: Preserve structured error format for 404 responses in distribution endpoint

### DIFF
--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -159,13 +159,21 @@ async def _pull_on_host(parsed: Any, source_uri: str, host: Host) -> tuple[str, 
                         )
                     return path, cached
 
-                # Propagate specific error codes, wrap others in 502
+                # Propagate specific error codes with structured format, wrap others in 502
                 PROPAGATED_CODES = {404, 507}
                 try:
                     err = await response.json()
+                    # Host returns structured error: {"error", "detail", "source_uri", "status_code"}
+                    if err.get("error") and err.get("status_code"):
+                        # Preserve structured error format for propagation
+                        out_code = err.get("status_code", response.status)
+                        if out_code in PROPAGATED_CODES:
+                            raise HTTPException(status_code=out_code, detail=err)
                     detail = (
                         err.get("detail") or err.get("error") or await response.text()
                     )
+                except HTTPException:
+                    raise
                 except Exception:
                     detail = await response.text()
 

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -219,3 +219,33 @@ async def test_distribute_model_disk_check_failure_proceeds(mock_host):
         results = await distribute_model(req)
         assert len(results) == 1
         assert results[0].path == "/path"
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_404_structured_error(mock_host):
+    """Test that 404 errors from host are propagated with structured format (B-008)."""
+    uri = "huggingface://nonexistent/repo"
+    parsed = parse(uri)
+
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 404
+        # Host returns structured error format
+        mock_resp.json.return_value = {
+            "error": "not_found",
+            "detail": "HuggingFace repository not found: 404 Client Error...",
+            "source_uri": "huggingface://nonexistent/repo",
+            "status_code": 404,
+        }
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await _pull_on_host(parsed, uri, mock_host)
+        assert exc.value.status_code == 404
+        # The HTTPException should have the structured error as detail
+        assert exc.value.detail == {
+            "error": "not_found",
+            "detail": "HuggingFace repository not found: 404 Client Error...",
+            "source_uri": "huggingface://nonexistent/repo",
+            "status_code": 404,
+        }


### PR DESCRIPTION
## Description
Fixes the model distribution endpoint to properly propagate structured 404 errors from the host instead of returning HTTP 500 with raw error text. When a non-existent HuggingFace model is requested, the endpoint now returns a structured error response with `error`, `detail`, `source_uri`, and `status_code` fields as expected.

## Changes
- Modified `solar-control/app/routes/management/models.py`: Updated `_pull_on_host()` to detect and preserve structured error responses from the host when status code is 404 or 507
- Added `test_pull_on_host_404_structured_error` in `solar-control/tests/test_distribute.py` to verify structured 404 error propagation

## Reproduction Steps
1. Call `POST /api/models/distribute` with a non-existent HuggingFace model (e.g., `huggingface://nonexistent/repo`)
2. Observe that the endpoint returns HTTP 500 with raw error text instead of HTTP 404 with structured error

## Related Issues
Fixes #30 
