### PR TITLE
fix(gateway): recover model registry when WS instance cache is empty; keep registry on refresh failure

### DIFF
--- a/app/gateway.py
+++ b/app/gateway.py
@@ -68,6 +68,33 @@ class OpenAIGateway:
 
     # ── Model registry ────────────────────────────────────────
 
+    @staticmethod
+    def _ws_cache_from_http_instances(
+        instances: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Convert solar-host REST instance payloads to the WS cache shape."""
+        cached: list[dict[str, Any]] = []
+        for instance in instances:
+            config = instance.get("config") or {}
+            cached.append(
+                {
+                    "id": instance.get("id"),
+                    "alias": config.get("alias", instance.get("alias", "unknown")),
+                    "status": instance.get("status"),
+                    "port": instance.get("port"),
+                    "supported_endpoints": instance.get(
+                        "supported_endpoints",
+                        RegistryEntry.DEFAULT_ENDPOINTS,
+                    ),
+                    "backend_type": config.get(
+                        "backend_type",
+                        instance.get("backend_type", "llamacpp"),
+                    ),
+                    "api_key": config.get("api_key"),
+                }
+            )
+        return cached
+
     async def refresh_model_registry(self) -> None:
         """Refresh the model registry from all hosts and store in Redis."""
         await self._ensure_session()
@@ -81,9 +108,11 @@ class OpenAIGateway:
 
         new_model_map: dict[str, list[RegistryEntry]] = defaultdict(list)
         hosts = await host_db.get_all_hosts()
+        refresh_failed = False
 
         ws_hosts = []
         http_hosts = []
+        missing_cache_hosts = []
         for host in hosts:
             if await is_host_connected(host.id):
                 ws_hosts.append(host)
@@ -93,6 +122,13 @@ class OpenAIGateway:
         for host in ws_hosts:
             ws_instances = await get_host_instances(host.id)
             await host_db.update_host_status(host.id, HostStatus.ONLINE)
+            if not ws_instances:
+                logger.warning(
+                    "Host %s is connected but has no cached instances; polling HTTP",
+                    host.id,
+                )
+                missing_cache_hosts.append(host)
+                continue
 
             for instance in ws_instances:
                 if instance.get("status") == "running":
@@ -102,13 +138,13 @@ class OpenAIGateway:
                     if entry:
                         new_model_map[entry.model_alias].append(entry)
 
-        if http_hosts:
+        if http_hosts or missing_cache_hosts:
             now = time.time()
             grace = settings.disconnect_grace_period_s
             reconnect_interval = settings.reconnect_request_interval_s
 
             grace_hosts = []
-            poll_hosts = []
+            poll_hosts = list(missing_cache_hosts)
 
             for host in http_hosts:
                 dc_ts = await host_store.get_disconnect_time(host.id)
@@ -137,6 +173,7 @@ class OpenAIGateway:
             if poll_hosts:
 
                 async def poll_host(host):
+                    nonlocal refresh_failed
                     result_entries: list[RegistryEntry] = []
                     try:
                         url = f"{host.url}/instances"
@@ -148,6 +185,10 @@ class OpenAIGateway:
                         ) as response:
                             if response.status == 200:
                                 instances = await response.json()
+                                await host_store.set_host_instances(
+                                    host.id,
+                                    self._ws_cache_from_http_instances(instances),
+                                )
                                 prev_status = host.status
                                 await host_db.update_host_status(
                                     host.id, HostStatus.ONLINE
@@ -162,10 +203,12 @@ class OpenAIGateway:
                                         if entry:
                                             result_entries.append(entry)
                             else:
+                                refresh_failed = True
                                 await host_db.update_host_status(
                                     host.id, HostStatus.ERROR
                                 )
                     except Exception:
+                        refresh_failed = True
                         cached = await get_host_instances(host.id)
                         if cached:
                             for instance in cached:
@@ -189,6 +232,16 @@ class OpenAIGateway:
                         continue
                     for entry in result:
                         new_model_map[entry.model_alias].append(entry)
+
+        if not new_model_map and hosts and refresh_failed:
+            previous_registry = await registry_store.get_registry()
+            if previous_registry:
+                logger.warning(
+                    "Registry refresh produced no entries after host failures; "
+                    "keeping previous registry with %d models",
+                    len(previous_registry),
+                )
+                return
 
         await registry_store.set_registry(dict(new_model_map))
 

--- a/tests/test_gateway_registry.py
+++ b/tests/test_gateway_registry.py
@@ -1,0 +1,144 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.gateway import OpenAIGateway
+from app.models import Host, HostStatus, RegistryEntry
+
+
+class _Response:
+    def __init__(self, status: int, payload=None):
+        self.status = status
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
+
+
+class _RequestContext:
+    def __init__(self, response: _Response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Session:
+    closed = False
+
+    def __init__(self, response: _Response):
+        self._response = response
+
+    def get(self, *args, **kwargs):
+        return _RequestContext(self._response)
+
+
+@pytest.fixture
+def host():
+    return Host(
+        id="host-1",
+        name="Test Host",
+        url="http://test-host:8000",
+        api_key="host-api-key",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.mark.anyio
+async def test_refresh_recovers_connected_host_with_empty_instance_cache(host):
+    instances = [
+        {
+            "id": "inst-1",
+            "status": "running",
+            "port": 3500,
+            "supported_endpoints": ["/v1/chat/completions", "/v1/models"],
+            "config": {
+                "alias": "model-a",
+                "api_key": "instance-api-key",
+                "backend_type": "llamacpp",
+            },
+        }
+    ]
+
+    gateway = OpenAIGateway()
+    gateway.session = _Session(_Response(200, instances))
+
+    with (
+        patch("app.gateway.host_db.get_all_hosts", AsyncMock(return_value=[host])),
+        patch("app.gateway.host_db.update_host_status", AsyncMock()),
+        patch(
+            "app.socketio_app.host_handlers.is_host_connected",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.socketio_app.host_handlers.get_host_instances",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.gateway.host_store.get_disconnect_time", AsyncMock(return_value=None)
+        ),
+        patch("app.gateway.host_store.set_host_instances", AsyncMock()) as set_cache,
+        patch("app.gateway.registry_store.set_registry", AsyncMock()) as set_registry,
+    ):
+        await gateway.refresh_model_registry()
+
+    set_cache.assert_awaited_once_with(
+        "host-1",
+        [
+            {
+                "id": "inst-1",
+                "alias": "model-a",
+                "status": "running",
+                "port": 3500,
+                "supported_endpoints": ["/v1/chat/completions", "/v1/models"],
+                "backend_type": "llamacpp",
+                "api_key": "instance-api-key",
+            }
+        ],
+    )
+
+    registry = set_registry.await_args.args[0]
+    assert list(registry) == ["model-a"]
+    assert registry["model-a"][0].instance_id == "inst-1"
+    assert registry["model-a"][0].api_key == "instance-api-key"
+
+
+@pytest.mark.anyio
+async def test_refresh_keeps_previous_registry_when_polling_fails(host):
+    previous = {
+        "model-a": [
+            RegistryEntry(
+                host_id="host-1",
+                instance_id="inst-1",
+                url="http://test-host:3500",
+                api_key="key",
+                model_alias="model-a",
+            )
+        ]
+    }
+
+    gateway = OpenAIGateway()
+    gateway.session = _Session(_Response(503))
+
+    with (
+        patch("app.gateway.host_db.get_all_hosts", AsyncMock(return_value=[host])),
+        patch("app.gateway.host_db.update_host_status", AsyncMock()),
+        patch(
+            "app.socketio_app.host_handlers.is_host_connected",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.gateway.host_store.get_disconnect_time", AsyncMock(return_value=None)
+        ),
+        patch("app.gateway.host_store.get_host_instances", AsyncMock(return_value=[])),
+        patch(
+            "app.gateway.registry_store.get_registry", AsyncMock(return_value=previous)
+        ),
+        patch("app.gateway.registry_store.set_registry", AsyncMock()) as set_registry,
+    ):
+        await gateway.refresh_model_registry()
+
+    set_registry.assert_not_awaited()


### PR DESCRIPTION
## Description
Model registry refresh relied on WebSocket–cached host instances. When a host was connected but its instance cache was empty (for example after reconnect or cache loss), refresh skipped building entries for that host and could publish an empty registry. This change treats “connected, empty cache” like hosts that need HTTP polling: it loads `/instances`, normalizes the payload into the WebSocket cache shape, and updates Redis. If polling fails across hosts and the refresh would clear the registry entirely, the previous registry is retained so clients do not lose routing until the next successful refresh.

## Changes
- Add `_ws_cache_from_http_instances` to map solar-host REST instance payloads to the WebSocket cache format used by `host_store`.
- When a host is connected via WebSocket but `get_host_instances` returns nothing, log a warning and route that host through HTTP polling together with disconnected hosts.
- After a successful HTTP poll, call `set_host_instances` so the cache stays aligned with what was fetched.
- Track refresh failures during HTTP polling; if there are hosts but the new model map is empty and polling failed, skip `set_registry` and keep the existing registry (with a warning).
- Add `tests/test_gateway_registry.py` for empty-cache recovery and for preserving the previous registry when polling returns a non-OK status.

## Reproduction Steps
1. Simulate or observe a host that reports as connected while `get_host_instances` returns `[]` (e.g. reconnect before instance sync).
2. Run `refresh_model_registry()` (or wait for the periodic refresh).
3. Before: registry could end up empty or stale for that host. After: control polls `GET /instances`, repopulates the instance cache, and updates the registry.