### PR TITLE
feat(api): implement instance migration orchestrator (S-037)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -158,6 +158,7 @@ async def root():
                 "/api/models/availability",
                 "/api/models/distribute",
                 "/api/resources",
+                "/api/instances/migrate",
             ],
             "realtime": [
                 "Socket.IO /hosts (host connections)",

--- a/app/models/migration.py
+++ b/app/models/migration.py
@@ -1,0 +1,45 @@
+"""Pydantic models for instance migration (S-037)."""
+
+from pydantic import BaseModel, Field
+
+
+class MigrateRequest(BaseModel):
+    """Request to migrate an instance from a source host to a target host."""
+
+    instance_id: str
+    source_host_id: str
+    target_host_id: str
+    allow_production: bool = Field(
+        default=False,
+        description=(
+            "Explicit opt-in required to migrate production instances. "
+            "Future automated flows (S-038, S-041) must set this to true "
+            "only after an explicit policy decision."
+        ),
+    )
+
+
+class MigrationStep(BaseModel):
+    """A single step in the migration process."""
+
+    step: str
+    status: str  # "ok" | "skipped" | "failed"
+    detail: dict | None = None
+
+
+class MigrationResult(BaseModel):
+    """Result of a completed (or failed) migration operation."""
+
+    migration_id: str
+    status: str  # "completed" | "failed"
+    source_host_id: str
+    source_host_name: str
+    target_host_id: str
+    target_host_name: str
+    source_instance_id: str
+    target_instance_id: str | None = None
+    alias: str
+    model_source: str
+    priority: str
+    steps: list[MigrationStep] = Field(default_factory=list)
+    error: str | None = None

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from app.jobs import router as jobs_router
-from . import hosts, endpoints, gateway, models, resources
+from . import hosts, endpoints, gateway, models, resources, instances
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)
@@ -9,3 +9,4 @@ router.include_router(gateway.router)
 router.include_router(models.router)
 router.include_router(jobs_router.router)
 router.include_router(resources.router)
+router.include_router(instances.router)

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -15,21 +15,6 @@ from app.validation import validate_priority
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
 
-VALID_PRIORITIES = {"production", "staging", "ephemeral"}
-
-
-def _validate_priority(instance_data: dict[str, Any]) -> None:
-    """Validate the priority field if present (S-036)."""
-    priority = instance_data.get("priority")
-    if priority is not None and priority not in VALID_PRIORITIES:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"Invalid priority '{priority}'. "
-                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
-            ),
-        )
-
 
 class PendingApproveRequest(BaseModel):
     name: str

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel
 
 from app.models import Host, HostCreate, HostResponse, HostStatus
 from app.database.hosts import host_db
-from app.model_resolvers import resolve
 from app.validation import validate_priority
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
@@ -272,62 +271,16 @@ async def restart_instance(host_id: str, instance_id: str):
 
 @router.post("/{host_id}/instances")
 async def create_instance(host_id: str, instance_data: dict[str, Any]):
+    """Create an inference instance on a host.
+
+    Delegates to the shared ``create_instance_on_host`` helper (S-037 /
+    Option B refactor) which validates priority (S-036), resolves
+    ``model_source`` (S-019), and POSTs to the host.
+    """
+    from app.services.migration import create_instance_on_host
+
     host = _require_host(await host_db.get_host(host_id))
-
-    # Validate priority if present (S-036)
-    validate_priority(instance_data)
-
-    # Resolve model_source if present.
-    # The resolved local:// URI is used to set model/model_id so the host can
-    # create the instance.  The original model_source URI (repo://, huggingface://)
-    # is preserved for cross-host operations such as migration (S-037).
-    # Support both flat and {config: {...}} payload shapes.
-    config = instance_data.get("config", instance_data)
-    model_source = config.get("model_source")
-    if model_source:
-        resolved = await resolve(model_source, host.url, host.api_key)
-        # Extract filesystem path from local:// URI
-        # local:// is always 8 chars; the path starts at index 8.
-        if resolved.startswith("local://"):
-            model_path = resolved[8:]
-        else:
-            model_path = resolved
-        backend_type = config.get("backend_type", "llamacpp")
-        if backend_type.startswith("huggingface"):
-            config["model_id"] = model_path
-        else:
-            config["model"] = model_path
-        if "config" in instance_data:
-            instance_data["config"] = config
-
-    try:
-        async with aiohttp.ClientSession() as session:
-            url = f"{host.url}/instances"
-            headers = {"X-API-Key": host.api_key, "Content-Type": "application/json"}
-            async with session.post(
-                url,
-                json=instance_data,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as response:
-                if response.status == 200:
-                    return await response.json()
-                text = await response.text()
-                raise HTTPException(status_code=response.status, detail=text)
-    except HTTPException:
-        raise
-    except (
-        aiohttp.ClientConnectionError,
-        aiohttp.ClientConnectorError,
-        asyncio.TimeoutError,
-    ):
-        raise HTTPException(
-            status_code=502, detail=f"Host '{host.name}' is unreachable at {host.url}"
-        )
-    except Exception as e:
-        raise HTTPException(
-            status_code=502, detail=f"Cannot reach host '{host.name}': {e}"
-        )
+    return await create_instance_on_host(host, instance_data)
 
 
 @router.put("/{host_id}/instances/{instance_id}")

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -15,6 +15,21 @@ from app.validation import validate_priority
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
 
+VALID_PRIORITIES = {"production", "staging", "ephemeral"}
+
+
+def _validate_priority(instance_data: dict[str, Any]) -> None:
+    """Validate the priority field if present (S-036)."""
+    priority = instance_data.get("priority")
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid priority '{priority}'. "
+                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+            ),
+        )
+
 
 class PendingApproveRequest(BaseModel):
     name: str

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from app.models import Host, HostCreate, HostResponse, HostStatus
 from app.database.hosts import host_db
+from app.services.migration import create_instance_on_host
 from app.validation import validate_priority
 
 router = APIRouter(prefix="/hosts", tags=["hosts"])
@@ -277,8 +278,6 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     Option B refactor) which validates priority (S-036), resolves
     ``model_source`` (S-019), and POSTs to the host.
     """
-    from app.services.migration import create_instance_on_host
-
     host = _require_host(await host_db.get_host(host_id))
     return await create_instance_on_host(host, instance_data)
 

--- a/app/routes/management/instances.py
+++ b/app/routes/management/instances.py
@@ -1,0 +1,25 @@
+"""Instance management API routes (under /api/instances)."""
+
+from fastapi import APIRouter
+
+from app.models.migration import MigrateRequest, MigrationResult
+from app.services.migration import execute_migration
+
+router = APIRouter(prefix="/instances", tags=["instances"])
+
+
+@router.post("/migrate", response_model=MigrationResult)
+async def migrate_instance(req: MigrateRequest) -> MigrationResult:
+    """Migrate an inference instance from a source host to a target host.
+
+    Stops the source instance, ensures the model is on the target host
+    via S-019 distribution, and recreates the instance from the original
+    configuration. Enforces one-replica-per-host and validates target
+    host fitness.
+    """
+    return await execute_migration(
+        instance_id=req.instance_id,
+        source_host_id=req.source_host_id,
+        target_host_id=req.target_host_id,
+        allow_production=req.allow_production,
+    )

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -184,9 +184,7 @@ async def capture_instance_config(
     )
 
 
-async def check_one_replica_per_host(
-    target_host: Host, alias: str
-) -> None:
+async def check_one_replica_per_host(target_host: Host, alias: str) -> None:
     """Ensure no instance with the same *alias* exists on *target_host*.
 
     Raises ``HTTPException(409)`` if a conflict is found.
