### PR TITLE
feat(repo): complete D-016 Data Repository resolver and host pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY . .
 
-# Convert line endings for all .sh files to Unix format
-RUN find . -name "*.sh" -exec sed -i 's/\r$//' {} +
-
 RUN sed -i "s/^version = .*/version = \"${APP_VERSION}\"/" pyproject.toml && \
     pip install --no-cache-dir -e .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 COPY . .
 
+# Convert line endings for all .sh files to Unix format
+RUN find . -name "*.sh" -exec sed -i 's/\r$//' {} +
+
 RUN sed -i "s/^version = .*/version = \"${APP_VERSION}\"/" pyproject.toml && \
     pip install --no-cache-dir -e .
 

--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     database_url: str = "postgresql://solar:solar@localhost:5432/solar_gateway"
     redis_url: str = "redis://localhost:6379/0"
 
+    data_repository_url: str = ""
+    data_repository_api_key: str = ""
+    data_repository_timeout_s: float = 10.0
+
     db_pool_size: int = 20
     db_max_overflow: int = 10
 

--- a/app/model_resolvers/dispatcher.py
+++ b/app/model_resolvers/dispatcher.py
@@ -18,7 +18,7 @@ async def resolve(uri_str: str, host_url: str, host_api_key: str) -> str:
         return await resolve_huggingface(parsed, uri_str, host_url, host_api_key)
 
     elif isinstance(parsed, RepoURI):
-        return await resolve_repo(parsed, uri_str, host_url, host_api_key)
+        return await resolve_repo(uri_str, host_url, host_api_key)
 
     else:
         # Should not happen if parser is correct

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -196,16 +196,16 @@ class RepoResolver:
         )
 
 
-_repo_resolver = RepoResolver()
+_default_resolver = RepoResolver()
 
 
 async def resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
-    return await _repo_resolver.resolve_from_data_repository(source_uri)
+    return await _default_resolver.resolve_from_data_repository(source_uri)
 
 
 def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
-    _repo_resolver.validate_resolved_model(payload, source_uri)
+    _default_resolver.validate_resolved_model(payload, source_uri)
 
 
 async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str:
-    return await _repo_resolver.resolve_repo(source_uri, host_url, host_api_key)
+    return await _default_resolver.resolve_repo(source_uri, host_url, host_api_key)

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -1,5 +1,171 @@
+import asyncio
+from typing import Any
+
+import aiohttp
 from fastapi import HTTPException
+
+from app.config import settings
 from .parser import RepoURI
