### PR TITLE
feat(resources): implement aggregated cluster resource query API (S-035)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,20 @@ Hosts connect via Socket.IO to the `/hosts` namespace; they appear in pending un
 - `GET /api/gateway/requests` - Paginated request history with filtering
 - `GET /api/gateway/events/recent` - Recent routing events (errors, reroutes)
 
+### Model Management
+
+- `GET /api/models/availability` - Which models exist on which hosts
+- `POST /api/models/distribute` - Distribute (pull) a model to target hosts from its authoritative source
+
+### Resource Queries
+
+- `GET /api/resources` - Aggregated cluster-wide view of host capacity, workloads, and reservations. Supports filters: `role`, `gpu_type`, `min_available_vram_gb`, `min_available_ram_gb`
+
 ### Instance Proxy (via solar-control to host)
+
+- `POST /api/hosts/{host_id}/instances` - Create an inference instance
+- `PUT /api/hosts/{host_id}/instances/{instance_id}` - Update instance configuration
+- `DELETE /api/hosts/{host_id}/instances/{instance_id}` - Delete an instance
 
 - `POST /api/hosts/{host_id}/instances/{instance_id}/start` - Start instance
 - `POST /api/hosts/{host_id}/instances/{instance_id}/stop` - Stop instance
@@ -336,6 +349,10 @@ app/
       hosts.py           #   Host management + instance proxy
       endpoints.py       #   API endpoint management
       gateway.py         #   Gateway stats and request history
+      models.py          #   Model availability and distribution
+      resources.py       #   Aggregated cluster resource queries
+  services/              # Shared business logic
+    migration.py         #   Instance migration orchestrator
   socketio_app/
     server.py            # Socket.IO server setup
     host_handlers.py     # /hosts namespace handlers

--- a/app/database/hosts.py
+++ b/app/database/hosts.py
@@ -100,7 +100,7 @@ class HostDB:
         async with self._session() as session:
             stmt = select(HostRow).order_by(HostRow.created_at)
             if role:
-                stmt = stmt.where(HostRow.roles.op("@>")(f'["{role}"]'))
+                stmt = stmt.where(HostRow.roles.contains([role]))
             result = await session.execute(stmt)
             return [self._row_to_host(row) for row in result.scalars()]
 

--- a/app/main.py
+++ b/app/main.py
@@ -155,6 +155,9 @@ async def root():
                 "/api/endpoints",
                 "/api/gateway/stats",
                 "/api/gateway/requests",