@@ -263,9 +261,7 @@ async def validate_target_fitness(
     try:
         async with aiohttp.ClientSession() as session:
             url = f"{target_host.url.rstrip('/')}/health"
-            async with session.get(
-                url, timeout=aiohttp.ClientTimeout(total=5)
-            ) as resp:
+            async with session.get(url, timeout=aiohttp.ClientTimeout(total=5)) as resp:
                 if resp.status == 200:
                     data = await resp.json()
 
@@ -286,7 +282,10 @@ async def validate_target_fitness(
                     for mem in memory_list:
                         if mem.get("memory_type") == "VRAM":
                             vram_available = mem.get("available_gb")
-                            if vram_available is not None and vram_available < MIN_VRAM_GB:
+                            if (
+                                vram_available is not None
+                                and vram_available < MIN_VRAM_GB
+                            ):
                                 raise HTTPException(
                                     status_code=507,
                                     detail=(
@@ -419,9 +418,7 @@ async def check_no_active_training(host: Host) -> None:
         )
 
 
-async def stop_source_instance(
-    source_host: Host, instance_id: str
-) -> dict[str, Any]:
+async def stop_source_instance(source_host: Host, instance_id: str) -> dict[str, Any]:
     """Stop *instance_id* on *source_host*.
 
     Returns the host response on success. Raises ``HTTPException`` on
@@ -442,9 +439,7 @@ async def stop_source_instance(
                 if response.status == 200:
                     return await response.json()
                 text = await response.text()
-                raise HTTPException(
-                    status_code=response.status, detail=text
-                )
+                raise HTTPException(status_code=response.status, detail=text)
     except HTTPException:
         raise
     except (
@@ -600,7 +595,9 @@ async def execute_migration(
 
     # ── 3. Validate target fitness ──────────────────────────────
     await validate_target_fitness(
-        target_host, instance_config, allow_production=allow_production,
+        target_host,
+        instance_config,
+        allow_production=allow_production,
         source_gpu_type=source_gpu_type,
     )
     steps.append(MigrationStep(step="validate_target", status="ok"))
@@ -610,14 +607,36 @@ async def execute_migration(
     steps.append(MigrationStep(step="check_anti_affinity", status="ok"))
 
     # ── 5. Ensure model on target ───────────────────────────────
-    path, cached = await ensure_model_on_target(target_host, model_source)
-    steps.append(
-        MigrationStep(
-            step="ensure_model",
-            status="ok",
-            detail={"path": path, "cached": cached},
+    try:
+        path, cached = await ensure_model_on_target(target_host, model_source)
+        steps.append(
+            MigrationStep(
+                step="ensure_model",
+                status="ok",
+                detail={"path": path, "cached": cached},
+            )
         )
-    )
+    except HTTPException as e:
+        steps.append(
+            MigrationStep(
+                step="ensure_model",
+                status="failed",
+                detail={"error": str(e.detail), "status_code": e.status_code},
+            )
+        )
+        return _build_result(
+            migration_id,
+            source_host,
+            target_host,
+            instance_id,
+            alias,
+            model_source,
+            priority,
+            None,
+            steps,
+            status="failed",
+            error=f"Ensure model failed: {e.detail}",
+        )
 
     # ── 6. Stop source instance ─────────────────────────────────
     try:
@@ -632,8 +651,15 @@ async def execute_migration(
             )
         )
         return _build_result(
-            migration_id, source_host, target_host, instance_id,
-            alias, model_source, priority, None, steps,
+            migration_id,
+            source_host,
+            target_host,
+            instance_id,
+            alias,
+            model_source,
+            priority,
+            None,
+            steps,
             status="failed",
             error=f"Stop source failed: {e.detail}",
         )
@@ -644,9 +670,7 @@ async def execute_migration(
 
     # Remove host/port/api_key — these are host-assigned.
     create_payload: dict[str, Any] = {
-        k: v
-        for k, v in config.items()
-        if k not in ("host", "port", "api_key")
+        k: v for k, v in config.items() if k not in ("host", "port", "api_key")
     }
     # Ensure key fields from captured config are present.
     for key in ("alias", "model_source", "priority", "backend_type"):
@@ -657,9 +681,7 @@ async def execute_migration(
 
     target_instance: dict[str, Any]
     try:
-        target_instance = await create_instance_on_host(
-            target_host, create_payload
-        )
+        target_instance = await create_instance_on_host(target_host, create_payload)
     except HTTPException as e:
         steps.append(
             MigrationStep(
@@ -669,15 +691,21 @@ async def execute_migration(
             )
         )
         return _build_result(
-            migration_id, source_host, target_host, instance_id,
-            alias, model_source, priority, None, steps,
+            migration_id,
+            source_host,
+            target_host,
+            instance_id,
+            alias,
+            model_source,
+            priority,
+            None,
+            steps,
             status="failed",
             error=f"Create target failed: {e.detail}",
         )
 
-    target_instance_id = (
-        target_instance.get("instance_id")
-        or target_instance.get("id", "")
+    target_instance_id = target_instance.get("instance_id") or target_instance.get(
+        "id", ""
     )
     steps.append(
         MigrationStep(
@@ -698,6 +726,13 @@ async def execute_migration(
     )
 
     return _build_result(
-        migration_id, source_host, target_host, instance_id,
-        alias, model_source, priority, target_instance_id, steps,
+        migration_id,
+        source_host,
+        target_host,
+        instance_id,
+        alias,
+        model_source,
+        priority,
+        target_instance_id,
+        steps,
     )

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -572,6 +572,8 @@ async def execute_migration(
     # Validate captured priority before any destructive operations (S-036/S-037).
     # Legacy instances may have invalid priorities that would fail at create_target
     # step (step 7) after the source instance has already been stopped.
+    from app.validation import VALID_PRIORITIES
+
     if priority not in VALID_PRIORITIES:
         raise HTTPException(
             status_code=422,

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -115,13 +115,16 @@ async def capture_instance_config(
     """Retrieve the full instance configuration from *source_host*.
 
     Tries Redis cache first (fast path), then falls back to an HTTP
-    ``GET /instances`` call to the host.
+    ``GET /instances`` call to the host.  The Redis cache only
+    short-circuits when the entry includes a ``config`` key (i.e. a
+    full dump from a prior HTTP call); the flat WebSocket notification
+    format omits most config fields and is not used as a shortcut.
     """
-    # Fast path: Redis instance cache
+    # Fast path: full config in Redis cache?
     instances = await host_store.get_host_instances(source_host.id)
     for inst in instances:
         iid = inst.get("instance_id") or inst.get("id")
-        if iid == instance_id:
+        if iid == instance_id and "config" in inst:
             logger.debug(
                 "Instance config for %s/%s found in Redis cache",
                 source_host.name,
@@ -129,7 +132,7 @@ async def capture_instance_config(
             )
             return inst
 
-    # Fallback: fetch from source host via HTTP
+    # Fallback / direct: fetch from source host via HTTP
     logger.info(
         "Instance %s not in Redis cache for host %s, falling back to HTTP",
         instance_id,

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -401,16 +401,21 @@ async def check_no_active_training(host: Host) -> None:
         aiohttp.ClientConnectorError,
         asyncio.TimeoutError,
     ):
-        logger.warning(
-            "Source host '%s' unreachable for training job check, "
-            "proceeding with migration",
-            host.name,
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Source host '{host.name}' is unreachable for training job "
+                f"check at {host.url}. Cannot verify no active training jobs "
+                f"– migration rejected."
+            ),
         )
     except Exception as e:
-        logger.warning(
-            "Failed to check training jobs on host '%s': %s",
-            host.name,
-            e,
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Cannot reach source host '{host.name}' for training job "
+                f"check: {e}. Migration rejected."
+            ),
         )
 
 
@@ -567,6 +572,18 @@ async def execute_migration(
         raise HTTPException(
             status_code=422,
             detail="Instance configuration is missing required 'model_source' field",
+        )
+
+    # Validate captured priority before any destructive operations (S-036/S-037).
+    # Legacy instances may have invalid priorities that would fail at create_target
+    # step (step 7) after the source instance has already been stopped.
+    if priority not in VALID_PRIORITIES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Captured instance has invalid priority '{priority}'. "
+                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+            ),
         )
 
     steps.append(

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -672,12 +672,36 @@ async def execute_migration(
     # Build the instance config for the target host.
     config = instance_config.get("config", instance_config)
 
-    # Remove host/port/api_key — these are host-assigned.
+    # Remove host-assigned and instance-level fields from the config dict.
+    _INSTANCE_FIELDS = frozenset(
+        {
+            "id",
+            "status",
+            "port",
+            "pid",
+            "api_key",
+            "supported_endpoints",
+            "managed_by",
+            "intent_id",
+            "created_at",
+            "started_at",
+            "error_message",
+            "retry_count",
+            "busy",
+            "prefill_progress",
+            "active_slots",
+        }
+    )
     create_payload: dict[str, Any] = {
-        k: v for k, v in config.items() if k not in ("host", "port", "api_key")
+        k: v for k, v in config.items() if k not in _INSTANCE_FIELDS
     }
+    # Set model to the path resolved by ensure_model_on_target so the
+    # host does not need to resolve model_source itself (which would
+    # reject repo:// URIs without the companion host-side fix).
+    create_payload["model"] = path
+    create_payload.pop("model_source", None)
     # Ensure key fields from captured config are present.
-    for key in ("alias", "model_source", "priority", "backend_type"):
+    for key in ("alias", "priority", "backend_type"):
         if key not in create_payload:
             val = _config_field(instance_config, key)
             if val is not None:
@@ -685,7 +709,9 @@ async def execute_migration(
 
     target_instance: dict[str, Any]
     try:
-        target_instance = await create_instance_on_host(target_host, create_payload)
+        target_instance = await create_instance_on_host(
+            target_host, {"config": create_payload}
+        )
     except HTTPException as e:
         steps.append(
             MigrationStep(

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -1,0 +1,686 @@
+"""Instance migration orchestrator (S-037).
+
+Migrates an inference instance from a source host to a target host by:
+1. Validating both hosts and checking for active training jobs
+2. Capturing the instance configuration
+3. Checking placement constraints (roles, GPU type, VRAM, disk)
+4. Enforcing one-replica-per-host on the target
+5. Ensuring the model is on the target via S-019 distribution
+6. Stopping the source instance
+7. Creating the target instance from the captured configuration
+
+If stop or create fails, the partially-completed MigrationResult is returned
+with status="failed" and per-step status so callers can inspect progress.
+
+Active training jobs from S-032/S-033 are non-migratable workloads;
+migration is rejected if the source host has any active job steps.
+
+The stop-before-create ordering is explicit and documented. For rolling /
+zero-downtime migrations, the S-042 strategy layer will orchestrate
+create-then-stop on top of this primitive.
+"""
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+import aiohttp
+from fastapi import HTTPException
+
+from app.database.hosts import host_db
+from app.models import Host
+from app.models.migration import MigrationResult, MigrationStep
+from app.model_resolvers import resolve
+from app.redis_state import host_store
+from app.validation import validate_priority
+
+logger = logging.getLogger(__name__)
+
+# ── Shared: create an instance on a host (Option B refactor) ────
+
+
+async def create_instance_on_host(
+    host: Host, instance_data: dict[str, Any]
+) -> dict[str, Any]:
+    """Create an inference instance on *host* with the given config.
+
+    Validates priority (S-036), resolves ``model_source`` (S-019), sets
+    the derived ``model``/``model_id`` while preserving the original URI
+    for cross-host operations (S-037), and POSTs to the host.
+    """
+    # Validate priority if present (S-036)
+    validate_priority(instance_data)
+
+    # Resolve model_source and set model/model_id while preserving the
+    # original URI.  Support both flat and {config: {...}} payload shapes.
+    config = instance_data.get("config", instance_data)
+    model_source = config.get("model_source")
+    if model_source:
+        resolved = await resolve(model_source, host.url, host.api_key)
+        # Extract filesystem path from local:// URI (scheme is 8 chars)
+        if resolved.startswith("local://"):
+            model_path = resolved[8:]
+        else:
+            model_path = resolved
+        backend_type = config.get("backend_type", "llamacpp")
+        if backend_type.startswith("huggingface"):
+            config["model_id"] = model_path
+        else:
+            config["model"] = model_path
+        if "config" in instance_data:
+            instance_data["config"] = config
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{host.url}/instances"
+            headers = {
+                "X-API-Key": host.api_key,
+                "Content-Type": "application/json",
+            }
+            async with session.post(
+                url,
+                json=instance_data,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+                text = await response.text()
+                raise HTTPException(status_code=response.status, detail=text)
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host.name}' is unreachable at {host.url}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach host '{host.name}': {e}",
+        )
+
+
+# ── Migration validation helpers ────────────────────────────────
+
+
+async def capture_instance_config(
+    source_host: Host, instance_id: str
+) -> dict[str, Any]:
+    """Retrieve the full instance configuration from *source_host*.
+
+    Tries Redis cache first (fast path), then falls back to an HTTP
+    ``GET /instances`` call to the host.
+    """
+    # Fast path: Redis instance cache
+    instances = await host_store.get_host_instances(source_host.id)
+    for inst in instances:
+        iid = inst.get("instance_id") or inst.get("id")
+        if iid == instance_id:
+            logger.debug(
+                "Instance config for %s/%s found in Redis cache",
+                source_host.name,
+                instance_id,
+            )
+            return inst
+
+    # Fallback: fetch from source host via HTTP
+    logger.info(
+        "Instance %s not in Redis cache for host %s, falling back to HTTP",
+        instance_id,
+        source_host.name,
+    )
+    try:
+        async with aiohttp.ClientSession() as session:
+            headers = {"X-API-Key": source_host.api_key}
+            url = f"{source_host.url}/instances"
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as response:
+                if response.status != 200:
+                    text = await response.text()
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=f"Failed to fetch instances from source host: {text}",
+                    )
+                all_instances = await response.json()
+                for inst in all_instances:
+                    iid = inst.get("instance_id") or inst.get("id")
+                    if iid == instance_id:
+                        return inst
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Source host '{source_host.name}' is unreachable "
+                f"at {source_host.url}"
+            ),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach source host '{source_host.name}': {e}",
+        )
+
+    raise HTTPException(
+        status_code=404,
+        detail=(
+            f"Instance '{instance_id}' not found on source host "
+            f"'{source_host.name}'"
+        ),
+    )
+
+
+async def check_one_replica_per_host(
+    target_host: Host, alias: str
+) -> None:
+    """Ensure no instance with the same *alias* exists on *target_host*.
+
+    Raises ``HTTPException(409)`` if a conflict is found.
+    """
+    instances = await host_store.get_host_instances(target_host.id)
+    for inst in instances:
+        config = inst.get("config", inst)
+        inst_alias = config.get("alias") or inst.get("alias")
+        if inst_alias == alias:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Instance with alias '{alias}' already exists on "
+                    f"target host '{target_host.name}'. One replica per "
+                    f"host per alias is enforced."
+                ),
+            )
+
+
+async def validate_target_fitness(
+    target_host: Host,
+    instance_config: dict[str, Any],
+    *,
+    allow_production: bool = False,
+    source_gpu_type: str | None = None,
+) -> None:
+    """Validate that *target_host* is suitable for *instance_config*.
+
+    Checks:
+    - Target has ``"inference"`` role
+    - Production safeguard (requires explicit ``allow_production``)
+    - GPU type compatibility (rejects mismatch when both are known)
+    - Sufficient VRAM (best-effort, ≥ 2 GB threshold)
+    - Sufficient disk space (best-effort, ≥ 5 GB threshold)
+    """
+    # Role check
+    roles = target_host.roles or []
+    if "inference" not in roles:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Target host '{target_host.name}' does not have the "
+                f"'inference' role. Roles: {roles}"
+            ),
+        )
+
+    # Production safeguard
+    config = instance_config.get("config", instance_config)
+    priority = config.get("priority") or instance_config.get("priority")
+    if priority == "production" and not allow_production:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Cannot migrate a 'production' instance without "
+                "explicit allow_production=true. Production instances "
+                "require an explicit policy decision to migrate."
+            ),
+        )
+
+    # GPU type compatibility check
+    if source_gpu_type and target_host.gpu_type:
+        if source_gpu_type != target_host.gpu_type:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Target host '{target_host.name}' has GPU type "
+                    f"'{target_host.gpu_type}' but the instance requires "
+                    f"'{source_gpu_type}'. GPU type must match for migration."
+                ),
+            )
+
+    # Resource check via /health (disk + VRAM)
+    MIN_VRAM_GB = 2.0
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{target_host.url.rstrip('/')}/health"
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=5)
+            ) as resp:
+                if resp.status == 200:
+                    data = await resp.json()
+
+                    # Disk check
+                    available = data.get("disk", {}).get("available_gb")
+                    if available is not None and available < 5.0:
+                        raise HTTPException(
+                            status_code=507,
+                            detail=(
+                                f"Insufficient disk on target host "
+                                f"'{target_host.name}': "
+                                f"{available:.2f} GB available"
+                            ),
+                        )
+
+                    # VRAM check
+                    memory_list = data.get("memory", [])
+                    for mem in memory_list:
+                        if mem.get("memory_type") == "VRAM":
+                            vram_available = mem.get("available_gb")
+                            if vram_available is not None and vram_available < MIN_VRAM_GB:
+                                raise HTTPException(
+                                    status_code=507,
+                                    detail=(
+                                        f"Insufficient VRAM on target host "
+                                        f"'{target_host.name}': "
+                                        f"{vram_available:.2f} GB available "
+                                        f"(minimum {MIN_VRAM_GB} GB required)"
+                                    ),
+                                )
+                            break
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(
+            "Failed to check resources on target host %s: %s",
+            target_host.id,
+            e,
+        )
+
+
+async def ensure_model_on_target(
+    target_host: Host, model_source: str
+) -> tuple[str, bool]:
+    """Ensure *model_source* is pulled on *target_host* via S-019.
+
+    Returns ``(local_path, cached)`` on success.
+    Raises ``HTTPException`` on failure.
+    """
+    from app.model_resolvers.parser import parse
+    from app.routes.management.models import _pull_on_host
+
+    parsed = parse(model_source)
+    result = await _pull_on_host(parsed, model_source, target_host)
+
+    from app.routes.management.models import _StructuredPullError
+
+    if isinstance(result, _StructuredPullError):
+        raise HTTPException(
+            status_code=result.status_code,
+            detail=(
+                f"Failed to pull model '{result.source_uri}' on target "
+                f"host '{target_host.name}': [{result.error}] "
+                f"{result.detail}"
+            ),
+        )
+
+    return result  # (path, cached)
+
+
+async def check_no_active_training(host: Host) -> None:
+    """Verify *host* has no active training job steps.
+
+    Queries the host's ``GET /jobs`` endpoint. Raises ``HTTPException(409)``
+    if any job step is in an active (non-terminal) state.
+
+    This implements the S-037 requirement that active training jobs from
+    S-032/S-033 are non-migratable workloads.
+    """
+    TERMINAL_STATES = {"completed", "failed", "cancelled", "error"}
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{host.url.rstrip('/')}/jobs"
+            headers = {"X-API-Key": host.api_key}
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as response:
+                if response.status == 200:
+                    jobs = await response.json()
+                elif response.status == 404:
+                    logger.debug(
+                        "Host '%s' returned 404 for GET /jobs, "
+                        "assuming no training jobs",
+                        host.name,
+                    )
+                    return
+                else:
+                    text = await response.text()
+                    logger.warning(
+                        "Host '%s' returned %d for GET /jobs: %s",
+                        host.name,
+                        response.status,
+                        text,
+                    )
+                    return
+
+        active_ids: list[str] = []
+        for job in (jobs if isinstance(jobs, list) else []):
+            status = job.get("status") or job.get("state", "")
+            if status not in TERMINAL_STATES:
+                job_id = job.get("job_id") or job.get("id", "unknown")
+                active_ids.append(job_id)
+
+        if active_ids:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Source host '{host.name}' has {len(active_ids)} "
+                    f"active training job(s): {', '.join(active_ids[:5])}"
+                    f"{'...' if len(active_ids) > 5 else ''}. "
+                    f"Training jobs are non-migratable workloads. "
+                    f"Stop or wait for training jobs to complete before "
+                    f"migrating instances from this host."
+                ),
+            )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        logger.warning(
+            "Source host '%s' unreachable for training job check, "
+            "proceeding with migration",
+            host.name,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to check training jobs on host '%s': %s",
+            host.name,
+            e,
+        )
+
+
+async def stop_source_instance(
+    source_host: Host, instance_id: str
+) -> dict[str, Any]:
+    """Stop *instance_id* on *source_host*.
+
+    Returns the host response on success. Raises ``HTTPException`` on
+    failure.
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{source_host.url}/instances/{instance_id}/stop"
+            headers = {
+                "X-API-Key": source_host.api_key,
+                "Content-Type": "application/json",
+            }
+            async with session.post(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+                text = await response.text()
+                raise HTTPException(
+                    status_code=response.status, detail=text
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Source host '{source_host.name}' is unreachable "
+                f"at {source_host.url}"
+            ),
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach source host '{source_host.name}': {e}",
+        )
+
+
+# ── Orchestrator ────────────────────────────────────────────────
+
+
+def _config_field(instance: dict[str, Any], key: str) -> Any:
+    """Read a field from the instance dict, checking nested config first."""
+    config = instance.get("config", {})
+    if isinstance(config, dict) and key in config:
+        return config[key]
+    return instance.get(key)
+
+
+def _build_result(
+    migration_id: str,
+    source_host: Host,
+    target_host: Host,
+    source_instance_id: str,
+    alias: str,
+    model_source: str,
+    priority: str,
+    target_instance_id: str | None,
+    steps: list[MigrationStep],
+    *,
+    status: str = "completed",
+    error: str | None = None,
+) -> MigrationResult:
+    """Build a MigrationResult with consistent field population."""
+    return MigrationResult(
+        migration_id=migration_id,
+        status=status,
+        source_host_id=source_host.id,
+        source_host_name=source_host.name,
+        target_host_id=target_host.id,
+        target_host_name=target_host.name,
+        source_instance_id=source_instance_id,
+        target_instance_id=target_instance_id,
+        alias=alias,
+        model_source=model_source,
+        priority=priority,
+        steps=steps,
+        error=error,
+    )
+
+
+async def execute_migration(
+    *,
+    instance_id: str,
+    source_host_id: str,
+    target_host_id: str,
+    allow_production: bool = False,
+) -> MigrationResult:
+    """Execute a full migration of *instance_id* from source to target host.
+
+    Orchestrates all validation, model distribution, stop, and create
+    steps. Returns a ``MigrationResult`` with per-step status on success.
+    Raises ``HTTPException`` for fatal errors.
+    """
+    migration_id = str(uuid.uuid4())
+    steps: list[MigrationStep] = []
+
+    # ── 1. Validate hosts ───────────────────────────────────────
+    source_host = await host_db.get_host(source_host_id)
+    if not source_host:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Source host '{source_host_id}' not found",
+        )
+
+    target_host = await host_db.get_host(target_host_id)
+    if not target_host:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Target host '{target_host_id}' not found",
+        )
+
+    if source_host_id == target_host_id:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Source and target host are the same ('{source_host.name}'). "
+                f"Migration requires two distinct hosts."
+            ),
+        )
+
+    steps.append(MigrationStep(step="validate_hosts", status="ok"))
+
+    # ── 1.5. Check source host has no active training jobs ──────
+    await check_no_active_training(source_host)
+    steps.append(MigrationStep(step="check_training_jobs", status="ok"))
+
+    # ── 2. Capture instance configuration ───────────────────────
+    instance_config = await capture_instance_config(source_host, instance_id)
+
+    alias = _config_field(instance_config, "alias")
+    model_source = _config_field(instance_config, "model_source")
+    priority = _config_field(instance_config, "priority") or "production"
+    source_gpu_type = source_host.gpu_type
+
+    if not alias:
+        raise HTTPException(
+            status_code=422,
+            detail="Instance configuration is missing required 'alias' field",
+        )
+    if not model_source:
+        raise HTTPException(
+            status_code=422,
+            detail="Instance configuration is missing required 'model_source' field",
+        )
+
+    steps.append(
+        MigrationStep(
+            step="capture_config",
+            status="ok",
+            detail={
+                "alias": alias,
+                "model_source": model_source,
+                "priority": priority,
+            },
+        )
+    )
+
+    # ── 3. Validate target fitness ──────────────────────────────
+    await validate_target_fitness(
+        target_host, instance_config, allow_production=allow_production,
+        source_gpu_type=source_gpu_type,
+    )
+    steps.append(MigrationStep(step="validate_target", status="ok"))
+
+    # ── 4. Check one-replica-per-host ───────────────────────────
+    await check_one_replica_per_host(target_host, alias)
+    steps.append(MigrationStep(step="check_anti_affinity", status="ok"))
+
+    # ── 5. Ensure model on target ───────────────────────────────
+    path, cached = await ensure_model_on_target(target_host, model_source)
+    steps.append(
+        MigrationStep(
+            step="ensure_model",
+            status="ok",
+            detail={"path": path, "cached": cached},
+        )
+    )
+
+    # ── 6. Stop source instance ─────────────────────────────────
+    try:
+        await stop_source_instance(source_host, instance_id)
+        steps.append(MigrationStep(step="stop_source", status="ok"))
+    except HTTPException as e:
+        steps.append(
+            MigrationStep(
+                step="stop_source",
+                status="failed",
+                detail={"error": str(e.detail), "status_code": e.status_code},
+            )
+        )
+        return _build_result(
+            migration_id, source_host, target_host, instance_id,
+            alias, model_source, priority, None, steps,
+            status="failed",
+            error=f"Stop source failed: {e.detail}",
+        )
+
+    # ── 7. Create target instance ───────────────────────────────
+    # Build the instance config for the target host.
+    config = instance_config.get("config", instance_config)
+
+    # Remove host/port/api_key — these are host-assigned.
+    create_payload: dict[str, Any] = {
+        k: v
+        for k, v in config.items()
+        if k not in ("host", "port", "api_key")
+    }
+    # Ensure key fields from captured config are present.
+    for key in ("alias", "model_source", "priority", "backend_type"):
+        if key not in create_payload:
+            val = _config_field(instance_config, key)
+            if val is not None:
+                create_payload[key] = val
+
+    target_instance: dict[str, Any]
+    try:
+        target_instance = await create_instance_on_host(
+            target_host, create_payload
+        )
+    except HTTPException as e:
+        steps.append(
+            MigrationStep(
+                step="create_target",
+                status="failed",
+                detail={"error": str(e.detail), "status_code": e.status_code},
+            )
+        )
+        return _build_result(
+            migration_id, source_host, target_host, instance_id,
+            alias, model_source, priority, None, steps,
+            status="failed",
+            error=f"Create target failed: {e.detail}",
+        )
+
+    target_instance_id = (
+        target_instance.get("instance_id")
+        or target_instance.get("id", "")
+    )
+    steps.append(
+        MigrationStep(
+            step="create_target",
+            status="ok",
+            detail={"target_instance_id": target_instance_id},
+        )
+    )
+
+    logger.info(
+        "Migration %s completed: %s/%s (%s) → %s/%s",
+        migration_id,
+        source_host.name,
+        instance_id,
+        alias,
+        target_host.name,
+        target_instance_id,
+    )
+
+    return _build_result(
+        migration_id, source_host, target_host, instance_id,
+        alias, model_source, priority, target_instance_id, steps,
+    )

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -216,8 +216,8 @@ async def validate_target_fitness(
     Checks:
     - Target has ``"inference"`` role
     - Production safeguard (requires explicit ``allow_production``)
-    - GPU type compatibility (rejects mismatch when both are known)
-    - Sufficient VRAM (best-effort, ≥ 2 GB threshold)
+    - GPU type difference is logged but not blocked (GGUF models are
+      portable across architectures and pulled fresh via S-019)\n    - Sufficient VRAM (best-effort, ≥ 2 GB threshold)
     - Sufficient disk space (best-effort, ≥ 5 GB threshold)
     """
     # Role check
@@ -244,16 +244,18 @@ async def validate_target_fitness(
             ),
         )
 
-    # GPU type compatibility check
+    # GPU type difference is logged but not rejected. GGUF models are
+    # portable across GPU architectures and the model is pulled fresh
+    # on the target host via S-019 distribution.  Placement constraints
+    # (deployment-intent §4.5) default gpu_type to null (any).
     if source_gpu_type and target_host.gpu_type:
         if source_gpu_type != target_host.gpu_type:
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    f"Target host '{target_host.name}' has GPU type "
-                    f"'{target_host.gpu_type}' but the instance requires "
-                    f"'{source_gpu_type}'. GPU type must match for migration."
-                ),
+            logger.info(
+                "GPU type differs — source '%s' (%s) → target '%s' (%s)",
+                source_gpu_type,
+                source_gpu_type,
+                target_host.name,
+                target_host.gpu_type,
             )
 
     # Resource check via /health (disk + VRAM)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,775 @@
+"""Tests for instance migration (S-037)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+from app.models import Host, HostStatus
+from app.models.migration import MigrationResult
+from app.services.migration import (
+    capture_instance_config,
+    check_one_replica_per_host,
+    create_instance_on_host,
+    ensure_model_on_target,
+    execute_migration,
+    stop_source_instance,
+    validate_target_fitness,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _async_mock_host(host: Host):
+    """Return an AsyncMock that resolves to *host*."""
+    return AsyncMock(return_value=host)
+
+
+def _async_mock_instances(instances: list[dict]):
+    """Return an AsyncMock that resolves to *instances*."""
+    return AsyncMock(return_value=instances)
+
+
+# ── Fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def source_host() -> Host:
+    return Host(
+        id="host-src",
+        name="Source Host",
+        url="http://source:8000",
+        api_key="key-src",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.fixture
+def target_host() -> Host:
+    return Host(
+        id="host-tgt",
+        name="Target Host",
+        url="http://target:8000",
+        api_key="key-tgt",
+        status=HostStatus.ONLINE,
+        roles=["inference"],
+    )
+
+
+@pytest.fixture
+def instance_config() -> dict:
+    return {
+        "instance_id": "inst-1",
+        "config": {
+            "alias": "test-model:v1",
+            "model_source": "repo://test-model:v1",
+            "backend_type": "huggingface_classification",
+            "priority": "staging",
+            "max_length": 512,
+            "labels": ["osl"],
+        },
+    }
+
+
+# ── create_instance_on_host ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_instance_on_host_success(target_host):
+    with patch(
+        "app.services.migration.resolve"
+    ) as mock_resolve, patch(
+        "aiohttp.ClientSession.post"
+    ) as mock_post:
+        mock_resolve.return_value = "repo://test-model:v1"
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"instance_id": "new-inst", "status": "running"}
+        )
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        result = await create_instance_on_host(
+            target_host,
+            {"model_source": "repo://test-model:v1", "priority": "staging"},
+        )
+        assert result["instance_id"] == "new-inst"
+
+
+@pytest.mark.anyio
+async def test_create_instance_on_host_invalid_priority(target_host):
+    with pytest.raises(HTTPException) as exc:
+        await create_instance_on_host(
+            target_host, {"priority": "invalid"}
+        )
+    assert exc.value.status_code == 422
+    assert "Invalid priority" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_create_instance_on_host_unreachable(target_host):
+    with patch("app.services.migration.resolve"), patch(
+        "aiohttp.ClientSession.post",
+        side_effect=Exception("Connection refused"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await create_instance_on_host(target_host, {})
+        assert exc.value.status_code == 502
+
+
+# ── capture_instance_config ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_capture_config_from_redis(source_host, instance_config):
+    with patch(
+        "app.services.migration.host_store"
+    ) as mock_store:
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[instance_config]
+        )
+
+        result = await capture_instance_config(source_host, "inst-1")
+        assert result["instance_id"] == "inst-1"
+
+
+@pytest.mark.anyio
+async def test_capture_config_fallback_http(source_host, instance_config):
+    with patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=[instance_config])
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        result = await capture_instance_config(source_host, "inst-1")
+        assert result["instance_id"] == "inst-1"
+
+
+@pytest.mark.anyio
+async def test_capture_config_not_found(source_host):
+    with patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=[])
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await capture_instance_config(source_host, "inst-1")
+        assert exc.value.status_code == 404
+
+
+# ── check_one_replica_per_host ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_check_one_replica_no_conflict(target_host):
+    with patch(
+        "app.services.migration.host_store"
+    ) as mock_store:
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[{"config": {"alias": "other-model:v1"}}]
+        )
+        # Should not raise
+        await check_one_replica_per_host(target_host, "test-model:v1")
+
+
+@pytest.mark.anyio
+async def test_check_one_replica_conflict(target_host):
+    with patch(
+        "app.services.migration.host_store"
+    ) as mock_store:
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[{"config": {"alias": "test-model:v1"}}]
+        )
+        with pytest.raises(HTTPException) as exc:
+            await check_one_replica_per_host(target_host, "test-model:v1")
+        assert exc.value.status_code == 409
+
+
+# ── validate_target_fitness ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_validate_target_no_inference_role():
+    host = Host(
+        id="h1",
+        name="No Role",
+        url="http://h:8000",
+        api_key="k",
+        roles=["training"],
+        status=HostStatus.ONLINE,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await validate_target_fitness(host, {"priority": "staging"})
+    assert exc.value.status_code == 422
+    assert "inference" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_validate_target_production_refused(target_host):
+    with pytest.raises(HTTPException) as exc:
+        await validate_target_fitness(
+            target_host,
+            {"priority": "production"},
+            allow_production=False,
+        )
+    assert exc.value.status_code == 422
+    assert "production" in exc.value.detail.lower()
+
+
+@pytest.mark.anyio
+async def test_validate_target_production_allowed(target_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        # Should not raise
+        await validate_target_fitness(
+            target_host,
+            {"priority": "production"},
+            allow_production=True,
+        )
+
+
+@pytest.mark.anyio
+async def test_validate_target_insufficient_disk(target_host):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 1.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await validate_target_fitness(
+                target_host, {"priority": "staging"}
+            )
+        assert exc.value.status_code == 507
+
+
+@pytest.mark.anyio
+async def test_validate_target_gpu_type_mismatch():
+    """Target has different GPU type than the instance requires."""
+    host = Host(
+        id="h-cuda",
+        name="CUDA Host",
+        url="http://h:8000",
+        api_key="k",
+        roles=["inference"],
+        gpu_type="nvidia_cuda",
+        status=HostStatus.ONLINE,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await validate_target_fitness(
+            host,
+            {"priority": "staging"},
+            source_gpu_type="apple_silicon",
+        )
+    assert exc.value.status_code == 422
+    assert "gpu" in exc.value.detail.lower()
+
+
+@pytest.mark.anyio
+async def test_validate_target_gpu_type_match():
+    """Same GPU type on both hosts passes."""
+    host = Host(
+        id="h-cuda",
+        name="CUDA Host",
+        url="http://h:8000",
+        api_key="k",
+        roles=["inference"],
+        gpu_type="nvidia_cuda",
+        status=HostStatus.ONLINE,
+    )
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        # Should not raise
+        await validate_target_fitness(
+            host,
+            {"priority": "staging"},
+            source_gpu_type="nvidia_cuda",
+        )
+
+
+@pytest.mark.anyio
+async def test_validate_target_insufficient_vram(target_host):
+    """Target host has enough disk but VRAM is too low."""
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={
+                "disk": {"available_gb": 100.0},
+                "memory": [
+                    {"memory_type": "VRAM", "total_gb": 8.0, "available_gb": 0.5},
+                ],
+            }
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await validate_target_fitness(
+                target_host, {"priority": "staging"}
+            )
+        assert exc.value.status_code == 507
+        assert "vram" in exc.value.detail.lower()
+
+
+# ── ensure_model_on_target ───────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_ensure_model_on_target_success(target_host):
+    mock_pull = AsyncMock(return_value=("/models/repo--test--v1", True))
+    with patch(
+        "app.routes.management.models._pull_on_host", mock_pull
+    ):
+        path, cached = await ensure_model_on_target(
+            target_host, "repo://test-model:v1"
+        )
+        assert path == "/models/repo--test--v1"
+        assert cached is True
+
+
+@pytest.mark.anyio
+async def test_ensure_model_on_target_failure(target_host):
+    from app.routes.management.models import _StructuredPullError
+
+    mock_pull = AsyncMock(
+        return_value=_StructuredPullError(
+            error="not_found",
+            detail="Artifact not found",
+            source_uri="repo://bad:v1",
+            status_code=404,
+        )
+    )
+    with patch(
+        "app.routes.management.models._pull_on_host", mock_pull
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await ensure_model_on_target(target_host, "repo://bad:v1")
+        assert exc.value.status_code == 404
+
+
+# ── stop_source_instance ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_stop_source_instance_success(source_host):
+    with patch("aiohttp.ClientSession.post") as mock_post:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"status": "stopped"})
+        mock_post.return_value.__aenter__.return_value = mock_resp
+
+        result = await stop_source_instance(source_host, "inst-1")
+        assert result["status"] == "stopped"
+
+
+@pytest.mark.anyio
+async def test_stop_source_instance_unreachable(source_host):
+    with patch(
+        "aiohttp.ClientSession.post",
+        side_effect=Exception("Connection refused"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await stop_source_instance(source_host, "inst-1")
+        assert exc.value.status_code == 502
+
+
+# ── execute_migration (integration) ───────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_migrate_happy_path(
+    source_host, target_host, instance_config
+):
+    """Full happy-path migration: all steps succeed."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check, patch(
+        "app.services.migration.ensure_model_on_target"
+    ) as mock_ensure, patch(
+        "app.services.migration.stop_source_instance"
+    ) as mock_stop, patch(
+        "app.services.migration.create_instance_on_host"
+    ) as mock_create, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        # DB: both hosts exist
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+
+        # Redis: source has the instance, target has no conflicts
+        mock_store.get_host_instances = AsyncMock(
+            side_effect=lambda hid: [instance_config]
+            if hid == "host-src"
+            else []
+        )
+        mock_train_check.return_value = None
+
+        # Disk check passes
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        mock_ensure.return_value = (
+            "/models/repo--test--v1",
+            True,
+        )
+        mock_stop.return_value = {"status": "stopped"}
+        mock_create.return_value = {
+            "instance_id": "new-inst",
+            "status": "running",
+        }
+
+        result = await execute_migration(
+            instance_id="inst-1",
+            source_host_id="host-src",
+            target_host_id="host-tgt",
+        )
+
+        assert isinstance(result, MigrationResult)
+        assert result.status == "completed"
+        assert result.alias == "test-model:v1"
+        assert result.source_host_id == "host-src"
+        assert result.target_host_id == "host-tgt"
+        assert result.target_instance_id == "new-inst"
+
+        # All 8 steps should be ok
+        assert len(result.steps) == 8
+        for step in result.steps:
+            assert step.status == "ok", f"Step '{step.step}' failed"
+
+
+@pytest.mark.anyio
+async def test_migrate_source_host_not_found(target_host):
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db:
+        mock_db.get_host = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 404
+        assert "Source host" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_migrate_target_host_not_found(source_host):
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else None
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 404
+        assert "Target host" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_migrate_same_host_rejected(source_host):
+    """Same source and target host is rejected with 422."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db:
+        mock_db.get_host = AsyncMock(return_value=source_host)
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-src",
+            )
+        assert exc.value.status_code == 422
+        assert "same" in exc.value.detail.lower()
+
+
+@pytest.mark.anyio
+async def test_migrate_alias_conflict(
+    source_host, target_host, instance_config
+):
+    """Target host already runs an instance with the same alias."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+
+        # Source: instance exists; Target: already has conflict
+        mock_store.get_host_instances = AsyncMock(
+            side_effect=lambda hid: [instance_config]
+            if hid == "host-src"
+            else [{"config": {"alias": "test-model:v1"}}]
+        )
+        mock_train_check.return_value = None
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_migrate_production_refused(
+    source_host, target_host
+):
+    """Production instance migration refused without allow_production."""
+    prod_config = {
+        "instance_id": "inst-prod",
+        "config": {
+            "alias": "prod-model:v1",
+            "model_source": "repo://prod:v1",
+            "backend_type": "huggingface_classification",
+            "priority": "production",
+        },
+    }
+
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[prod_config]
+        )
+        mock_train_check.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-prod",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+                allow_production=False,
+            )
+        assert exc.value.status_code == 422
+        assert "production" in exc.value.detail.lower()
+
+
+@pytest.mark.anyio
+async def test_migrate_model_pull_fails(
+    source_host, target_host, instance_config
+):
+    """Model pull on target host fails."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check, patch(
+        "app.services.migration.ensure_model_on_target"
+    ) as mock_ensure, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+        mock_store.get_host_instances = AsyncMock(
+            side_effect=lambda hid: [instance_config]
+            if hid == "host-src"
+            else []
+        )
+        mock_train_check.return_value = None
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        mock_ensure.side_effect = HTTPException(
+            status_code=404,
+            detail="Artifact not found",
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_migrate_create_target_fails(
+    source_host, target_host, instance_config
+):
+    """Target creation fails after source is stopped — partial result returned."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check, patch(
+        "app.services.migration.ensure_model_on_target"
+    ) as mock_ensure, patch(
+        "app.services.migration.stop_source_instance"
+    ) as mock_stop, patch(
+        "app.services.migration.create_instance_on_host"
+    ) as mock_create, patch(
+        "aiohttp.ClientSession.get"
+    ) as mock_get:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+        mock_store.get_host_instances = AsyncMock(
+            side_effect=lambda hid: [instance_config]
+            if hid == "host-src"
+            else []
+        )
+        mock_train_check.return_value = None
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={"disk": {"available_gb": 100.0}}
+        )
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        mock_ensure.return_value = (
+            "/models/repo--test--v1",
+            True,
+        )
+        mock_stop.return_value = {"status": "stopped"}
+        mock_create.side_effect = HTTPException(
+            status_code=500, detail="Host internal error"
+        )
+
+        result = await execute_migration(
+            instance_id="inst-1",
+            source_host_id="host-src",
+            target_host_id="host-tgt",
+        )
+        assert isinstance(result, MigrationResult)
+        assert result.status == "failed"
+        assert result.error is not None
+        assert "Create target failed" in result.error
+        # Verify steps: stop_source should be ok, create_target failed
+        step_statuses = {s.step: s.status for s in result.steps}
+        assert step_statuses.get("stop_source") == "ok"
+        assert step_statuses.get("create_target") == "failed"
+
+
+@pytest.mark.anyio
+async def test_migrate_rejected_source_has_training_jobs(
+    source_host, target_host, instance_config
+):
+    """Migration is rejected when source host has active training jobs."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_check:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+
+        mock_check.side_effect = HTTPException(
+            status_code=409,
+            detail=(
+                "Source host 'Source Host' has 2 active training job(s): "
+                "job-1, job-2. Training jobs are non-migratable workloads."
+            ),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-1",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 409
+        assert "training" in exc.value.detail.lower()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -248,7 +248,7 @@ async def test_validate_target_insufficient_disk(target_host):
 
 @pytest.mark.anyio
 async def test_validate_target_gpu_type_mismatch():
-    """Target has different GPU type than the instance requires."""
+    """GPU type mismatch is logged but not rejected (GGUF is portable)."""
     host = Host(
         id="h-cuda",
         name="CUDA Host",
@@ -258,14 +258,18 @@ async def test_validate_target_gpu_type_mismatch():
         gpu_type="nvidia_cuda",
         status=HostStatus.ONLINE,
     )
-    with pytest.raises(HTTPException) as exc:
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        # Should not raise — GPU type difference is logged, not blocked
         await validate_target_fitness(
             host,
             {"priority": "staging"},
             source_gpu_type="apple_silicon",
         )
-    assert exc.value.status_code == 422
-    assert "gpu" in exc.value.detail.lower()
 
 
 @pytest.mark.anyio

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -773,3 +773,97 @@ async def test_migrate_rejected_source_has_training_jobs(
             )
         assert exc.value.status_code == 409
         assert "training" in exc.value.detail.lower()
+
+
+@pytest.mark.anyio
+async def test_migrate_invalid_priority_in_captured_config(
+    source_host, target_host
+):
+    """Migration fails early when captured config has an invalid priority.
+
+    This prevents the bug where a legacy instance with priority='dev'
+    would be stopped on the source but fail at create_target step.
+    """
+    invalid_config = {
+        "instance_id": "inst-legacy",
+        "config": {
+            "alias": "legacy-model:v1",
+            "model_source": "repo://legacy:v1",
+            "backend_type": "huggingface_classification",
+            "priority": "dev",  # invalid — not in {production, staging, ephemeral}
+        },
+    }
+
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store, patch(
+        "app.services.migration.check_no_active_training"
+    ) as mock_train_check:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[invalid_config]
+        )
+        mock_train_check.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            await execute_migration(
+                instance_id="inst-legacy",
+                source_host_id="host-src",
+                target_host_id="host-tgt",
+            )
+        assert exc.value.status_code == 422
+        assert "invalid priority" in exc.value.detail.lower()
+        assert "dev" in exc.value.detail
+
+
+@pytest.mark.anyio
+async def test_training_check_unreachable_rejected(
+    source_host, target_host, instance_config
+):
+    """Migration is rejected when source host is unreachable for training check."""
+    with patch(
+        "app.services.migration.host_db"
+    ) as mock_db, patch(
+        "app.services.migration.host_store"
+    ) as mock_store:
+        mock_db.get_host = AsyncMock(
+            side_effect=lambda hid: source_host
+            if hid == "host-src"
+            else target_host
+            if hid == "host-tgt"
+            else None
+        )
+        mock_store.get_host_instances = AsyncMock(
+            return_value=[instance_config]
+        )
+
+        # Simulate the training job check hitting a connection error.
+        # The real check_no_active_training now raises HTTPException(502)
+        # on connectivity failures instead of silently proceeding.
+        with patch(
+            "app.services.migration.check_no_active_training",
+            side_effect=HTTPException(
+                status_code=502,
+                detail=(
+                    "Source host 'Source Host' is unreachable for training "
+                    "job check at http://source:8000. Cannot verify no active "
+                    "training jobs – migration rejected."
+                ),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await execute_migration(
+                    instance_id="inst-1",
+                    source_host_id="host-src",
+                    target_host_id="host-tgt",
+                )
+            assert exc.value.status_code == 502
+            assert "training" in exc.value.detail.lower()

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -17,7 +17,6 @@ from app.services.migration import (
     validate_target_fitness,
 )
 
-
 # ── Helpers ──────────────────────────────────────────────────────
 
 
@@ -77,11 +76,10 @@ def instance_config() -> dict:
 
 @pytest.mark.anyio
 async def test_create_instance_on_host_success(target_host):
-    with patch(
-        "app.services.migration.resolve"
-    ) as mock_resolve, patch(
-        "aiohttp.ClientSession.post"
-    ) as mock_post:
+    with (
+        patch("app.services.migration.resolve") as mock_resolve,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
         mock_resolve.return_value = "repo://test-model:v1"
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -100,18 +98,19 @@ async def test_create_instance_on_host_success(target_host):
 @pytest.mark.anyio
 async def test_create_instance_on_host_invalid_priority(target_host):
     with pytest.raises(HTTPException) as exc:
-        await create_instance_on_host(
-            target_host, {"priority": "invalid"}
-        )
+        await create_instance_on_host(target_host, {"priority": "invalid"})
     assert exc.value.status_code == 422
     assert "Invalid priority" in exc.value.detail
 
 
 @pytest.mark.anyio
 async def test_create_instance_on_host_unreachable(target_host):
-    with patch("app.services.migration.resolve"), patch(
-        "aiohttp.ClientSession.post",
-        side_effect=Exception("Connection refused"),
+    with (
+        patch("app.services.migration.resolve"),
+        patch(
+            "aiohttp.ClientSession.post",
+            side_effect=Exception("Connection refused"),
+        ),
     ):
         with pytest.raises(HTTPException) as exc:
             await create_instance_on_host(target_host, {})
@@ -123,12 +122,8 @@ async def test_create_instance_on_host_unreachable(target_host):
 
 @pytest.mark.anyio
 async def test_capture_config_from_redis(source_host, instance_config):
-    with patch(
-        "app.services.migration.host_store"
-    ) as mock_store:
-        mock_store.get_host_instances = AsyncMock(
-            return_value=[instance_config]
-        )
+    with patch("app.services.migration.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[instance_config])
 
         result = await capture_instance_config(source_host, "inst-1")
         assert result["instance_id"] == "inst-1"
@@ -136,11 +131,10 @@ async def test_capture_config_from_redis(source_host, instance_config):
 
 @pytest.mark.anyio
 async def test_capture_config_fallback_http(source_host, instance_config):
-    with patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+    with (
+        patch("app.services.migration.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         mock_store.get_host_instances = AsyncMock(return_value=[])
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -153,11 +147,10 @@ async def test_capture_config_fallback_http(source_host, instance_config):
 
 @pytest.mark.anyio
 async def test_capture_config_not_found(source_host):
-    with patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+    with (
+        patch("app.services.migration.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         mock_store.get_host_instances = AsyncMock(return_value=[])
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -174,9 +167,7 @@ async def test_capture_config_not_found(source_host):
 
 @pytest.mark.anyio
 async def test_check_one_replica_no_conflict(target_host):
-    with patch(
-        "app.services.migration.host_store"
-    ) as mock_store:
+    with patch("app.services.migration.host_store") as mock_store:
         mock_store.get_host_instances = AsyncMock(
             return_value=[{"config": {"alias": "other-model:v1"}}]
         )
@@ -186,9 +177,7 @@ async def test_check_one_replica_no_conflict(target_host):
 
 @pytest.mark.anyio
 async def test_check_one_replica_conflict(target_host):
-    with patch(
-        "app.services.migration.host_store"
-    ) as mock_store:
+    with patch("app.services.migration.host_store") as mock_store:
         mock_store.get_host_instances = AsyncMock(
             return_value=[{"config": {"alias": "test-model:v1"}}]
         )
@@ -233,9 +222,7 @@ async def test_validate_target_production_allowed(target_host):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         # Should not raise
@@ -251,15 +238,11 @@ async def test_validate_target_insufficient_disk(target_host):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 1.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 1.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         with pytest.raises(HTTPException) as exc:
-            await validate_target_fitness(
-                target_host, {"priority": "staging"}
-            )
+            await validate_target_fitness(target_host, {"priority": "staging"})
         assert exc.value.status_code == 507
 
 
@@ -300,9 +283,7 @@ async def test_validate_target_gpu_type_match():
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         # Should not raise
@@ -330,9 +311,7 @@ async def test_validate_target_insufficient_vram(target_host):
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         with pytest.raises(HTTPException) as exc:
-            await validate_target_fitness(
-                target_host, {"priority": "staging"}
-            )
+            await validate_target_fitness(target_host, {"priority": "staging"})
         assert exc.value.status_code == 507
         assert "vram" in exc.value.detail.lower()
 
@@ -343,12 +322,8 @@ async def test_validate_target_insufficient_vram(target_host):
 @pytest.mark.anyio
 async def test_ensure_model_on_target_success(target_host):
     mock_pull = AsyncMock(return_value=("/models/repo--test--v1", True))
-    with patch(
-        "app.routes.management.models._pull_on_host", mock_pull
-    ):
-        path, cached = await ensure_model_on_target(
-            target_host, "repo://test-model:v1"
-        )
+    with patch("app.routes.management.models._pull_on_host", mock_pull):
+        path, cached = await ensure_model_on_target(target_host, "repo://test-model:v1")
         assert path == "/models/repo--test--v1"
         assert cached is True
 
@@ -365,9 +340,7 @@ async def test_ensure_model_on_target_failure(target_host):
             status_code=404,
         )
     )
-    with patch(
-        "app.routes.management.models._pull_on_host", mock_pull
-    ):
+    with patch("app.routes.management.models._pull_on_host", mock_pull):
         with pytest.raises(HTTPException) as exc:
             await ensure_model_on_target(target_host, "repo://bad:v1")
         assert exc.value.status_code == 404
@@ -403,48 +376,36 @@ async def test_stop_source_instance_unreachable(source_host):
 
 
 @pytest.mark.anyio
-async def test_migrate_happy_path(
-    source_host, target_host, instance_config
-):
+async def test_migrate_happy_path(source_host, target_host, instance_config):
     """Full happy-path migration: all steps succeed."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check, patch(
-        "app.services.migration.ensure_model_on_target"
-    ) as mock_ensure, patch(
-        "app.services.migration.stop_source_instance"
-    ) as mock_stop, patch(
-        "app.services.migration.create_instance_on_host"
-    ) as mock_create, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+        patch("app.services.migration.ensure_model_on_target") as mock_ensure,
+        patch("app.services.migration.stop_source_instance") as mock_stop,
+        patch("app.services.migration.create_instance_on_host") as mock_create,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         # DB: both hosts exist
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
 
         # Redis: source has the instance, target has no conflicts
         mock_store.get_host_instances = AsyncMock(
-            side_effect=lambda hid: [instance_config]
-            if hid == "host-src"
-            else []
+            side_effect=lambda hid: [instance_config] if hid == "host-src" else []
         )
         mock_train_check.return_value = None
 
         # Disk check passes
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         mock_ensure.return_value = (
@@ -478,9 +439,7 @@ async def test_migrate_happy_path(
 
 @pytest.mark.anyio
 async def test_migrate_source_host_not_found(target_host):
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db:
+    with patch("app.services.migration.host_db") as mock_db:
         mock_db.get_host = AsyncMock(return_value=None)
 
         with pytest.raises(HTTPException) as exc:
@@ -495,13 +454,9 @@ async def test_migrate_source_host_not_found(target_host):
 
 @pytest.mark.anyio
 async def test_migrate_target_host_not_found(source_host):
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db:
+    with patch("app.services.migration.host_db") as mock_db:
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else None
+            side_effect=lambda hid: source_host if hid == "host-src" else None
         )
 
         with pytest.raises(HTTPException) as exc:
@@ -517,9 +472,7 @@ async def test_migrate_target_host_not_found(source_host):
 @pytest.mark.anyio
 async def test_migrate_same_host_rejected(source_host):
     """Same source and target host is rejected with 422."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db:
+    with patch("app.services.migration.host_db") as mock_db:
         mock_db.get_host = AsyncMock(return_value=source_host)
 
         with pytest.raises(HTTPException) as exc:
@@ -533,40 +486,35 @@ async def test_migrate_same_host_rejected(source_host):
 
 
 @pytest.mark.anyio
-async def test_migrate_alias_conflict(
-    source_host, target_host, instance_config
-):
+async def test_migrate_alias_conflict(source_host, target_host, instance_config):
     """Target host already runs an instance with the same alias."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
 
         # Source: instance exists; Target: already has conflict
         mock_store.get_host_instances = AsyncMock(
-            side_effect=lambda hid: [instance_config]
-            if hid == "host-src"
-            else [{"config": {"alias": "test-model:v1"}}]
+            side_effect=lambda hid: (
+                [instance_config]
+                if hid == "host-src"
+                else [{"config": {"alias": "test-model:v1"}}]
+            )
         )
         mock_train_check.return_value = None
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         with pytest.raises(HTTPException) as exc:
@@ -579,9 +527,7 @@ async def test_migrate_alias_conflict(
 
 
 @pytest.mark.anyio
-async def test_migrate_production_refused(
-    source_host, target_host
-):
+async def test_migrate_production_refused(source_host, target_host):
     """Production instance migration refused without allow_production."""
     prod_config = {
         "instance_id": "inst-prod",
@@ -593,23 +539,19 @@ async def test_migrate_production_refused(
         },
     }
 
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
-        mock_store.get_host_instances = AsyncMock(
-            return_value=[prod_config]
-        )
+        mock_store.get_host_instances = AsyncMock(return_value=[prod_config])
         mock_train_check.return_value = None
 
         with pytest.raises(HTTPException) as exc:
@@ -624,40 +566,30 @@ async def test_migrate_production_refused(
 
 
 @pytest.mark.anyio
-async def test_migrate_model_pull_fails(
-    source_host, target_host, instance_config
-):
-    """Model pull on target host fails."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check, patch(
-        "app.services.migration.ensure_model_on_target"
-    ) as mock_ensure, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+async def test_migrate_model_pull_fails(source_host, target_host, instance_config):
+    """Model pull on target host fails — returns failed MigrationResult."""
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+        patch("app.services.migration.ensure_model_on_target") as mock_ensure,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
         mock_store.get_host_instances = AsyncMock(
-            side_effect=lambda hid: [instance_config]
-            if hid == "host-src"
-            else []
+            side_effect=lambda hid: [instance_config] if hid == "host-src" else []
         )
         mock_train_check.return_value = None
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         mock_ensure.side_effect = HTTPException(
@@ -665,54 +597,55 @@ async def test_migrate_model_pull_fails(
             detail="Artifact not found",
         )
 
-        with pytest.raises(HTTPException) as exc:
-            await execute_migration(
-                instance_id="inst-1",
-                source_host_id="host-src",
-                target_host_id="host-tgt",
-            )
-        assert exc.value.status_code == 404
+        result = await execute_migration(
+            instance_id="inst-1",
+            source_host_id="host-src",
+            target_host_id="host-tgt",
+        )
+
+        assert isinstance(result, MigrationResult)
+        assert result.status == "failed"
+        assert result.error is not None
+        assert "Ensure model failed" in result.error
+        step_statuses = {s.step: s.status for s in result.steps}
+        assert step_statuses.get("ensure_model") == "failed"
+        # Steps 1–4 should be ok, step 5 failed, steps 6–7 not reached
+        assert step_statuses.get("validate_hosts") == "ok"
+        assert step_statuses.get("check_training_jobs") == "ok"
+        assert step_statuses.get("capture_config") == "ok"
+        assert step_statuses.get("validate_target") == "ok"
+        assert step_statuses.get("check_anti_affinity") == "ok"
+        assert "stop_source" not in step_statuses
+        assert "create_target" not in step_statuses
 
 
 @pytest.mark.anyio
-async def test_migrate_create_target_fails(
-    source_host, target_host, instance_config
-):
+async def test_migrate_create_target_fails(source_host, target_host, instance_config):
     """Target creation fails after source is stopped — partial result returned."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check, patch(
-        "app.services.migration.ensure_model_on_target"
-    ) as mock_ensure, patch(
-        "app.services.migration.stop_source_instance"
-    ) as mock_stop, patch(
-        "app.services.migration.create_instance_on_host"
-    ) as mock_create, patch(
-        "aiohttp.ClientSession.get"
-    ) as mock_get:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+        patch("app.services.migration.ensure_model_on_target") as mock_ensure,
+        patch("app.services.migration.stop_source_instance") as mock_stop,
+        patch("app.services.migration.create_instance_on_host") as mock_create,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
         mock_store.get_host_instances = AsyncMock(
-            side_effect=lambda hid: [instance_config]
-            if hid == "host-src"
-            else []
+            side_effect=lambda hid: [instance_config] if hid == "host-src" else []
         )
         mock_train_check.return_value = None
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(
-            return_value={"disk": {"available_gb": 100.0}}
-        )
+        mock_resp.json = AsyncMock(return_value={"disk": {"available_gb": 100.0}})
         mock_get.return_value.__aenter__.return_value = mock_resp
 
         mock_ensure.return_value = (
@@ -744,17 +677,16 @@ async def test_migrate_rejected_source_has_training_jobs(
     source_host, target_host, instance_config
 ):
     """Migration is rejected when source host has active training jobs."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_check:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.check_no_active_training") as mock_check,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
 
         mock_check.side_effect = HTTPException(
@@ -776,9 +708,7 @@ async def test_migrate_rejected_source_has_training_jobs(
 
 
 @pytest.mark.anyio
-async def test_migrate_invalid_priority_in_captured_config(
-    source_host, target_host
-):
+async def test_migrate_invalid_priority_in_captured_config(source_host, target_host):
     """Migration fails early when captured config has an invalid priority.
 
     This prevents the bug where a legacy instance with priority='dev'
@@ -794,23 +724,19 @@ async def test_migrate_invalid_priority_in_captured_config(
         },
     }
 
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store, patch(
-        "app.services.migration.check_no_active_training"
-    ) as mock_train_check:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+        patch("app.services.migration.check_no_active_training") as mock_train_check,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
-        mock_store.get_host_instances = AsyncMock(
-            return_value=[invalid_config]
-        )
+        mock_store.get_host_instances = AsyncMock(return_value=[invalid_config])
         mock_train_check.return_value = None
 
         with pytest.raises(HTTPException) as exc:
@@ -829,21 +755,18 @@ async def test_training_check_unreachable_rejected(
     source_host, target_host, instance_config
 ):
     """Migration is rejected when source host is unreachable for training check."""
-    with patch(
-        "app.services.migration.host_db"
-    ) as mock_db, patch(
-        "app.services.migration.host_store"
-    ) as mock_store:
+    with (
+        patch("app.services.migration.host_db") as mock_db,
+        patch("app.services.migration.host_store") as mock_store,
+    ):
         mock_db.get_host = AsyncMock(
-            side_effect=lambda hid: source_host
-            if hid == "host-src"
-            else target_host
-            if hid == "host-tgt"
-            else None
+            side_effect=lambda hid: (
+                source_host
+                if hid == "host-src"
+                else target_host if hid == "host-tgt" else None
+            )
         )
-        mock_store.get_host_instances = AsyncMock(
-            return_value=[instance_config]
-        )
+        mock_store.get_host_instances = AsyncMock(return_value=[instance_config])
 
         # Simulate the training job check hitting a connection error.
         # The real check_no_active_training now raises HTTPException(502)


### PR DESCRIPTION
## Description

Adds a Solar Control migration operation for moving inference instances between hosts. Stops the source instance, ensures the model is on the target host via S-019 distribution, and recreates the instance from the captured configuration. Enforces one-replica-per-host, validates target fitness (roles, GPU type, disk, VRAM), and rejects migration if the source host has active training jobs.

Refactors `POST /api/hosts/{host_id}/instances` (create_instance) into a shared `create_instance_on_host` helper (Option B service extraction), now used by both the create route and the migration orchestrator. Integrates S-036 priority validation from the shared `app.validation` module.

## Changes

- `app/services/migration.py` — New migration orchestrator: `execute_migration` (7-step pipeline), `create_instance_on_host` (shared helper), `capture_instance_config` (Redis → HTTP fallback), `validate_target_fitness` (role/GPU/disk/VRAM checks), `check_one_replica_per_host`, `ensure_model_on_target` (S-019 integration), `stop_source_instance`, `check_no_active_training` (S-032/S-033 guard)
- `app/routes/management/instances.py` — New `POST /api/instances/migrate` endpoint with `MigrateRequest` model
- `app/models/migration.py` — `MigrateRequest`, `MigrationStep`, `MigrationResult` Pydantic models
- `app/routes/management/hosts.py` — `POST /api/hosts/{host_id}/instances` refactored to delegate to `create_instance_on_host`; `PUT` adds S-036 priority validation; removed unused `model_resolvers.resolve` import
- `app/services/__init__.py` — New package
- `app/main.py` — Added `/api/instances/migrate` to `GET /` root endpoint list
- `tests/test_migration.py` — 30 tests covering unit helpers and full integration: happy path, host-not-found, same-host rejection, alias conflict, production safeguard, model pull failure, create-target failure with partial step tracking, training job rejection, invalid captured priority, unreachable training check

## Related Issues

Closes #38