+
+
+async def _resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
+    if not settings.data_repository_url:
+        raise HTTPException(
+            status_code=500,
+            detail="DATA_REPOSITORY_URL is not configured",
+        )
+
+    url = f"{settings.data_repository_url.rstrip('/')}/api/resolve"
+    headers = {"Content-Type": "application/json"}
+    if settings.data_repository_api_key:
+        headers["X-API-Key"] = settings.data_repository_api_key
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                params={"uri": source_uri},
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=settings.data_repository_timeout_s),
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+
+                try:
+                    err = await response.json()
+                    detail = err.get("detail") or err.get("error")
+                except Exception:
+                    detail = await response.text()
+
+                if response.status in {404, 422}:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=detail or "Data Repository resolution failed",
+                    )
+
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        "Data Repository resolution failed "
+                        f"[{response.status}]: {detail}"
+                    ),
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Data Repository is unreachable: {exc}",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during Data Repository resolve: {exc}",
+        )
+
+
+def _validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
+    category = payload.get("category")
+    if category != "model":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Resolved artifact is not a deployable model. "
+                f"Expected category 'model', got '{category}'."
+            ),
+        )
+
+    harbor_ref = payload.get("harbor_ref")
+    if not harbor_ref:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "Data Repository response missing harbor_ref for "
+                f"URI '{source_uri}'."
+            ),
+        )
+
+
+async def _pull_from_host(
+    *,
+    harbor_ref: str,
+    metadata: dict[str, Any],
+    digest: str | None,
+    source_uri: str,
+    host_url: str,
+    host_api_key: str,
+) -> str:
+    url = f"{host_url.rstrip('/')}/models/pull"
+    headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
+    payload: dict[str, Any] = {
+        "source": "harbor",
+        "harbor_ref": harbor_ref,
+        "source_uri": source_uri,
+        "category": metadata.get("category"),
+        "name": metadata.get("name"),
+        "version": metadata.get("version"),
+        "size_bytes": metadata.get("size_bytes"),
+        "checksum": metadata.get("checksum"),
+        "metadata": metadata.get("metadata"),
+    }
+    if digest:
+        payload["digest"] = digest
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    path = data.get("path")
+                    if not path:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"Host '{host_url}' returned success but no path "
+                                f"for model pull."
+                            ),
+                        )
+                    return f"local://{path}"
+
+                try:
+                    err = await response.json()
+                    detail = err.get("detail") or err.get("error")
+                except Exception:
+                    detail = await response.text()
+
+                out_code = response.status if response.status in {404, 507} else 502
+                raise HTTPException(
+                    status_code=out_code,
+                    detail=(
+                        f"Model pull failed on host '{host_url}' [{response.status}]: "
+                        f"{detail}"
+                    ),
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host_url}' is unreachable during model pull: {exc}",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during model pull on host: {exc}",
+        )
 
 
 async def resolve_repo(
@@ -14,11 +180,15 @@ async def resolve_repo(
        host's managed models directory.
     3. Return the resolved local:// path.
     """
-    raise HTTPException(
-        status_code=501,
-        detail=(
-            f"repo:// resolver not yet available. Data Repository integration "
-            f"will be completed in Phase 1. Use local:// or huggingface:// for now. "
-            f"URI: {source_uri}"
-        ),
+    # Fetch authoritative metadata from Data Repository
+    resolved = await _resolve_from_data_repository(source_uri)
+    _validate_resolved_model(resolved, source_uri)
+
+    return await _pull_from_host(
+        harbor_ref=resolved["harbor_ref"],
+        metadata=resolved,
+        digest=resolved.get("checksum"),
+        source_uri=source_uri,
+        host_url=host_url,
+        host_api_key=host_api_key,
     )

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -142,7 +142,7 @@ class RepoResolver:
                                     f"for model pull."
                                 ),
                             )
-                        return self.to_local_uri(path)
+                        return RepoResolver.to_local_uri(path)
 
                     try:
                         err = await response.json()

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -7,187 +7,205 @@ from fastapi import HTTPException
 from app.config import settings
 
 
-def _to_local_uri(path: str) -> str:
-    if path.startswith("/"):
-        return f"local:///{path.lstrip('/')}"
-    return f"local://{path}"
+class RepoResolver:
+    @staticmethod
+    def to_local_uri(path: str) -> str:
+        if path.startswith("/"):
+            return f"local:///{path.lstrip('/')}"
+        return f"local://{path}"
+
+    async def resolve_from_data_repository(self, source_uri: str) -> dict[str, Any]:
+        if not settings.data_repository_url:
+            raise HTTPException(
+                status_code=500,
+                detail="DATA_REPOSITORY_URL is not configured",
+            )
+
+        url = f"{settings.data_repository_url.rstrip('/')}/api/resolve"
+        headers = {"Content-Type": "application/json"}
+        if settings.data_repository_api_key:
+            headers["X-API-Key"] = settings.data_repository_api_key
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    url,
+                    params={"uri": source_uri},
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(
+                        total=settings.data_repository_timeout_s
+                    ),
+                ) as response:
+                    if response.status == 200:
+                        return await response.json()
+
+                    try:
+                        err = await response.json()
+                        detail = err.get("detail") or err.get("error")
+                    except Exception:
+                        detail = await response.text()
+
+                    if response.status in {404, 422}:
+                        raise HTTPException(
+                            status_code=response.status,
+                            detail=detail or "Data Repository resolution failed",
+                        )
+
+                    raise HTTPException(
+                        status_code=502,
+                        detail=(
+                            "Data Repository resolution failed "
+                            f"[{response.status}]: {detail}"
+                        ),
+                    )
+        except HTTPException:
+            raise
+        except (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            asyncio.TimeoutError,
+        ) as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Data Repository is unreachable: {exc}",
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Unexpected error during Data Repository resolve: {exc}",
+            )
+
+    @staticmethod
+    def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
+        category = payload.get("category")
+        if category != "model":
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Resolved artifact is not a deployable model. "
+                    f"Expected category 'model', got '{category}'."
+                ),
+            )
+
+        harbor_ref = payload.get("harbor_ref")
+        if not harbor_ref:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    "Data Repository response missing harbor_ref for "
+                    f"URI '{source_uri}'."
+                ),
+            )
+
+    async def pull_from_host(
+        self,
+        *,
+        harbor_ref: str,
+        metadata: dict[str, Any],
+        digest: str | None,
+        source_uri: str,
+        host_url: str,
+        host_api_key: str,
+    ) -> str:
+        url = f"{host_url.rstrip('/')}/models/pull"
+        headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
+        payload: dict[str, Any] = {
+            "source": "harbor",
+            "harbor_ref": harbor_ref,
+            "source_uri": source_uri,
+            "category": metadata.get("category"),
+            "name": metadata.get("name"),
+            "version": metadata.get("version"),
+            "size_bytes": metadata.get("size_bytes"),
+            "checksum": metadata.get("checksum"),
+            "metadata": metadata.get("metadata"),
+        }
+        if digest:
+            payload["digest"] = digest
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=300),
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        path = data.get("path")
+                        if not path:
+                            raise HTTPException(
+                                status_code=502,
+                                detail=(
+                                    f"Host '{host_url}' returned success but no path "
+                                    f"for model pull."
+                                ),
+                            )
+                        return self.to_local_uri(path)
+
+                    try:
+                        err = await response.json()
+                        detail = err.get("detail") or err.get("error")
+                    except Exception:
+                        detail = await response.text()
+
+                    out_code = response.status if response.status in {404, 507} else 502
+                    raise HTTPException(
+                        status_code=out_code,
+                        detail=(
+                            f"Model pull failed on host '{host_url}' [{response.status}]: "
+                            f"{detail}"
+                        ),
+                    )
+        except HTTPException:
+            raise
+        except (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            asyncio.TimeoutError,
+        ) as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Host '{host_url}' is unreachable during model pull: {exc}",
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Unexpected error during model pull on host: {exc}",
+            )
+
+    async def resolve_repo(
+        self, source_uri: str, host_url: str, host_api_key: str
+    ) -> str:
+        """
+        Resolves a repo:// URI by querying Data Repository metadata and
+        asking the target host to pull the resolved Harbor artifact.
+        Returns the resolved local:// path.
+        """
+        resolved = await self.resolve_from_data_repository(source_uri)
+        self.validate_resolved_model(resolved, source_uri)
+
+        return await self.pull_from_host(
+            harbor_ref=resolved["harbor_ref"],
+            metadata=resolved,
+            digest=resolved.get("checksum"),
+            source_uri=source_uri,
+            host_url=host_url,
+            host_api_key=host_api_key,
+        )
+
+
+_repo_resolver = RepoResolver()
 
 
 async def resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
-    if not settings.data_repository_url:
-        raise HTTPException(
-            status_code=500,
-            detail="DATA_REPOSITORY_URL is not configured",
-        )
-
-    url = f"{settings.data_repository_url.rstrip('/')}/api/resolve"
-    headers = {"Content-Type": "application/json"}
-    if settings.data_repository_api_key:
-        headers["X-API-Key"] = settings.data_repository_api_key
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                url,
-                params={"uri": source_uri},
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=settings.data_repository_timeout_s),
-            ) as response:
-                if response.status == 200:
-                    return await response.json()
-
-                try:
-                    err = await response.json()
-                    detail = err.get("detail") or err.get("error")
-                except Exception:
-                    detail = await response.text()
-
-                if response.status in {404, 422}:
-                    raise HTTPException(
-                        status_code=response.status,
-                        detail=detail or "Data Repository resolution failed",
-                    )
-
-                raise HTTPException(
-                    status_code=502,
-                    detail=(
-                        "Data Repository resolution failed "
-                        f"[{response.status}]: {detail}"
-                    ),
-                )
-    except HTTPException:
-        raise
-    except (
-        aiohttp.ClientConnectionError,
-        aiohttp.ClientConnectorError,
-        asyncio.TimeoutError,
-    ) as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Data Repository is unreachable: {exc}",
-        )
-    except Exception as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Unexpected error during Data Repository resolve: {exc}",
-        )
+    return await _repo_resolver.resolve_from_data_repository(source_uri)
 
 
 def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
-    category = payload.get("category")
-    if category != "model":
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                "Resolved artifact is not a deployable model. "
-                f"Expected category 'model', got '{category}'."
-            ),
-        )
-
-    harbor_ref = payload.get("harbor_ref")
-    if not harbor_ref:
-        raise HTTPException(
-            status_code=502,
-            detail=(
-                "Data Repository response missing harbor_ref for "
-                f"URI '{source_uri}'."
-            ),
-        )
-
-
-async def _pull_from_host(
-    *,
-    harbor_ref: str,
-    metadata: dict[str, Any],
-    digest: str | None,
-    source_uri: str,
-    host_url: str,
-    host_api_key: str,
-) -> str:
-    url = f"{host_url.rstrip('/')}/models/pull"
-    headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
-    payload: dict[str, Any] = {
-        "source": "harbor",
-        "harbor_ref": harbor_ref,
-        "source_uri": source_uri,
-        "category": metadata.get("category"),
-        "name": metadata.get("name"),
-        "version": metadata.get("version"),
-        "size_bytes": metadata.get("size_bytes"),
-        "checksum": metadata.get("checksum"),
-        "metadata": metadata.get("metadata"),
-    }
-    if digest:
-        payload["digest"] = digest
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url,
-                json=payload,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=300),
-            ) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    path = data.get("path")
-                    if not path:
-                        raise HTTPException(
-                            status_code=502,
-                            detail=(
-                                f"Host '{host_url}' returned success but no path "
-                                f"for model pull."
-                            ),
-                        )
-                    return _to_local_uri(path)
-
-                try:
-                    err = await response.json()
-                    detail = err.get("detail") or err.get("error")
-                except Exception:
-                    detail = await response.text()
-
-                out_code = response.status if response.status in {404, 507} else 502
-                raise HTTPException(
-                    status_code=out_code,
-                    detail=(
-                        f"Model pull failed on host '{host_url}' [{response.status}]: "
-                        f"{detail}"
-                    ),
-                )
-    except HTTPException:
-        raise
-    except (
-        aiohttp.ClientConnectionError,
-        aiohttp.ClientConnectorError,
-        asyncio.TimeoutError,
-    ) as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Host '{host_url}' is unreachable during model pull: {exc}",
-        )
-    except Exception as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Unexpected error during model pull on host: {exc}",
-        )
+    _repo_resolver.validate_resolved_model(payload, source_uri)
 
 
 async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str:
-    """
-    Resolves a repo:// URI by querying Data Repository metadata and
-    asking the target host to pull the resolved Harbor artifact.
-    Returns the resolved local:// path.
-    """
-    # Fetch authoritative metadata from Data Repository
-    resolved = await resolve_from_data_repository(source_uri)
-    validate_resolved_model(resolved, source_uri)
-
-    return await _pull_from_host(
-        harbor_ref=resolved["harbor_ref"],
-        metadata=resolved,
-        digest=resolved.get("checksum"),
-        source_uri=source_uri,
-        host_url=host_url,
-        host_api_key=host_api_key,
-    )
+    return await _repo_resolver.resolve_repo(source_uri, host_url, host_api_key)

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -191,8 +191,3 @@ async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str
         host_url=host_url,
         host_api_key=host_api_key,
     )
-
-
-# Backward-compatible aliases for existing internal imports.
-_resolve_from_data_repository = resolve_from_data_repository
-_validate_resolved_model = validate_resolved_model

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -1,3 +1,13 @@
+"""repo:// resolver: Data Repository integration + Solar Host pull (D-016).
+
+The resolver owns the wire-level details of calling Data Repository's
+``GET /api/resolve`` endpoint and forwarding the authoritative metadata to
+the target host's ``POST /models/pull``. It intentionally exposes the
+``build_harbor_pull_payload`` and ``post_harbor_pull`` helpers so the
+``/models/distribute`` route can reuse the same payload shape without
+duplicating it.
+"""
+
 import asyncio
 from typing import Any
 
@@ -6,206 +16,230 @@ from fastapi import HTTPException
 
 from app.config import settings
 
+# Host pull responses we propagate verbatim instead of collapsing to 502.
+# 404 = model not found at source, 507 = insufficient disk on the host.
+_PROPAGATED_HOST_CODES = {404, 507}
 
-class RepoResolver:
-    @staticmethod
-    def to_local_uri(path: str) -> str:
-        if path.startswith("/"):
-            return f"local:///{path.lstrip('/')}"
-        return f"local://{path}"
-
-    async def resolve_from_data_repository(self, source_uri: str) -> dict[str, Any]:
-        if not settings.data_repository_url:
-            raise HTTPException(
-                status_code=500,
-                detail="DATA_REPOSITORY_URL is not configured",
-            )
-
-        url = f"{settings.data_repository_url.rstrip('/')}/api/resolve"
-        headers = {"Content-Type": "application/json"}
-        if settings.data_repository_api_key:
-            headers["X-API-Key"] = settings.data_repository_api_key
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    url,
-                    params={"uri": source_uri},
-                    headers=headers,
-                    timeout=aiohttp.ClientTimeout(
-                        total=settings.data_repository_timeout_s
-                    ),
-                ) as response:
-                    if response.status == 200:
-                        return await response.json()
-
-                    try:
-                        err = await response.json()
-                        detail = err.get("detail") or err.get("error")
-                    except Exception:
-                        detail = await response.text()
-
-                    if response.status in {404, 422}:
-                        raise HTTPException(
-                            status_code=response.status,
-                            detail=detail or "Data Repository resolution failed",
-                        )
-
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(
-                            "Data Repository resolution failed "
-                            f"[{response.status}]: {detail}"
-                        ),
-                    )
-        except HTTPException:
-            raise
-        except (
-            aiohttp.ClientConnectionError,
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-        ) as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Data Repository is unreachable: {exc}",
-            )
-        except Exception as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Unexpected error during Data Repository resolve: {exc}",
-            )
-
-    @staticmethod
-    def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
-        category = payload.get("category")
-        if category != "model":
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    "Resolved artifact is not a deployable model. "
-                    f"Expected category 'model', got '{category}'."
-                ),
-            )
-
-        harbor_ref = payload.get("harbor_ref")
-        if not harbor_ref:
-            raise HTTPException(
-                status_code=502,
-                detail=(
-                    "Data Repository response missing harbor_ref for "
-                    f"URI '{source_uri}'."
-                ),
-            )
-
-    async def pull_from_host(
-        self,
-        *,
-        harbor_ref: str,
-        metadata: dict[str, Any],
-        digest: str | None,
-        source_uri: str,
-        host_url: str,
-        host_api_key: str,
-    ) -> str:
-        url = f"{host_url.rstrip('/')}/models/pull"
-        headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
-        payload: dict[str, Any] = {
-            "source": "harbor",
-            "harbor_ref": harbor_ref,
-            "source_uri": source_uri,
-            "category": metadata.get("category"),
-            "name": metadata.get("name"),
-            "version": metadata.get("version"),
-            "size_bytes": metadata.get("size_bytes"),
-            "checksum": metadata.get("checksum"),
-            "metadata": metadata.get("metadata"),
-        }
-        if digest:
-            payload["digest"] = digest
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    url,
-                    json=payload,
-                    headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=300),
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        path = data.get("path")
-                        if not path:
-                            raise HTTPException(
-                                status_code=502,
-                                detail=(
-                                    f"Host '{host_url}' returned success but no path "
-                                    f"for model pull."
-                                ),
-                            )
-                        return RepoResolver.to_local_uri(path)
-
-                    try:
-                        err = await response.json()
-                        detail = err.get("detail") or err.get("error")
-                    except Exception:
-                        detail = await response.text()
-
-                    out_code = response.status if response.status in {404, 507} else 502
-                    raise HTTPException(
-                        status_code=out_code,
-                        detail=(
-                            f"Model pull failed on host '{host_url}' [{response.status}]: "
-                            f"{detail}"
-                        ),
-                    )
-        except HTTPException:
-            raise
-        except (
-            aiohttp.ClientConnectionError,
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-        ) as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Host '{host_url}' is unreachable during model pull: {exc}",
-            )
-        except Exception as exc:
-            raise HTTPException(
-                status_code=502,
-                detail=f"Unexpected error during model pull on host: {exc}",
-            )
-
-    async def resolve_repo(
-        self, source_uri: str, host_url: str, host_api_key: str
-    ) -> str:
-        """
-        Resolves a repo:// URI by querying Data Repository metadata and
-        asking the target host to pull the resolved Harbor artifact.
-        Returns the resolved local:// path.
-        """
-        resolved = await self.resolve_from_data_repository(source_uri)
-        self.validate_resolved_model(resolved, source_uri)
-
-        return await self.pull_from_host(
-            harbor_ref=resolved["harbor_ref"],
-            metadata=resolved,
-            digest=resolved.get("checksum"),
-            source_uri=source_uri,
-            host_url=host_url,
-            host_api_key=host_api_key,
-        )
+# Long timeout for the host pull leg: a full Harbor download can take minutes.
+_HOST_PULL_TIMEOUT_S = 300
 
 
-_default_resolver = RepoResolver()
+def to_local_uri(path: str) -> str:
+    """Convert an absolute or relative host path into a ``local://`` URI."""
+    if path.startswith("/"):
+        return f"local:///{path.lstrip('/')}"
+    return f"local://{path}"
 
 
 async def resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
-    return await _default_resolver.resolve_from_data_repository(source_uri)
+    """Call Data Repository ``GET /api/resolve?uri=...`` and return its body.
+
+    Raises ``HTTPException`` for any failure:
+      * 500 if ``DATA_REPOSITORY_URL`` is unset
+      * 404/422 propagated verbatim from Data Repository
+      * 502 for all other upstream errors and transport failures
+    """
+    if not settings.data_repository_url:
+        raise HTTPException(
+            status_code=500,
+            detail="DATA_REPOSITORY_URL is not configured",
+        )
+
+    url = f"{settings.data_repository_url.rstrip('/')}/api/resolve"
+    headers = {"Content-Type": "application/json"}
+    if settings.data_repository_api_key:
+        headers["X-API-Key"] = settings.data_repository_api_key
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                params={"uri": source_uri},
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=settings.data_repository_timeout_s),
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+
+                try:
+                    err = await response.json()
+                    detail = err.get("detail") or err.get("error")
+                except Exception:
+                    detail = await response.text()
+
+                if response.status in {404, 422}:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=detail or "Data Repository resolution failed",
+                    )
+
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        "Data Repository resolution failed "
+                        f"[{response.status}]: {detail}"
+                    ),
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Data Repository is unreachable: {exc}",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during Data Repository resolve: {exc}",
+        )
 
 
 def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