+                "/api/models/availability",
+                "/api/models/distribute",
+                "/api/resources",
             ],
             "realtime": [
                 "Socket.IO /hosts (host connections)",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,8 +2,10 @@ from .gateway import (
     RegistryEntry as RegistryEntry,
 )
 from .host import (
+    AggregatedResourceResponse as AggregatedResourceResponse,
     Host as Host,
     HostCreate as HostCreate,
+    HostResourceSnapshot as HostResourceSnapshot,
     HostResponse as HostResponse,
     HostStatus as HostStatus,
     MemoryInfo as MemoryInfo,

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -57,3 +57,74 @@ class HostResponse(BaseModel):
 
     host: Host
     message: str
+
+
+class HostResourceSnapshot(BaseModel):
+    """Per-host resource snapshot in the aggregated cluster view (S-035).
+
+    Combines locally stored metadata (roles, GPU type) with live resource
+    data proxied from the solar-host ``GET /resources`` endpoint.
+
+    Resource availability follows S-034 semantics:
+    ``available = total - (system_used + reserved_headroom)`` where
+    ``reserved_headroom = Σ max(reserved − actual, 0)`` per reservation.
+    """
+
+    host_id: str
+    host_name: str
+    url: str
+    status: HostStatus
+    roles: list[str] = Field(default_factory=list)
+    gpu_type: str | None = None
+    version: str | None = None
+
+    # Whether the host was reachable for live resource data
+    reachable: bool = False
+    error: str | None = None
+
+    # Total resources (from hardware)
+    vram_total_gb: float | None = None
+    ram_total_gb: float | None = None
+    disk_total_gb: float | None = None
+
+    # System-level usage (OS + idle backends)
+    vram_system_used_gb: float | None = None
+    ram_system_used_gb: float | None = None
+    disk_system_used_gb: float | None = None
+
+    # Reservation headroom (Σ max(reserved - actual, 0))
+    vram_reserved_headroom_gb: float | None = None
+    ram_reserved_headroom_gb: float | None = None
+    disk_reserved_headroom_gb: float | None = None
+
+    # Reported used = system_used + reserved_headroom
+    vram_reported_used_gb: float | None = None
+    ram_reported_used_gb: float | None = None
+    disk_reported_used_gb: float | None = None
+
+    # Available = total - reported_used
+    vram_available_gb: float | None = None
+    ram_available_gb: float | None = None
+    disk_available_gb: float | None = None
+
+    # Running workloads (from Redis instance cache)
+    instance_count: int = 0
+    running_instance_count: int = 0
+
+    # Reservation summary (totals only — no per-reservation list)
+    reservation_count: int = 0
+    reservation_vram_total_gb: float = 0.0
+    reservation_ram_total_gb: float = 0.0
+    reservation_disk_total_gb: float = 0.0
+
+    # Timestamps
+    snapshot_timestamp: str | None = None
+
+
+class AggregatedResourceResponse(BaseModel):
+    """Aggregated cluster-wide resource view (S-035)."""
+
+    hosts: list[HostResourceSnapshot]
+    total_hosts: int
+    reachable_hosts: int
+    unreachable_hosts: int

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
-from . import hosts, endpoints, gateway, models
 from app.jobs import router as jobs_router
+from . import hosts, endpoints, gateway, models, resources
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)
@@ -8,3 +8,4 @@ router.include_router(endpoints.router)
 router.include_router(gateway.router)
 router.include_router(models.router)
 router.include_router(jobs_router.router)
+router.include_router(resources.router)

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -1,0 +1,191 @@
+"""Aggregated resource query API (S-035).
+
+GET /api/resources — cluster-wide view of host capacity, workloads, and reservations.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+import aiohttp
+from fastapi import APIRouter, HTTPException, Query
+
+from app.database.hosts import host_db
+from app.models import Host, HostResourceSnapshot, AggregatedResourceResponse
+from app.redis_state import host_store
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/resources", tags=["resources"])
+
+_RESOURCE_TIMEOUT = 5  # seconds to wait for a host's /resources response
+
+
+async def _fetch_host_resource_snapshot(
+    host: Host,
+) -> HostResourceSnapshot:
+    """Fetch live resource data from a single solar-host.
+
+    Proxies GET /resources from the host. On any error (connection,
+    timeout, non-200), marks the host as unreachable and returns a
+    degraded snapshot with DB-only data.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Base snapshot from local DB (always available)
+    base = HostResourceSnapshot(
+        host_id=host.id,
+        host_name=host.name,
+        url=host.url,
+        status=host.status,
+        roles=host.roles or [],
+        gpu_type=host.gpu_type,
+        version=host.version,
+        reachable=False,
+        snapshot_timestamp=now_iso,
+    )
+
+    # Try to get instances from Redis
+    try:
+        instances = await host_store.get_host_instances(host.id)
+        base.instance_count = len(instances)
+        base.running_instance_count = sum(
+            1 for i in instances if i.get("status") == "running"
+        )
+    except Exception:
+        pass
+
+    # Proxy live resource data from the host
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{host.url.rstrip('/')}/resources"
+            headers = {"X-API-Key": host.api_key}
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=_RESOURCE_TIMEOUT),
+            ) as resp:
+                if resp.status != 200:
+                    base.error = f"Host returned {resp.status}"
+                    return base
+
+                data = await resp.json()
+    except (aiohttp.ClientConnectionError, aiohttp.ClientConnectorError):
+        base.error = f"Host unreachable at {host.url}"
+        return base
+    except asyncio.TimeoutError:
+        base.error = f"Host timed out ({_RESOURCE_TIMEOUT}s)"
+        return base
+    except Exception as exc:
+        base.error = f"Failed to fetch resources: {exc}"
+        return base
+
+    # Merge live resource dimensions
+    base.reachable = True
+    base.snapshot_timestamp = now_iso
+
+    for dim_name in ("vram", "ram", "disk"):
+        dim = data.get(dim_name)
+        if dim is None:
+            continue
+        setattr(base, f"{dim_name}_total_gb", dim.get("total_gb"))
+        setattr(base, f"{dim_name}_system_used_gb", dim.get("system_used_gb"))
+        setattr(
+            base, f"{dim_name}_reserved_headroom_gb", dim.get("reserved_headroom_gb")
+        )
+        setattr(base, f"{dim_name}_reported_used_gb", dim.get("reported_used_gb"))
+        setattr(base, f"{dim_name}_available_gb", dim.get("available_gb"))
+
+    # Merge reservation summary
+    reservations = data.get("reservations", [])
+    base.reservation_count = len(reservations)
+    base.reservation_vram_total_gb = sum(
+        float(r.get("vram_gb", 0)) for r in reservations
+    )
+    base.reservation_ram_total_gb = sum(float(r.get("ram_gb", 0)) for r in reservations)
+    base.reservation_disk_total_gb = sum(
+        float(r.get("disk_gb") or 0) for r in reservations
+    )
+
+    return base
+
+
+@router.get("", response_model=AggregatedResourceResponse)
+async def get_resources(
+    host_id: str | None = Query(None, description="Filter to a specific host"),
+    role: str | None = Query(
+        None, description="Filter by host role (e.g. 'training', 'inference')"
+    ),
+    gpu_type: str | None = Query(
+        None, description="Filter by GPU type (e.g. 'nvidia_cuda')"
+    ),
+    min_available_vram_gb: float | None = Query(
+        None, description="Minimum available VRAM in GB"
+    ),
+    min_available_ram_gb: float | None = Query(
+        None, description="Minimum available RAM in GB"
+    ),
+) -> AggregatedResourceResponse:
+    """Return aggregated cluster-wide resource view.
+
+    Fetches live resource snapshots from every known host and merges
+    with locally stored metadata.  Unreachable hosts are included in
+    the response with ``reachable=False`` and an error string instead
+    of failing the entire request.
+
+    The resource availability formula follows S-034 semantics:
+    ``available = total - (system_used + reserved_headroom)`` where
+    ``reserved_headroom = Σ max(reserved − actual, 0)`` per reservation.
+    This correctly implements ``effective = max(actual, requested)`` —
+    real consumption is never double-counted.
+    """
+    if isinstance(host_id, str):
+        host = await host_db.get_host(host_id)
+        if not host:
+            raise HTTPException(status_code=404, detail="Host not found")
+        hosts = [host]
+    else:
+        hosts = await host_db.get_all_hosts(
+            role=role if isinstance(role, str) else None
+        )
+
+    # Fetch all host snapshots concurrently
+    snapshots: list[HostResourceSnapshot] = await asyncio.gather(
+        *[_fetch_host_resource_snapshot(h) for h in hosts]
+    )
+
+    # Apply response-level filters
+    if isinstance(gpu_type, str):
+        snapshots = [
+            s
+            for s in snapshots
+            if s.gpu_type and s.gpu_type.lower() == gpu_type.lower()
+        ]
+
+    if isinstance(min_available_vram_gb, (int, float)):
+        snapshots = [
+            s
+            for s in snapshots
+            if s.reachable
+            and s.vram_available_gb is not None
+            and s.vram_available_gb >= min_available_vram_gb
+        ]
+
+    if isinstance(min_available_ram_gb, (int, float)):
+        snapshots = [
+            s
+            for s in snapshots
+            if s.reachable
+            and s.ram_available_gb is not None
+            and s.ram_available_gb >= min_available_ram_gb
+        ]
+
+    reachable = sum(1 for s in snapshots if s.reachable)
+    unreachable = sum(1 for s in snapshots if not s.reachable)
+
+    return AggregatedResourceResponse(
+        hosts=snapshots,
+        total_hosts=len(snapshots),
+        reachable_hosts=reachable,
+        unreachable_hosts=unreachable,
+    )

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -53,7 +53,11 @@ async def _fetch_host_resource_snapshot(
             1 for i in instances if i.get("status") == "running"
         )
     except Exception:
-        pass
+        logger.warning(
+            "Failed to fetch instances from Redis for host %s",
+            host.id,
+            exc_info=True,
+        )
 
     # Proxy live resource data from the host
     try:
@@ -66,7 +70,9 @@ async def _fetch_host_resource_snapshot(
                 timeout=aiohttp.ClientTimeout(total=_RESOURCE_TIMEOUT),
             ) as resp:
                 if resp.status != 200:
-                    base.error = f"Host returned {resp.status}"
+                    base.error = (
+                        f"Host {host.name} at {host.url} returned HTTP {resp.status}"
+                    )
                     return base
 
                 data = await resp.json()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,347 @@
+"""Tests for GET /api/resources (S-035)."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models import (
+    Host,
+    HostStatus,
+    HostResourceSnapshot,
+    AggregatedResourceResponse,
+)
+from app.routes.management.resources import _fetch_host_resource_snapshot
+
+
+@pytest.fixture
+def mock_host_online():
+    return Host(
+        id="host-1",
+        name="GPU Node 1",
+        url="http://host-1:8000",
+        api_key="key-1",
+        status=HostStatus.ONLINE,
+        gpu_type="A100-80GB",
+        roles=["inference", "training"],
+    )
+
+
+@pytest.fixture
+def mock_host_offline():
+    return Host(
+        id="host-2",
+        name="GPU Node 2",
+        url="http://host-2:8000",
+        api_key="key-2",
+        status=HostStatus.OFFLINE,
+        gpu_type="A10-24GB",
+        roles=["inference"],
+    )
+
+
+@pytest.fixture
+def live_resource_payload():
+    """Mimics a solar-host GET /resources response."""
+    return {
+        "memory_type": "VRAM",
+        "vram": {
+            "total_gb": 80.0,
+            "system_used_gb": 10.0,
+            "reserved_headroom_gb": 20.0,
+            "reported_used_gb": 30.0,
+            "available_gb": 50.0,
+        },
+        "ram": {
+            "total_gb": 256.0,
+            "system_used_gb": 32.0,
+            "reserved_headroom_gb": 64.0,
+            "reported_used_gb": 96.0,
+            "available_gb": 160.0,
+        },
+        "disk": {
+            "total_gb": 1000.0,
+            "system_used_gb": 200.0,
+            "reserved_headroom_gb": 50.0,
+            "reported_used_gb": 250.0,
+            "available_gb": 750.0,
+        },
+        "reservations": [
+            {
+                "id": "res-1",
+                "job_id": "job-1",
+                "workload_type": "training",
+                "status": "pending",
+                "vram_gb": 20.0,
+                "ram_gb": 64.0,
+                "disk_gb": 50.0,
+            }
+        ],
+    }
+
+
+# ── _fetch_host_resource_snapshot tests ────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_success(
+    mock_host_online, live_resource_payload
+):
+    """Live host returns valid resource snapshot."""
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[
+                {"id": "inst-1", "status": "running"},
+                {"id": "inst-2", "status": "stopped"},
+            ]
+        )
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=live_resource_payload)
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+        assert snap.reachable is True
+        assert snap.host_id == "host-1"
+        assert snap.host_name == "GPU Node 1"
+        assert snap.gpu_type == "A100-80GB"
+        assert snap.roles == ["inference", "training"]
+        assert snap.vram_total_gb == 80.0
+        assert snap.vram_available_gb == 50.0
+        assert snap.ram_total_gb == 256.0
+        assert snap.ram_available_gb == 160.0
+        assert snap.disk_total_gb == 1000.0
+        assert snap.disk_available_gb == 750.0
+        assert snap.instance_count == 2
+        assert snap.running_instance_count == 1
+        assert snap.reservation_count == 1
+        assert snap.reservation_vram_total_gb == 20.0
+        assert snap.reservation_ram_total_gb == 64.0
+        assert snap.reservation_disk_total_gb == 50.0
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_unreachable(mock_host_online):
+    """Connection error marks host as unreachable with error message."""
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        import aiohttp
+
+        mock_get.side_effect = aiohttp.ClientConnectionError("Refused")
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+        assert snap.reachable is False
+        assert snap.error is not None
+        assert "unreachable" in snap.error
+        assert snap.host_name == "GPU Node 1"  # DB data still present
+        assert snap.gpu_type == "A100-80GB"
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_timeout(mock_host_online):
+    """Timeout marks host as unreachable."""
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_get.side_effect = asyncio.TimeoutError()
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+        assert snap.reachable is False
+        assert "timed out" in snap.error.lower()
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_non_200(mock_host_online):
+    """Non-200 response marks host as unreachable."""
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 503
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+        assert snap.reachable is False
+        assert "returned 503" in (snap.error or "")
+
+
+# ── get_resources integration tests ─────────────────────────────────
+
+
+# Helper: build a simple reachable snapshot per host
+def _make_snap(h, *, reachable=True, **kw):
+    return HostResourceSnapshot(
+        host_id=h.id,
+        host_name=h.name,
+        url=h.url,
+        status=h.status,
+        roles=h.roles or [],
+        gpu_type=h.gpu_type,
+        reachable=reachable,
+        **kw,
+    )
+
+
+@pytest.mark.anyio
+async def test_get_resources_all_hosts(mock_host_online, mock_host_offline):
+    """Aggregated endpoint returns all hosts with correct counts."""
+    from app.routes.management.resources import get_resources
+
+    hosts = [mock_host_online, mock_host_offline]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+    ):
+        mock_fetch.side_effect = [
+            _make_snap(
+                mock_host_online,
+                vram_total_gb=80.0,
+                vram_available_gb=50.0,
+                ram_total_gb=256.0,
+                ram_available_gb=160.0,
+                instance_count=3,
+                running_instance_count=2,
+                reservation_count=1,
+            ),
+            _make_snap(mock_host_offline, reachable=False, error="Host unreachable"),
+        ]
+
+        resp = await get_resources()
+
+        assert isinstance(resp, AggregatedResourceResponse)
+        assert resp.total_hosts == 2
+        assert resp.reachable_hosts == 1
+        assert resp.unreachable_hosts == 1
+        assert len(resp.hosts) == 2
+        assert resp.hosts[0].reachable is True
+        assert resp.hosts[1].reachable is False
+
+
+@pytest.mark.anyio
+async def test_get_resources_filter_by_gpu_type(mock_host_online, mock_host_offline):
+    """gpu_type filter returns only matching hosts."""
+    from app.routes.management.resources import get_resources
+
+    hosts = [mock_host_online, mock_host_offline]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+    ):
+        mock_fetch.side_effect = [
+            _make_snap(mock_host_online),
+            _make_snap(mock_host_offline),
+        ]
+
+        resp = await get_resources(gpu_type="A100-80GB")
+        assert len(resp.hosts) == 1
+        assert resp.hosts[0].host_id == "host-1"
+
+
+@pytest.mark.anyio
+async def test_get_resources_filter_by_role(mock_host_online):
+    """role filter passed to host_db.get_all_hosts."""
+    from app.routes.management.resources import get_resources
+
+    hosts = [mock_host_online]
+
+    with (
+        patch(
+            "app.database.hosts.host_db.get_all_hosts", return_value=hosts
+        ) as mock_db,
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+    ):
+        mock_fetch.side_effect = [_make_snap(mock_host_online)]
+
+        resp = await get_resources(role="training")
+        mock_db.assert_called_once_with(role="training")
+        assert len(resp.hosts) == 1
+
+
+@pytest.mark.anyio
+async def test_get_resources_filter_by_host_id(mock_host_online):
+    """host_id filter returns single host or 404."""
+    from app.routes.management.resources import get_resources
+    from fastapi import HTTPException
+
+    with (
+        patch("app.database.hosts.host_db.get_host", return_value=mock_host_online),
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+    ):
+        mock_fetch.return_value = _make_snap(mock_host_online)
+
+        resp = await get_resources(host_id="host-1")
+        assert len(resp.hosts) == 1
+        assert resp.hosts[0].host_id == "host-1"
+
+    # 404 case
+    with patch("app.database.hosts.host_db.get_host", return_value=None):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_resources(host_id="nonexistent")
+        assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_get_resources_min_available_vram(mock_host_online):
+    """min_available_vram_gb filter excludes hosts below threshold."""
+    from app.routes.management.resources import get_resources
+
+    hosts = [mock_host_online]
+
+    with (
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+    ):
+        # Host has 50 GB available VRAM — use return_value for repeated calls
+        mock_fetch.return_value = _make_snap(
+            mock_host_online,
+            vram_total_gb=80.0,
+            vram_available_gb=50.0,
+            ram_total_gb=256.0,
+            ram_available_gb=160.0,
+        )
+
+        # Filter: min 40 GB — should include
+        resp = await get_resources(min_available_vram_gb=40)
+        assert len(resp.hosts) == 1
+
+        # Filter: min 60 GB — should exclude
+        resp = await get_resources(min_available_vram_gb=60)
+        assert len(resp.hosts) == 0
+
+
+@pytest.mark.anyio
+async def test_get_resources_no_hosts():
+    """Empty host list returns empty response."""
+    from app.routes.management.resources import get_resources
+
+    with patch("app.database.hosts.host_db.get_all_hosts", return_value=[]):
+        resp = await get_resources()
+        assert resp.total_hosts == 0
+        assert resp.hosts == []

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -177,7 +177,7 @@ async def test_fetch_host_resource_snapshot_non_200(mock_host_online):
         snap = await _fetch_host_resource_snapshot(mock_host_online)
 
         assert snap.reachable is False
-        assert "returned 503" in (snap.error or "")
+        assert "HTTP 503" in (snap.error or "")
 
 
 # ── get_resources integration tests ─────────────────────────────────


### PR DESCRIPTION
## Description
Adds GET /api/resources to solar-control, providing a cluster-wide aggregated
view of host capacity, running workloads, and reservations. Solar Control fans
out to all solar-hosts concurrently and merges live resource snapshots with
locally stored metadata. This is the single resource boundary for SuperNova
and downstream placement/reconciliation consumers (S-038, S-041).

## Changes
- Add app/routes/management/resources.py with fan-out aggregation endpoint
- Add HostResourceSnapshot and AggregatedResourceResponse models
- Support filters: host_id, role, gpu_type, min_available_vram_gb, min_available_ram_gb
- Handle unreachable hosts gracefully (reachable=False + error string)
- Add 10 tests covering success, unreachable, timeout, non-200, all filter types
- Register /api/resources route in management router and health endpoint listing

## Related Issues
Closes #36