### PR TITLE
feat(api): add priority validation to instance proxy endpoint (S-036)

### DIFF
--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -11,23 +11,9 @@ from pydantic import BaseModel
 from app.models import Host, HostCreate, HostResponse, HostStatus
 from app.database.hosts import host_db
 from app.model_resolvers import resolve
+from app.validation import validate_priority
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
-
-VALID_PRIORITIES = {"production", "staging", "ephemeral"}
-
-
-def _validate_priority(instance_data: dict[str, Any]) -> None:
-    """Validate the priority field if present (S-036)."""
-    priority = instance_data.get("priority")
-    if priority is not None and priority not in VALID_PRIORITIES:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Invalid priority '{priority}'. "
-                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
-            ),
-        )
 
 
 class PendingApproveRequest(BaseModel):
@@ -289,7 +275,7 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     host = _require_host(await host_db.get_host(host_id))
 
     # Validate priority if present (S-036)
-    _validate_priority(instance_data)
+    validate_priority(instance_data)
 
     # Resolve model_source if present
     model_source = instance_data.get("model_source")
@@ -332,7 +318,7 @@ async def update_instance(
     host_id: str, instance_id: str, instance_data: dict[str, Any]
 ):
     # Validate priority if present (S-036)
-    _validate_priority(instance_data)
+    validate_priority(instance_data)
     return await _proxy_instance_action(
         host_id, instance_id, "", method="PUT", json_data=instance_data, timeout=10
     )

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -14,6 +14,21 @@ from app.model_resolvers import resolve
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
 
+VALID_PRIORITIES = {"production", "staging", "ephemeral"}
+
+
+def _validate_priority(instance_data: dict[str, Any]) -> None:
+    """Validate the priority field if present (S-036)."""
+    priority = instance_data.get("priority")
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid priority '{priority}'. "
+                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+            ),
+        )
+
 
 class PendingApproveRequest(BaseModel):
     name: str
@@ -274,13 +289,7 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     host = _require_host(await host_db.get_host(host_id))
 
     # Validate priority if present (S-036)
-    VALID_PRIORITIES = {"production", "staging", "ephemeral"}
-    priority = instance_data.get("priority")
-    if priority is not None and priority not in VALID_PRIORITIES:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(VALID_PRIORITIES))}",
-        )
+    _validate_priority(instance_data)
 
     # Resolve model_source if present
     model_source = instance_data.get("model_source")
@@ -322,6 +331,8 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
 async def update_instance(
     host_id: str, instance_id: str, instance_data: dict[str, Any]
 ):
+    # Validate priority if present (S-036)
+    _validate_priority(instance_data)
     return await _proxy_instance_action(
         host_id, instance_id, "", method="PUT", json_data=instance_data, timeout=10
     )

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -273,6 +273,15 @@ async def restart_instance(host_id: str, instance_id: str):
 async def create_instance(host_id: str, instance_data: dict[str, Any]):
     host = _require_host(await host_db.get_host(host_id))
 
+    # Validate priority if present (S-036)
+    VALID_PRIORITIES = {"production", "staging", "ephemeral"}
+    priority = instance_data.get("priority")
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(VALID_PRIORITIES))}",
+        )
+
     # Resolve model_source if present
     model_source = instance_data.get("model_source")
     if model_source:

--- a/app/validation.py
+++ b/app/validation.py
@@ -1,0 +1,25 @@
+"""Shared validation helpers (S-036).
+
+Centralized validators used by route handlers and services so
+priorities, constraints, and error formats stay consistent across
+the codebase.
+"""
+
+from typing import Any
+
+from fastapi import HTTPException
+
+VALID_PRIORITIES: frozenset[str] = frozenset({"production", "staging", "ephemeral"})
+
+
+def validate_priority(instance_data: dict[str, Any]) -> None:
+    """Validate the priority field if present (S-036)."""
+    priority = instance_data.get("priority")
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid priority '{priority}'. "
+                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+            ),
+        )


### PR DESCRIPTION
## Description

Add `priority` validation to the instance creation proxy endpoint, rejecting invalid priority values with a clear 422 error before forwarding to the host.

## Changes

- Validate `priority` against `{production, staging, ephemeral}` in `POST /{host_id}/instances`
- Return 422 with explicit allowed-values error message on invalid priority

## Related Issues

Closes #37