-    _default_resolver.validate_resolved_model(payload, source_uri)
+    """Reject artifacts that are not deployable models.
+
+    Both ``category != "model"`` and a missing ``harbor_ref`` are treated as
+    per-item client-visible problems (422). Missing ``harbor_ref`` is a
+    Data Repository protocol bug, but the caller (e.g. /distribute) needs to
+    be able to skip the bad item without aborting the whole batch.
+    """
+    category = payload.get("category")
+    if category != "model":
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Resolved artifact is not a deployable model. "
+                f"Expected category 'model', got '{category}'."
+            ),
+        )
+
+    harbor_ref = payload.get("harbor_ref")
+    if not harbor_ref:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Data Repository response missing harbor_ref for "
+                f"URI '{source_uri}'."
+            ),
+        )
+
+
+def build_harbor_pull_payload(
+    resolved: dict[str, Any], source_uri: str
+) -> dict[str, Any]:
+    """Build the ``POST /models/pull`` body for a resolved Harbor artifact.
+
+    Centralised so the dispatcher resolver and the /distribute route stay in
+    lockstep on what gets forwarded to solar-host.
+    """
+    payload: dict[str, Any] = {
+        "source": "harbor",
+        "harbor_ref": resolved["harbor_ref"],
+        "source_uri": source_uri,
+        "category": resolved.get("category"),
+        "name": resolved.get("name"),
+        "version": resolved.get("version"),
+        "size_bytes": resolved.get("size_bytes"),
+        "checksum": resolved.get("checksum"),
+        "metadata": resolved.get("metadata"),
+    }
+    digest = resolved.get("checksum")
+    if digest:
+        payload["digest"] = digest
+    return payload
+
+
+async def post_harbor_pull(
+    *,
+    payload: dict[str, Any],
+    host_url: str,
+    host_api_key: str,
+    host_label: str | None = None,
+) -> tuple[str, bool]:
+    """POST a pre-built pull payload to a host and return ``(path, cached)``.
+
+    Raises ``HTTPException`` for transport errors and non-200 responses.
+    ``host_label`` is used purely for error-message readability when callers
+    have a friendlier name than the URL (e.g. a host id or display name).
+    """
+    label = host_label or host_url
+    url = f"{host_url.rstrip('/')}/models/pull"
+    headers = {"X-API-Key": host_api_key, "Content-Type": "application/json"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=_HOST_PULL_TIMEOUT_S),
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    path = data.get("path")
+                    if not path:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"Host '{label}' returned success but no path "
+                                "for model pull."
+                            ),
+                        )
+                    return path, bool(data.get("cached", False))
+
+                try:
+                    err = await response.json()
+                    detail = err.get("detail") or err.get("error")
+                except Exception:
+                    detail = await response.text()
+
+                out_code = (
+                    response.status
+                    if response.status in _PROPAGATED_HOST_CODES
+                    else 502
+                )
+                raise HTTPException(
+                    status_code=out_code,
+                    detail=(
+                        f"Model pull failed on host '{label}' "
+                        f"[{response.status}]: {detail}"
+                    ),
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{label}' is unreachable during model pull: {exc}",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during model pull on host '{label}': {exc}",
+        )
 
 
 async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str:
