### PR TITLE
fix(api): preserve model_source URI for cross-host operations

### DIFF
--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -26,8 +26,6 @@ _HOST_PULL_TIMEOUT_S = 300
 
 def to_local_uri(path: str) -> str:
     """Convert an absolute or relative host path into a ``local://`` URI."""
-    if path.startswith("/"):
-        return f"local:///{path.lstrip('/')}"
     return f"local://{path}"
 
 

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -277,11 +277,21 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     # Validate priority if present (S-036)
     validate_priority(instance_data)
 
-    # Resolve model_source if present
+    # Resolve model_source if present.
+    # The resolved local:// URI is used to set model/model_id so the host can
+    # create the instance.  The original model_source URI (repo://, huggingface://)
+    # is preserved for cross-host operations such as migration (S-037).
     model_source = instance_data.get("model_source")
     if model_source:
         resolved = await resolve(model_source, host.url, host.api_key)
-        instance_data = {**instance_data, "model_source": resolved}
+        # Extract filesystem path from local:// URI
+        if resolved.startswith("local:///"):
+            model_path = resolved[9:]   # absolute: "local:///opt/..." → "/opt/..."
+        elif resolved.startswith("local://"):
+            model_path = resolved[8:]   # relative: "local://path"   → "path"
+        else:
+            model_path = resolved
+        instance_data = {**instance_data, "model": model_path}
 
     try:
         async with aiohttp.ClientSession() as session:

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -287,10 +287,9 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     if model_source:
         resolved = await resolve(model_source, host.url, host.api_key)
         # Extract filesystem path from local:// URI
-        if resolved.startswith("local:///"):
-            model_path = resolved[9:]  # absolute: "local:///opt/..." → "/opt/..."
-        elif resolved.startswith("local://"):
-            model_path = resolved[8:]  # relative: "local://path"   → "path"
+        # local:// is always 8 chars; the path starts at index 8.
+        if resolved.startswith("local://"):
+            model_path = resolved[8:]
         else:
             model_path = resolved
         backend_type = config.get("backend_type", "llamacpp")

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -291,7 +291,11 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
             model_path = resolved[8:]   # relative: "local://path"   → "path"
         else:
             model_path = resolved
-        instance_data = {**instance_data, "model": model_path}
+        backend_type = instance_data.get("backend_type", "llamacpp")
+        if backend_type.startswith("huggingface"):
+            instance_data = {**instance_data, "model_id": model_path}
+        else:
+            instance_data = {**instance_data, "model": model_path}
 
     try:
         async with aiohttp.ClientSession() as session:

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -286,9 +286,9 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
         resolved = await resolve(model_source, host.url, host.api_key)
         # Extract filesystem path from local:// URI
         if resolved.startswith("local:///"):
-            model_path = resolved[9:]   # absolute: "local:///opt/..." → "/opt/..."
+            model_path = resolved[9:]  # absolute: "local:///opt/..." → "/opt/..."
         elif resolved.startswith("local://"):
-            model_path = resolved[8:]   # relative: "local://path"   → "path"
+            model_path = resolved[8:]  # relative: "local://path"   → "path"
         else:
             model_path = resolved
         backend_type = instance_data.get("backend_type", "llamacpp")

--- a/app/routes/management/hosts.py
+++ b/app/routes/management/hosts.py
@@ -281,7 +281,9 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
     # The resolved local:// URI is used to set model/model_id so the host can
     # create the instance.  The original model_source URI (repo://, huggingface://)
     # is preserved for cross-host operations such as migration (S-037).
-    model_source = instance_data.get("model_source")
+    # Support both flat and {config: {...}} payload shapes.
+    config = instance_data.get("config", instance_data)
+    model_source = config.get("model_source")
     if model_source:
         resolved = await resolve(model_source, host.url, host.api_key)
         # Extract filesystem path from local:// URI
@@ -291,11 +293,13 @@ async def create_instance(host_id: str, instance_data: dict[str, Any]):
             model_path = resolved[8:]  # relative: "local://path"   → "path"
         else:
             model_path = resolved
-        backend_type = instance_data.get("backend_type", "llamacpp")
+        backend_type = config.get("backend_type", "llamacpp")
         if backend_type.startswith("huggingface"):
-            instance_data = {**instance_data, "model_id": model_path}
+            config["model_id"] = model_path
         else:
-            instance_data = {**instance_data, "model": model_path}
+            config["model"] = model_path
+        if "config" in instance_data:
+            instance_data["config"] = config
 
     try:
         async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
## Description

When solar-control resolves a `model_source` URI (repo://, huggingface://) before
creating an instance, it was overwriting the original URI with the resolved
local:// path. This lost the authoritative source reference, breaking cross-host
operations like S-037 migration that need the original URI to pull the model on
another host.

This PR fixes the resolution flow across both repos: solar-control now sets the
derived model/model_id from the resolved path while preserving the original
model_source, and solar-host skips redundant re-resolution when the field is
already populated.

## Changes

### solar-control (`app/routes/management/hosts.py`)
- `create_instance`: resolve model_source → extract filesystem path from local:// URI
- Set `model` (llamacpp) or `model_id` (huggingface_*) based on backend_type
- Preserve original `model_source` URI unchanged for downstream consumers

## Related Issues

Required by S-037 (instance migration) which captures instance config and needs
the original model_source to pull the model on the target host.