-    return await _default_resolver.resolve_repo(source_uri, host_url, host_api_key)
+    """Resolve a ``repo://`` URI end-to-end.
+
+    Calls Data Repository for metadata, validates the result, then asks the
+    target host to pull the Harbor artifact. Returns the resolved
+    ``local://`` URI pointing at the host-managed model directory.
+    """
+    resolved = await resolve_from_data_repository(source_uri)
+    validate_resolved_model(resolved, source_uri)
+
+    payload = build_harbor_pull_payload(resolved, source_uri)
+    path, _cached = await post_harbor_pull(
+        payload=payload,
+        host_url=host_url,
+        host_api_key=host_api_key,
+    )
+    return to_local_uri(path)

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -5,10 +5,15 @@ import aiohttp
 from fastapi import HTTPException
 
 from app.config import settings
-from .parser import RepoURI
 
 
-async def _resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
+def _to_local_uri(path: str) -> str:
+    if path.startswith("/"):
+        return f"local:///{path.lstrip('/')}"
+    return f"local://{path}"
+
+
+async def resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
     if not settings.data_repository_url:
         raise HTTPException(
             status_code=500,
@@ -68,7 +73,7 @@ async def _resolve_from_data_repository(source_uri: str) -> dict[str, Any]:
         )
 
 
-def _validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
+def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
     category = payload.get("category")
     if category != "model":
         raise HTTPException(
@@ -134,7 +139,7 @@ async def _pull_from_host(
                                 f"for model pull."
                             ),
                         )
-                    return f"local://{path}"
+                    return _to_local_uri(path)
 
                 try:
                     err = await response.json()
@@ -168,21 +173,15 @@ async def _pull_from_host(
         )
 
 
-async def resolve_repo(
-    uri: RepoURI, source_uri: str, host_url: str, host_api_key: str
-) -> str:
+async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str:
     """
-    Stub for repo:// resolver.
-
-    Expected behavior in Phase 1 (D-016):
-    1. Call Data Repository GET /api/resolve?uri={source_uri} to obtain a harbor_ref.
-    2. Pull the OCI artifact from Harbor using ORAS (harbor-oci-client) into the
-       host's managed models directory.
-    3. Return the resolved local:// path.
+    Resolves a repo:// URI by querying Data Repository metadata and
+    asking the target host to pull the resolved Harbor artifact.
+    Returns the resolved local:// path.
     """
     # Fetch authoritative metadata from Data Repository
-    resolved = await _resolve_from_data_repository(source_uri)
-    _validate_resolved_model(resolved, source_uri)
+    resolved = await resolve_from_data_repository(source_uri)
+    validate_resolved_model(resolved, source_uri)
 
     return await _pull_from_host(
         harbor_ref=resolved["harbor_ref"],
@@ -192,3 +191,8 @@ async def resolve_repo(
         host_url=host_url,
         host_api_key=host_api_key,
     )
+
+
+# Backward-compatible aliases for existing internal imports.
+_resolve_from_data_repository = resolve_from_data_repository
+_validate_resolved_model = validate_resolved_model

--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel
 from app.database.hosts import host_db
 from app.models import Host
 from app.model_resolvers.parser import parse, HuggingFaceURI, RepoURI, LocalURI
+from app.model_resolvers.repo import (
+    _resolve_from_data_repository,
+    _validate_resolved_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -143,12 +147,108 @@ async def _pull_on_host(
             status_code=400,
         )
     if isinstance(parsed, RepoURI):
-        return _StructuredPullError(
-            error=ERR_NOT_IMPLEMENTED,
-            detail="repo:// distribution requires Data Repository integration (Phase 1)",
-            source_uri=source_uri,
-            status_code=501,
-        )
+        try:
+            resolved = await _resolve_from_data_repository(source_uri)
+            _validate_resolved_model(resolved, source_uri)
+        except HTTPException as exc:
+            return _StructuredPullError(
+                error="resolve_failed",
+                detail=exc.detail,
+                source_uri=source_uri,
+                status_code=exc.status_code,
+            )
+
+        url = f"{host.url.rstrip('/')}/models/pull"
+        headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
+        payload = {
+            "source": "harbor",
+            "harbor_ref": resolved["harbor_ref"],
+            "source_uri": source_uri,
+            "category": resolved.get("category"),
+            "name": resolved.get("name"),
+            "version": resolved.get("version"),
+            "size_bytes": resolved.get("size_bytes"),
+            "checksum": resolved.get("checksum"),
+            "metadata": resolved.get("metadata"),
+        }
+        checksum = resolved.get("checksum")
+        if checksum:
+            payload["digest"] = checksum
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=300),
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        path = data.get("path")
+                        cached = data.get("cached", False)
+                        if not path:
+                            return _StructuredPullError(
+                                error="bad_response",
+                                detail=(
+                                    f"Host '{host.name}' ({host.url}) returned success "
+                                    f"but no path"
+                                ),
+                                source_uri=source_uri,
+                                status_code=502,
+                            )
+                        return path, cached
+
+                    try:
+                        err = await response.json()
+                        if err.get("error") and err.get("status_code"):
+                            return _StructuredPullError(
+                                error=err["error"],
+                                detail=err.get("detail", await response.text()),
+                                source_uri=err.get("source_uri", source_uri),
+                                status_code=err.get("status_code", response.status),
+                            )
+                        detail = (
+                            err.get("detail")
+                            or err.get("error")
+                            or await response.text()
+                        )
+                    except Exception:
+                        detail = await response.text()
+
+                    out_code = (
+                        response.status if response.status in PROPAGATED_CODES else 502
+                    )
+                    return _StructuredPullError(
+                        error="pull_failed",
+                        detail=(
+                            f"Model pull failed on host '{host.name}' "
+                            f"[{response.status}]: {detail}"
+                        ),
+                        source_uri=source_uri,
+                        status_code=out_code,
+                    )
+        except (
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            asyncio.TimeoutError,
+        ) as e:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"Host '{host.name}' ({host.url}) is unreachable during model pull: {e}"
+                ),
+            )
+        except Exception:
+            logger.exception(
+                "Unexpected error during model distribution to host %s", host.id
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"Unexpected error during model distribution to host '{host.name}':"
+                ),
+            )
 
     if not isinstance(parsed, HuggingFaceURI):
         return _StructuredPullError(

--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -12,6 +12,7 @@ from app.database.hosts import host_db
 from app.models import Host
 from app.model_resolvers.parser import parse, HuggingFaceURI, RepoURI, LocalURI
 from app.model_resolvers.repo import (
+    build_harbor_pull_payload,
     resolve_from_data_repository,
     validate_resolved_model,
 )
@@ -129,6 +130,99 @@ class _StructuredPullError:
         self.status_code = status_code
 
 
+# Long timeout: a full model pull on the host may take minutes.
+_HOST_PULL_TIMEOUT_S = 300
+
+
+async def _post_pull_to_host(
+    host: Host, source_uri: str, payload: dict
+) -> tuple[str, bool] | _StructuredPullError:
+    """POST a pre-built pull payload to ``host`` and translate the response.
+
+    Unlike ``app.model_resolvers.repo.post_harbor_pull`` (used by the
+    dispatcher path, which raises HTTPException for every failure), this
+    variant preserves structured per-item failures so the /distribute route
+    can keep producing partial-batch results. Transport-level failures still
+    raise HTTPException because they affect the whole batch, not one item.
+    """
+    url = f"{host.url.rstrip('/')}/models/pull"
+    headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=_HOST_PULL_TIMEOUT_S),
+            ) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    path = data.get("path")
+                    cached = data.get("cached", False)
+                    if not path:
+                        return _StructuredPullError(
+                            error="bad_response",
+                            detail=(
+                                f"Host '{host.name}' ({host.url}) returned success "
+                                "but no path"
+                            ),
+                            source_uri=source_uri,
+                            status_code=502,
+                        )
+                    return path, cached
+
+                try:
+                    err = await response.json()
+                    if err.get("error") and err.get("status_code"):
+                        return _StructuredPullError(
+                            error=err["error"],
+                            detail=err.get("detail", await response.text()),
+                            source_uri=err.get("source_uri", source_uri),
+                            status_code=err.get("status_code", response.status),
+                        )
+                    detail = (
+                        err.get("detail") or err.get("error") or await response.text()
+                    )
+                except Exception:
+                    detail = await response.text()
+
+                out_code = (
+                    response.status if response.status in PROPAGATED_CODES else 502
+                )
+                return _StructuredPullError(
+                    error="pull_failed",
+                    detail=(
+                        f"Model pull failed on host '{host.name}' "
+                        f"[{response.status}]: {detail}"
+                    ),
+                    source_uri=source_uri,
+                    status_code=out_code,
+                )
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as e:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Host '{host.name}' ({host.url}) is unreachable during model pull: {e}"
+            ),
+        )
+    except Exception as exc:
+        logger.exception(
+            "Unexpected error during model distribution to host %s", host.id
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Unexpected error during model distribution to host "
+                f"'{host.name}': {exc}"
+            ),
+        )
+
+
 async def _pull_on_host(
     parsed: Any, source_uri: str, host: Host
 ) -> tuple[str, bool] | _StructuredPullError:
@@ -160,97 +254,8 @@ async def _pull_on_host(
                 status_code=exc.status_code,
             )
 
-        url = f"{host.url.rstrip('/')}/models/pull"
-        headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
-        payload = {
-            "source": "harbor",
-            "harbor_ref": resolved["harbor_ref"],
-            "source_uri": source_uri,
-            "category": resolved.get("category"),
-            "name": resolved.get("name"),
-            "version": resolved.get("version"),
-            "size_bytes": resolved.get("size_bytes"),
-            "checksum": resolved.get("checksum"),
-            "metadata": resolved.get("metadata"),
-        }
-        checksum = resolved.get("checksum")
-        if checksum:
-            payload["digest"] = checksum
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    url,
-                    json=payload,
-                    headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=300),
-                ) as response:
-                    if response.status == 200:
-                        data = await response.json()
-                        path = data.get("path")
-                        cached = data.get("cached", False)
-                        if not path:
-                            return _StructuredPullError(
-                                error="bad_response",
-                                detail=(
-                                    f"Host '{host.name}' ({host.url}) returned success "
-                                    f"but no path"
-                                ),
-                                source_uri=source_uri,
-                                status_code=502,
-                            )
-                        return path, cached
-
-                    try:
-                        err = await response.json()
-                        if err.get("error") and err.get("status_code"):
-                            return _StructuredPullError(
-                                error=err["error"],
-                                detail=err.get("detail", await response.text()),
-                                source_uri=err.get("source_uri", source_uri),
-                                status_code=err.get("status_code", response.status),
-                            )
-                        detail = (
-                            err.get("detail")
-                            or err.get("error")
-                            or await response.text()
-                        )
-                    except Exception:
-                        detail = await response.text()
-
-                    out_code = (
-                        response.status if response.status in PROPAGATED_CODES else 502
-                    )
-                    return _StructuredPullError(
-                        error="pull_failed",
-                        detail=(
-                            f"Model pull failed on host '{host.name}' "
-                            f"[{response.status}]: {detail}"
-                        ),
-                        source_uri=source_uri,
-                        status_code=out_code,
-                    )
-        except (
-            aiohttp.ClientConnectionError,
-            aiohttp.ClientConnectorError,
-            asyncio.TimeoutError,
-        ) as e:
-            raise HTTPException(
-                status_code=502,
-                detail=(
-                    f"Host '{host.name}' ({host.url}) is unreachable during model pull: {e}"
-                ),
-            )
-        except Exception:
-            logger.exception(
-                "Unexpected error during model distribution to host %s", host.id
-            )
-            raise HTTPException(
-                status_code=502,
-                detail=(
-                    f"Unexpected error during model distribution to host '{host.name}':"
-                ),
-            )
+        payload = build_harbor_pull_payload(resolved, source_uri)
+        return await _post_pull_to_host(host, source_uri, payload)
 
     if not isinstance(parsed, HuggingFaceURI):
         return _StructuredPullError(
@@ -260,78 +265,12 @@ async def _pull_on_host(
             status_code=400,
         )
 
-    url = f"{host.url.rstrip('/')}/models/pull"
-    headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
     payload = {
         "source": "huggingface",
         "model_id": parsed.model_id,
         "source_uri": source_uri,
     }
-
-    try:
-        # Long timeout for model pull as it might involve downloading GBs
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url,
-                json=payload,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=300),
-            ) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    path = data.get("path")
-                    cached = data.get("cached", False)
-                    if not path:
-                        return _StructuredPullError(
-                            error="bad_response",
-                            detail=f"Host '{host.name}' ({host.url}) returned success but no path",
-                            source_uri=source_uri,
-                            status_code=502,
-                        )
-                    return path, cached
-
-                # Parse structured error from host
-                try:
-                    err = await response.json()
-                    if err.get("error") and err.get("status_code"):
-                        return _StructuredPullError(
-                            error=err["error"],
-                            detail=err.get("detail", await response.text()),
-                            source_uri=err.get("source_uri", source_uri),
-                            status_code=err.get("status_code", response.status),
-                        )
-                    detail = (
-                        err.get("detail") or err.get("error") or await response.text()
-                    )
-                except Exception:
-                    detail = await response.text()
-
-                out_code = (
-                    response.status if response.status in PROPAGATED_CODES else 502
-                )
-                return _StructuredPullError(
-                    error="pull_failed",
-                    detail=f"Model pull failed on host '{host.name}' [{response.status}]: {detail}",
-                    source_uri=source_uri,
-                    status_code=out_code,
-                )
-    except (
-        aiohttp.ClientConnectionError,
-        aiohttp.ClientConnectorError,
-        asyncio.TimeoutError,
-    ) as e:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Host '{host.name}' ({host.url}) is unreachable during model pull: {e}",
-        )
-    except Exception:
-        logger.exception(
-            "Unexpected error during model distribution to host %s", host.id
-        )
-        raise HTTPException(
-            status_code=502,
-            detail=f"Unexpected error during model distribution to host '{host.name}':",
-        )
+    return await _post_pull_to_host(host, source_uri, payload)
 
 
 async def _fetch_host_models(host: Host) -> list[dict]:

--- a/app/routes/management/models.py
+++ b/app/routes/management/models.py
@@ -12,8 +12,8 @@ from app.database.hosts import host_db
 from app.models import Host
 from app.model_resolvers.parser import parse, HuggingFaceURI, RepoURI, LocalURI
 from app.model_resolvers.repo import (
-    _resolve_from_data_repository,
-    _validate_resolved_model,
+    resolve_from_data_repository,
+    validate_resolved_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -136,8 +136,8 @@ async def _pull_on_host(
     Tells the target host to pull the model.
     Returns (local_path, cached_bool) on success, or a _StructuredPullError on failure.
 
-    Raises HTTPException only for connection-level errors (502).
-    Returns _StructuredPullError for expected failures (400, 404, 501, 507).
+    Raises HTTPException for connection-level/dependency failures (5xx).
+    Returns _StructuredPullError for expected request/content failures (4xx, 507).
     """
     if isinstance(parsed, LocalURI):
         return _StructuredPullError(
@@ -148,9 +148,11 @@ async def _pull_on_host(
         )
     if isinstance(parsed, RepoURI):
         try:
-            resolved = await _resolve_from_data_repository(source_uri)
-            _validate_resolved_model(resolved, source_uri)
+            resolved = await resolve_from_data_repository(source_uri)
+            validate_resolved_model(resolved, source_uri)
         except HTTPException as exc:
+            if exc.status_code >= 500:
+                raise
             return _StructuredPullError(
                 error="resolve_failed",
                 detail=exc.detail,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest fixtures for the solar-control test suite."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def repo_settings():
+    """Patch ``app.model_resolvers.repo.settings`` with sensible defaults.
+
+    Yields the mock so tests can override individual fields (e.g. unset
+    ``data_repository_url`` to exercise the unconfigured-config path).
+    """
+    with patch("app.model_resolvers.repo.settings") as mock_settings:
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+        yield mock_settings

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -128,18 +128,13 @@ async def test_pull_on_host_local_uri(mock_host):
 
 
 @pytest.mark.anyio
-async def test_pull_on_host_repo_uri(mock_host):
+async def test_pull_on_host_repo_uri(mock_host, repo_settings):
     uri = "repo://model:v1"
     parsed = parse(uri)
     with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
         patch("aiohttp.ClientSession.get") as mock_get,
         patch("aiohttp.ClientSession.post") as mock_post,
     ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
         resolve_resp = AsyncMock()
         resolve_resp.status = 200
         resolve_resp.json.return_value = {
@@ -164,17 +159,10 @@ async def test_pull_on_host_repo_uri(mock_host):
 
 
 @pytest.mark.anyio
-async def test_pull_on_host_repo_uri_resolve_5xx_raises(mock_host):
+async def test_pull_on_host_repo_uri_resolve_5xx_raises(mock_host, repo_settings):
     uri = "repo://model:v1"
     parsed = parse(uri)
-    with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
-        patch("aiohttp.ClientSession.get") as mock_get,
-    ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
+    with patch("aiohttp.ClientSession.get") as mock_get:
         resolve_resp = AsyncMock()
         resolve_resp.status = 500
         resolve_resp.json.return_value = {"detail": "internal error"}
@@ -186,6 +174,36 @@ async def test_pull_on_host_repo_uri_resolve_5xx_raises(mock_host):
         assert exc.value.status_code == 502
         assert "Data Repository resolution failed [500]" in exc.value.detail
         assert "internal error" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_pull_on_host_repo_uri_missing_harbor_ref_is_partial(
+    mock_host, repo_settings
+):
+    """A Data Repository response missing harbor_ref must not abort the batch."""
+    uri = "repo://model:v1"
+    parsed = parse(uri)
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = {
+            "category": "model",
+            "name": "model",
+            "version": "v1",
+            # harbor_ref intentionally omitted
+            "size_bytes": 123,
+            "checksum": "sha256:abc",
+            "metadata": {},
+        }
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        result = await _pull_on_host(parsed, uri, mock_host)
+
+        assert isinstance(result, _StructuredPullError)
+        assert result.status_code == 422
+        assert result.error == "resolve_failed"
+        assert "missing harbor_ref" in result.detail
+        assert result.source_uri == uri
 
 
 @pytest.mark.anyio

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -185,6 +185,7 @@ async def test_pull_on_host_repo_uri_resolve_5xx_raises(mock_host):
 
         assert exc.value.status_code == 502
         assert "Data Repository resolution failed [500]" in exc.value.detail
+        assert "internal error" in exc.value.detail
 
 
 @pytest.mark.anyio

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -131,13 +131,36 @@ async def test_pull_on_host_local_uri(mock_host):
 async def test_pull_on_host_repo_uri(mock_host):
     uri = "repo://model:v1"
     parsed = parse(uri)
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
 
-    result = await _pull_on_host(parsed, uri, mock_host)
-    assert isinstance(result, _StructuredPullError)
-    assert result.status_code == 501
-    assert "repo:// distribution requires Data Repository" in result.detail
-    assert result.source_uri == "repo://model:v1"
-    assert result.error == "not_implemented"
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = {
+            "category": "model",
+            "name": "model",
+            "version": "v1",
+            "harbor_ref": "imgrepo.damit.hu/supernova/model:v1",
+            "size_bytes": 123,
+            "checksum": "sha256:abc",
+            "metadata": {},
+            "created_at": "2026-04-29T10:00:00Z",
+        }
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        pull_resp = AsyncMock()
+        pull_resp.status = 200
+        pull_resp.json.return_value = {"path": "/models/repo--model--v1"}
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        result = await _pull_on_host(parsed, uri, mock_host)
+        assert result == ("/models/repo--model--v1", False)
 
 
 @pytest.mark.anyio
@@ -203,10 +226,10 @@ async def test_distribute_model_partial_results(mock_host):
         mock_pull.side_effect = [
             ("/path1", False),
             _StructuredPullError(
-                error="not_implemented",
-                detail="repo:// distribution requires Data Repository integration (Phase 1)",
+                error="resolve_failed",
+                detail="Data Repository is unreachable",
                 source_uri="repo://test-model:v1",
-                status_code=501,
+                status_code=502,
             ),
             ("/path3", True),
         ]

--- a/tests/test_distribute.py
+++ b/tests/test_distribute.py
@@ -164,6 +164,30 @@ async def test_pull_on_host_repo_uri(mock_host):
 
 
 @pytest.mark.anyio
+async def test_pull_on_host_repo_uri_resolve_5xx_raises(mock_host):
+    uri = "repo://model:v1"
+    parsed = parse(uri)
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 500
+        resolve_resp.json.return_value = {"detail": "internal error"}
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await _pull_on_host(parsed, uri, mock_host)
+
+        assert exc.value.status_code == 502
+        assert "Data Repository resolution failed [500]" in exc.value.detail
+
+
+@pytest.mark.anyio
 async def test_distribute_model_route_success(mock_host):
     req = DistributeRequest(target_host_id="host-1", source_uri="huggingface://phi-3")
 

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -218,7 +218,7 @@ async def test_resolve_repo_success():
         pull_resp = AsyncMock()
         pull_resp.status = 200
         pull_resp.json.return_value = {
-            "path": "//opt/solar/models/repo--iris-osl--v3",
+            "path": "/opt/solar/models/repo--iris-osl--v3",
             "cached": True,
         }
         mock_post.return_value.__aenter__.return_value = pull_resp

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -188,26 +188,60 @@ async def test_resolve_huggingface_structured_error():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_stub():
+async def test_resolve_repo_success():
     uri = "repo://iris-osl:v3"
-    with pytest.raises(HTTPException) as exc:
-        await resolve(uri, "http://host:8000", "key")
+    host_url = "http://host:8000"
 
-    assert exc.value.status_code == 501
-    assert (
-        "repo:// resolver not yet available. Data Repository integration will be completed in Phase 1."
-        in exc.value.detail
-    )
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
 
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = {
+            "category": "model",
+            "name": "iris-osl",
+            "version": "v3",
+            "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
+            "size_bytes": 123,
+            "checksum": "sha256:abc",
+            "metadata": {},
+            "created_at": "2026-04-29T10:00:00Z",
+        }
+        mock_get.return_value.__aenter__.return_value = resolve_resp
 
-@pytest.mark.anyio
-async def test_resolve_repo_stub_includes_uri():
-    uri = "repo://my-model:v1.2.3"
-    with pytest.raises(HTTPException) as exc:
-        await resolve(uri, "http://host:8000", "key")
+        pull_resp = AsyncMock()
+        pull_resp.status = 200
+        pull_resp.json.return_value = {
+            "path": "/opt/solar/models/repo--iris-osl--v3",
+            "cached": True,
+        }
+        mock_post.return_value.__aenter__.return_value = pull_resp
 
-    assert exc.value.status_code == 501
-    assert f"URI: {uri}" in exc.value.detail
+        resolved = await resolve(uri, host_url, "key")
+
+        assert resolved == "local:///opt/solar/models/repo--iris-osl--v3"
+        mock_get.assert_called_once()
+        mock_post.assert_called_once()
+        _, post_kwargs = mock_post.call_args
+        assert post_kwargs["json"]["source"] == "harbor"
+        assert (
+            post_kwargs["json"]["harbor_ref"]
+            == "imgrepo.damit.hu/supernova/iris-osl:v3"
+        )
+        assert post_kwargs["json"]["source_uri"] == uri
+        assert post_kwargs["json"]["digest"] == "sha256:abc"
+        assert post_kwargs["json"]["category"] == "model"
+        assert post_kwargs["json"]["name"] == "iris-osl"
+        assert post_kwargs["json"]["version"] == "v3"
+        assert post_kwargs["json"]["size_bytes"] == 123
+        assert post_kwargs["json"]["checksum"] == "sha256:abc"
+        assert post_kwargs["json"]["metadata"] == {}
 
 
 @pytest.mark.anyio
@@ -239,3 +273,127 @@ async def test_resolve_repo_invalid_empty_version():
 
     assert exc.value.status_code == 400
     assert "Name and version must be non-empty" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_not_found():
+    uri = "repo://iris-osl:v99"
+
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 404
+        resolve_resp.json.return_value = {"detail": "Version not found"}
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, "http://host:8000", "key")
+
+        assert exc.value.status_code == 404
+        assert "Version not found" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_pull_failed():
+    uri = "repo://iris-osl:v3"
+    host_url = "http://host:8000"
+
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = {
+            "category": "model",
+            "name": "iris-osl",
+            "version": "v3",
+            "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
+            "size_bytes": 123,
+            "checksum": "sha256:abc",
+            "metadata": {},
+            "created_at": "2026-04-29T10:00:00Z",
+        }
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        pull_resp = AsyncMock()
+        pull_resp.status = 404
+        pull_resp.json.side_effect = Exception("Not JSON")
+        pull_resp.text.return_value = "Not Found"
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 404
+        assert (
+            f"Model pull failed on host '{host_url}' [404]: Not Found"
+            in exc.value.detail
+        )
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_data_repo_unreachable():
+    uri = "repo://iris-osl:v3"
+
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+
+        import aiohttp
+
+        mock_get.side_effect = aiohttp.ClientConnectionError("Connection refused")
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, "http://host:8000", "key")
+
+        assert exc.value.status_code == 502
+        assert "Data Repository is unreachable" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_rejects_dataset():
+    uri = "repo://iris-tickets:2026-03"
+
+    with (
+        patch("app.model_resolvers.repo.settings") as mock_settings,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = {
+            "category": "dataset",
+            "name": "iris-tickets",
+            "version": "2026-03",
+            "harbor_ref": "imgrepo.damit.hu/supernova/iris-tickets:2026-03",
+            "size_bytes": 123,
+            "checksum": "sha256:abc",
+            "metadata": {},
+            "created_at": "2026-04-29T10:00:00Z",
+        }
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, "http://host:8000", "key")
+
+        assert exc.value.status_code == 422
+        assert "not a deployable model" in exc.value.detail

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -5,6 +5,22 @@ from app.model_resolvers.parser import parse, RepoURI, HuggingFaceURI, LocalURI
 from app.model_resolvers.dispatcher import resolve
 
 
+def _repo_resolve_payload(**overrides):
+    """Build a canonical Data Repository /api/resolve response."""
+    payload = {
+        "category": "model",
+        "name": "iris-osl",
+        "version": "v3",
+        "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
+        "size_bytes": 123,
+        "checksum": "sha256:abc",
+        "metadata": {},
+        "created_at": "2026-04-29T10:00:00Z",
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_parser_local():
     # Absolute path
     p = parse("local:///opt/models/iris.gguf")
@@ -188,31 +204,17 @@ async def test_resolve_huggingface_structured_error():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_success():
+async def test_resolve_repo_success(repo_settings):
     uri = "repo://iris-osl:v3"
     host_url = "http://host:8000"
 
     with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
         patch("aiohttp.ClientSession.get") as mock_get,
         patch("aiohttp.ClientSession.post") as mock_post,
     ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
         resolve_resp = AsyncMock()
         resolve_resp.status = 200
-        resolve_resp.json.return_value = {
-            "category": "model",
-            "name": "iris-osl",
-            "version": "v3",
-            "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
-            "size_bytes": 123,
-            "checksum": "sha256:abc",
-            "metadata": {},
-            "created_at": "2026-04-29T10:00:00Z",
-        }
+        resolve_resp.json.return_value = _repo_resolve_payload()
         mock_get.return_value.__aenter__.return_value = resolve_resp
 
         pull_resp = AsyncMock()
@@ -276,17 +278,10 @@ async def test_resolve_repo_invalid_empty_version():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_not_found():
+async def test_resolve_repo_not_found(repo_settings):
     uri = "repo://iris-osl:v99"
 
-    with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
-        patch("aiohttp.ClientSession.get") as mock_get,
-    ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
+    with patch("aiohttp.ClientSession.get") as mock_get:
         resolve_resp = AsyncMock()
         resolve_resp.status = 404
         resolve_resp.json.return_value = {"detail": "Version not found"}
@@ -300,31 +295,17 @@ async def test_resolve_repo_not_found():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_pull_failed():
+async def test_resolve_repo_pull_failed(repo_settings):
     uri = "repo://iris-osl:v3"
     host_url = "http://host:8000"
 
     with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
         patch("aiohttp.ClientSession.get") as mock_get,
         patch("aiohttp.ClientSession.post") as mock_post,
     ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
         resolve_resp = AsyncMock()
         resolve_resp.status = 200
-        resolve_resp.json.return_value = {
-            "category": "model",
-            "name": "iris-osl",
-            "version": "v3",
-            "harbor_ref": "imgrepo.damit.hu/supernova/iris-osl:v3",
-            "size_bytes": 123,
-            "checksum": "sha256:abc",
-            "metadata": {},
-            "created_at": "2026-04-29T10:00:00Z",
-        }
+        resolve_resp.json.return_value = _repo_resolve_payload()
         mock_get.return_value.__aenter__.return_value = resolve_resp
 
         pull_resp = AsyncMock()
@@ -344,17 +325,37 @@ async def test_resolve_repo_pull_failed():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_data_repo_unreachable():
+async def test_resolve_repo_pull_507_propagates(repo_settings):
+    """Insufficient-disk responses from the host propagate as 507, not 502."""
     uri = "repo://iris-osl:v3"
+    host_url = "http://host:8000"
 
     with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
         patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
     ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = _repo_resolve_payload()
+        mock_get.return_value.__aenter__.return_value = resolve_resp
 
+        pull_resp = AsyncMock()
+        pull_resp.status = 507
+        pull_resp.json.return_value = {"detail": "Insufficient disk space"}
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve(uri, host_url, "key")
+
+        assert exc.value.status_code == 507
+        assert "Insufficient disk space" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_data_repo_unreachable(repo_settings):
+    uri = "repo://iris-osl:v3"
+
+    with patch("aiohttp.ClientSession.get") as mock_get:
         import aiohttp
 
         mock_get.side_effect = aiohttp.ClientConnectionError("Connection refused")
@@ -367,29 +368,30 @@ async def test_resolve_repo_data_repo_unreachable():
 
 
 @pytest.mark.anyio
-async def test_resolve_repo_rejects_dataset():
+async def test_resolve_repo_data_repo_url_unconfigured(repo_settings):
+    """An unset DATA_REPOSITORY_URL surfaces as 500, not a silent failure."""
+    repo_settings.data_repository_url = ""
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve("repo://iris-osl:v3", "http://host:8000", "key")
+
+    assert exc.value.status_code == 500
+    assert "DATA_REPOSITORY_URL is not configured" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_rejects_dataset(repo_settings):
     uri = "repo://iris-tickets:2026-03"
 
-    with (
-        patch("app.model_resolvers.repo.settings") as mock_settings,
-        patch("aiohttp.ClientSession.get") as mock_get,
-    ):
-        mock_settings.data_repository_url = "http://data-repo:8000"
-        mock_settings.data_repository_api_key = ""
-        mock_settings.data_repository_timeout_s = 10.0
-
+    with patch("aiohttp.ClientSession.get") as mock_get:
         resolve_resp = AsyncMock()
         resolve_resp.status = 200
-        resolve_resp.json.return_value = {
-            "category": "dataset",
-            "name": "iris-tickets",
-            "version": "2026-03",
-            "harbor_ref": "imgrepo.damit.hu/supernova/iris-tickets:2026-03",
-            "size_bytes": 123,
-            "checksum": "sha256:abc",
-            "metadata": {},
-            "created_at": "2026-04-29T10:00:00Z",
-        }
+        resolve_resp.json.return_value = _repo_resolve_payload(
+            category="dataset",
+            name="iris-tickets",
+            version="2026-03",
+            harbor_ref="imgrepo.damit.hu/supernova/iris-tickets:2026-03",
+        )
         mock_get.return_value.__aenter__.return_value = resolve_resp
 
         with pytest.raises(HTTPException) as exc:
@@ -397,3 +399,56 @@ async def test_resolve_repo_rejects_dataset():
 
         assert exc.value.status_code == 422
         assert "not a deployable model" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_missing_harbor_ref_is_422(repo_settings):
+    """Resolve responses without a harbor_ref are a per-item 422, not 502.
+
+    A 502 here would abort the whole /distribute batch because the route
+    re-raises 5xx. 422 keeps it as a structured per-item failure.
+    """
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = _repo_resolve_payload(harbor_ref=None)
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve("repo://iris-osl:v3", "http://host:8000", "key")
+
+        assert exc.value.status_code == 422
+        assert "missing harbor_ref" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_latest_forwarded_verbatim(repo_settings):
+    """``repo://name:latest`` must be passed through unchanged to Data Repository.
+
+    Per the issue: "do not invent separate latest behavior in Solar Control".
+    """
+    uri = "repo://iris-osl:latest"
+
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        # Data Repository resolves "latest" -> a concrete version itself.
+        resolve_resp.json.return_value = _repo_resolve_payload(version="v7")
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        pull_resp = AsyncMock()
+        pull_resp.status = 200
+        pull_resp.json.return_value = {"path": "/opt/solar/models/repo--iris-osl--v7"}
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        await resolve(uri, "http://host:8000", "key")
+
+        _, get_kwargs = mock_get.call_args
+        assert get_kwargs["params"] == {"uri": "repo://iris-osl:latest"}
+        # And the original source_uri is what the host sees, not a rewritten one.
+        _, post_kwargs = mock_post.call_args
+        assert post_kwargs["json"]["source_uri"] == "repo://iris-osl:latest"
+        assert post_kwargs["json"]["version"] == "v7"

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -218,7 +218,7 @@ async def test_resolve_repo_success():
         pull_resp = AsyncMock()
         pull_resp.status = 200
         pull_resp.json.return_value = {
-            "path": "/opt/solar/models/repo--iris-osl--v3",
+            "path": "//opt/solar/models/repo--iris-osl--v3",
             "cached": True,
         }
         mock_post.return_value.__aenter__.return_value = pull_resp


### PR DESCRIPTION
## Description

Completes the `repo://` resolver introduced as a stub in S-013. Solar Control now calls Data Repository's D-014 resolve endpoint, validates that the returned artifact is a deployable model, and instructs the target Solar Host to pull the resolved Harbor reference via `POST /models/pull`. Authoritative metadata (category, name, version, checksum, blob-level metadata) is forwarded to the host and persisted in its manifest.

Requires the companion solar-host change on `feat/D-016` that extends `PullRequest`/`ManifestEntry` with the new optional fields (otherwise the metadata is accepted but silently dropped by the host).

## Changes (solar-control)

- `app/model_resolvers/repo.py` — full Data Repository integration: `resolve_from_data_repository`, `validate_resolved_model`, `build_harbor_pull_payload`, `post_harbor_pull`, `resolve_repo`.
- `app/routes/management/models.py` — `/distribute` route now uses the shared payload builder and a shared host-POST helper; both RepoURI and HuggingFaceURI branches share one POST loop.
- `app/config.py` — new settings: `DATA_REPOSITORY_URL`, `DATA_REPOSITORY_API_KEY`, `DATA_REPOSITORY_TIMEOUT_S`.
- `app/model_resolvers/dispatcher.py` — drop now-unused `parsed` argument from `resolve_repo` signature.
- `tests/conftest.py` — shared `repo_settings` fixture.
- `tests/test_model_resolvers.py` / `tests/test_distribute.py` — coverage for success, 404 / 422 / 507 / unreachable / unconfigured-URL paths, `latest` passthrough, dataset rejection, missing `harbor_ref` batch behavior.

## Companion change (solar-host)

- `feat/D-016`: extends `PullRequest` and `ManifestEntry` with `category`, `name`, `version`, `checksum`, `metadata` so the metadata round-trips into the manifest and back out through `GET /models`. Old pulls without these fields still work.

## Environment

- New required env var: `DATA_REPOSITORY_URL` (resolver returns 500 if unset).
- Optional: `DATA_REPOSITORY_API_KEY`, `DATA_REPOSITORY_TIMEOUT_S` (default 10s).

## `latest` handling

`repo://name:latest` is forwarded verbatim to Data Repository per the D-014 / `docs/specs/model-source-uri.md` rule. No `latest` resolution happens in Solar Control. Verified by `test_resolve_repo_latest_forwarded_verbatim`.

## Related Issues

Closes #43