### PR TITLE
feat(resources): add cluster-level reservation coordinator (S-038)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -159,6 +159,7 @@ async def root():
                 "/api/models/distribute",
                 "/api/resources",
                 "/api/instances/migrate",
+                "/api/resources/reservations",
             ],
             "realtime": [
                 "Socket.IO /hosts (host connections)",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -29,6 +29,13 @@ from .openai import (
     RerankResult as RerankResult,
     StreamOptions as StreamOptions,
 )
+from .reservation import (
+    MigrationCandidate as MigrationCandidate,
+    ReservationFailure as ReservationFailure,
+    ReservationReleaseResponse as ReservationReleaseResponse,
+    ReservationRequest as ReservationRequest,
+    ReservationResponse as ReservationResponse,
+)
 from .socketio import (
     HostHealthPayload as HostHealthPayload,
     HostPendingPayload as HostPendingPayload,

--- a/app/models/reservation.py
+++ b/app/models/reservation.py
@@ -87,9 +87,7 @@ class ReservationResponse(BaseModel):
     )
     migrated: bool = Field(
         default=False,
-        description=(
-            "Whether lower-priority workloads were migrated to free capacity"
-        ),
+        description=("Whether lower-priority workloads were migrated to free capacity"),
     )
     migrations: list[dict[str, Any]] = Field(
         default_factory=list,

--- a/app/models/reservation.py
+++ b/app/models/reservation.py
@@ -1,0 +1,138 @@
+"""Pydantic models for resource reservations (S-038)."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ReservationRequest(BaseModel):
+    """Request to reserve resources on a Solar Host, routed through Solar Control."""
+
+    # Required identity
+    requester: str = Field(
+        ..., description="Caller identifier (e.g. 'supernova', 'reconciler')"
+    )
+    job_id: str = Field(
+        ..., description="Unique job/request identifier from the caller"
+    )
+
+    # Resources requested
+    vram_gb: float = Field(..., gt=0, description="Requested VRAM in GB")
+    ram_gb: float | None = Field(default=None, gt=0, description="Requested RAM in GB")
+    disk_gb: float | None = Field(
+        default=None, gt=0, description="Requested disk in GB"
+    )
+
+    # Workload & constraints
+    workload_type: str = Field(
+        default="training",
+        description="Type of workload (e.g. 'training', 'inference')",
+    )
+    priority: str = Field(
+        default="staging",
+        description="Priority: production, staging, or ephemeral",
+    )
+    host_roles: list[str] = Field(
+        default_factory=lambda: ["training"],
+        description="Required host roles (host must have all listed)",
+    )
+    gpu_type: str | None = Field(
+        default=None, description="Required GPU type (null means any)"
+    )
+    host_allow: list[str] = Field(
+        default_factory=list,
+        description="If non-empty, restrict to these host IDs",
+    )
+    host_deny: list[str] = Field(
+        default_factory=list, description="Host IDs to exclude"
+    )
+
+    # Duration
+    ttl_seconds: int | None = Field(
+        default=None, gt=0, description="Optional TTL in seconds; host-side expiry"
+    )
+    expiration: str | None = Field(
+        default=None,
+        description="ISO 8601 expiration timestamp (alternative to ttl_seconds)",
+    )
+
+    # Preserve-one-replica constraint
+    preserve_alias: str | None = Field(
+        default=None,
+        description=(
+            "When evaluating hosts for migration, preserve at least one replica "
+            "of this alias per host. Used to enforce the one-replica-per-host "
+            "rule during displacement."
+        ),
+    )
+
+
+class ReservationResponse(BaseModel):
+    """Response returned after a successful reservation."""
+
+    reservation_id: str = Field(..., description="Solar Control reservation ID")
+    host_reservation_id: str = Field(..., description="Host-level reservation ID")
+    host_id: str
+    host_name: str
+    host_url: str
+    vram_gb: float
+    ram_gb: float | None = None
+    disk_gb: float | None = None
+    workload_type: str
+    priority: str
+    expiration: str | None = None
+    created_at: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    migrated: bool = Field(
+        default=False,
+        description=(
+            "Whether lower-priority workloads were migrated to free capacity"
+        ),
+    )
+    migrations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Details of any migrations performed",
+    )
+
+
+class ReservationFailure(BaseModel):
+    """Deterministic failure reason when capacity cannot be reserved."""
+
+    reason: str = Field(
+        ...,
+        description=(
+            "Machine-readable failure code "
+            "(e.g. 'no_eligible_host', 'insufficient_capacity')"
+        ),
+    )
+    detail: str = Field(..., description="Human-readable explanation")
+    requested: ReservationRequest | None = None
+    eligible_hosts: int = 0
+    hosts_checked: int = 0
+    migration_candidates: int = Field(
+        default=0,
+        description="Number of lower-priority instances that could be migrated",
+    )
+
+
+class ReservationReleaseResponse(BaseModel):
+    """Response returned after releasing a reservation."""
+
+    reservation_id: str
+    host_reservation_id: str
+    host_id: str
+    released: bool
+    message: str
+
+
+class MigrationCandidate(BaseModel):
+    """A lower-priority instance that could be migrated to free capacity."""
+
+    host_id: str
+    host_name: str
+    instance_id: str
+    alias: str
+    priority: str
+    vram_gb: float

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from app.jobs import router as jobs_router
-from . import hosts, endpoints, gateway, models, resources, instances
+from . import hosts, endpoints, gateway, models, resources, instances, reservations
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)
@@ -10,3 +10,4 @@ router.include_router(models.router)
 router.include_router(jobs_router.router)
 router.include_router(resources.router)
 router.include_router(instances.router)
+router.include_router(reservations.router)

--- a/app/routes/management/reservations.py
+++ b/app/routes/management/reservations.py
@@ -61,7 +61,7 @@ async def cancel_reservation(
 ) -> ReservationReleaseResponse:
     """Release a previously created reservation.
 
-    Proxies DELETE /resources/reserve/{id} to the Solar Host
+    Proxies DELETE /resources/reservations/{id} to the Solar Host
     and removes the reservation from Solar Control tracking.
     """
     return await release_reservation(reservation_id)

--- a/app/routes/management/reservations.py
+++ b/app/routes/management/reservations.py
@@ -1,0 +1,67 @@
+"""Resource reservation API routes (S-038).
+
+POST   /api/resources/reservations      — reserve resources
+DELETE /api/resources/reservations/{id}  — release a reservation
+"""
+
+import logging
+
+from fastapi import APIRouter
+
+from app.models.reservation import (
+    ReservationFailure,
+    ReservationReleaseResponse,
+    ReservationRequest,
+    ReservationResponse,
+)
+from app.services.reservation import reserve_resources, release_reservation
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/resources/reservations", tags=["reservations"])
+
+
+@router.post(
+    "",
+    response_model=ReservationResponse,
+    responses={
+        201: {"description": "Reservation created"},
+        409: {
+            "model": ReservationFailure,
+            "description": "No capacity available",
+        },
+    },
+    status_code=201,
+)
+async def create_reservation(
+    request: ReservationRequest,
+) -> ReservationResponse:
+    """Reserve resources for a job across the Solar cluster.
+
+    Solar Control evaluates all hosts, applies placement policy,
+    optionally migrates lower-priority workloads to free capacity,
+    and proxies the reservation to the selected host.
+
+    Returns the reservation ID, assigned host, and resource details.
+    On failure, returns a deterministic reason.
+    """
+    return await reserve_resources(request)
+
+
+@router.delete(
+    "/{reservation_id}",
+    response_model=ReservationReleaseResponse,
+    responses={
+        200: {"description": "Reservation released"},
+        404: {"description": "Reservation not found"},
+    },
+)
+async def cancel_reservation(
+    reservation_id: str,
+) -> ReservationReleaseResponse:
+    """Release a previously created reservation.
+
+    Proxies DELETE /resources/reserve/{id} to the Solar Host
+    and removes the reservation from Solar Control tracking.
+    """
+    return await release_reservation(reservation_id)

--- a/app/services/placement.py
+++ b/app/services/placement.py
@@ -108,8 +108,7 @@ async def find_candidates(
         if exclude_alias is not None:
             instances = await host_store.get_host_instances(host.id)
             conflict = any(
-                (i.get("config", i).get("alias") == exclude_alias)
-                for i in instances
+                (i.get("config", i).get("alias") == exclude_alias) for i in instances
             )
             if conflict:
                 continue
@@ -186,8 +185,6 @@ async def find_displaceable_instances(
             displaceable.append(inst)
 
     # Sort by lowest priority first (ephemeral before staging)
-    displaceable.sort(
-        key=lambda i: PRIORITY_ORDER.get(i.get("_priority", ""), 99)
-    )
+    displaceable.sort(key=lambda i: PRIORITY_ORDER.get(i.get("_priority", ""), 99))
 
     return displaceable

--- a/app/services/placement.py
+++ b/app/services/placement.py
@@ -1,0 +1,193 @@
+"""Shared placement policy helper (S-038 / S-041).
+
+Implements the placement algorithm from docs/specs/deployment-intent.md §8.4.
+Both the reservation coordinator and the intent reconciler use this module
+so there is ONE placement policy, not two.
+"""
+
+import logging
+from typing import Any
+
+from app.models import Host, HostResourceSnapshot
+from app.redis_state import host_store
+
+logger = logging.getLogger(__name__)
+
+# Priority ordering for displacement (deployment-intent.md §4.3)
+PRIORITY_ORDER: dict[str, int] = {
+    "ephemeral": 0,
+    "staging": 1,
+    "production": 2,
+}
+
+
+def _has_roles(host: Host, required_roles: list[str]) -> bool:
+    """Check that *host* has all required roles."""
+    host_roles = host.roles or []
+    return all(r in host_roles for r in required_roles)
+
+
+def fits_resources(
+    snapshot: HostResourceSnapshot,
+    vram_gb: float,
+    ram_gb: float | None,
+    disk_gb: float | None,
+) -> bool:
+    """Check if *snapshot* has sufficient available resources.
+
+    Uses available = total - Σeffective semantics from S-034/S-035.
+    """
+    if not snapshot.reachable:
+        return False
+
+    if snapshot.vram_available_gb is not None:
+        if snapshot.vram_available_gb < vram_gb:
+            return False
+
+    if ram_gb is not None and snapshot.ram_available_gb is not None:
+        if snapshot.ram_available_gb < ram_gb:
+            return False
+
+    if disk_gb is not None and snapshot.disk_available_gb is not None:
+        if snapshot.disk_available_gb < disk_gb:
+            return False
+
+    return True
+
+
+async def find_candidates(
+    hosts: list[Host],
+    snapshots: dict[str, HostResourceSnapshot],
+    *,
+    roles: list[str],
+    gpu_type: str | None = None,
+    host_allow: list[str] | None = None,
+    host_deny: list[str] | None = None,
+    vram_gb: float,
+    ram_gb: float | None = None,
+    disk_gb: float | None = None,
+    exclude_alias: str | None = None,
+) -> list[tuple[Host, HostResourceSnapshot]]:
+    """Find candidate hosts matching placement constraints.
+
+    Returns candidates ranked by: most free VRAM → fewest instances → host id.
+    The first ``(host, snapshot)`` pair is the best choice.
+
+    Implements deployment-intent.md §8.4 placement policy.
+    """
+    host_allow_set = set(host_allow) if host_allow else None
+    host_deny_set = set(host_deny) if host_deny else None
+
+    candidates: list[tuple[Host, HostResourceSnapshot]] = []
+
+    for host in hosts:
+        # Role filter
+        if not _has_roles(host, roles):
+            continue
+
+        # GPU type filter
+        if gpu_type is not None and host.gpu_type != gpu_type:
+            continue
+
+        # Allow/deny lists
+        if host_allow_set is not None and host.id not in host_allow_set:
+            continue
+        if host_deny_set is not None and host.id in host_deny_set:
+            continue
+
+        # Need a resource snapshot
+        snap = snapshots.get(host.id)
+        if snap is None:
+            continue
+
+        # Resource fit
+        if not fits_resources(snap, vram_gb, ram_gb, disk_gb):
+            continue
+
+        # One-replica-per-host check (if alias provided)
+        if exclude_alias is not None:
+            instances = await host_store.get_host_instances(host.id)
+            conflict = any(
+                (i.get("config", i).get("alias") == exclude_alias)
+                for i in instances
+            )
+            if conflict:
+                continue
+
+        candidates.append((host, snap))
+
+    # Rank: most free VRAM → fewest running instances → host id (stable tiebreak)
+    candidates.sort(
+        key=lambda pair: (
+            -(pair[1].vram_available_gb or 0),
+            pair[1].running_instance_count,
+            pair[0].id,
+        )
+    )
+
+    return candidates
+
+
+def can_displace(
+    candidate_priority: str,
+    existing_priority: str,
+) -> bool:
+    """Check if *candidate_priority* may displace *existing_priority*.
+
+    Displacement is allowed only toward strictly lower priority.
+    production never displaced; equal priority never displaced.
+    (deployment-intent.md §8.5)
+    """
+    candidate_order = PRIORITY_ORDER.get(candidate_priority)
+    existing_order = PRIORITY_ORDER.get(existing_priority)
+
+    if candidate_order is None or existing_order is None:
+        return False
+
+    return candidate_order > existing_order
+
+
+async def find_displaceable_instances(
+    host_id: str,
+    request_priority: str,
+    *,
+    preserve_alias: str | None = None,
+) -> list[dict[str, Any]]:
+    """Find instances on *host_id* that could be displaced by *request_priority*.
+
+    Returns instances eligible for migration, sorted lowest-priority first.
+    Respects the one-replica-per-host rule: if *preserve_alias* is set,
+    instances with that alias are only displaceable if more than one replica
+    of that alias exists on this host.
+    """
+    instances = await host_store.get_host_instances(host_id)
+
+    displaceable: list[dict[str, Any]] = []
+    alias_counts: dict[str, int] = {}
+
+    for inst in instances:
+        cfg = inst.get("config", inst)
+        alias = cfg.get("alias")
+        if alias:
+            alias_counts[alias] = alias_counts.get(alias, 0) + 1
+
+    for inst in instances:
+        cfg = inst.get("config", inst)
+        priority = cfg.get("priority") or inst.get("priority", "production")
+        alias = cfg.get("alias")
+
+        # Check one-replica preservation
+        if preserve_alias and alias == preserve_alias:
+            if alias_counts.get(alias, 0) <= 1:
+                continue  # Must preserve at least one replica
+
+        if can_displace(request_priority, priority):
+            inst["_priority"] = priority
+            displaceable.append(inst)
+
+    # Sort by lowest priority first (ephemeral before staging)
+    displaceable.sort(
+        key=lambda i: PRIORITY_ORDER.get(i.get("_priority", ""), 99)
+    )
+
+    return displaceable

--- a/app/services/reservation.py
+++ b/app/services/reservation.py
@@ -45,25 +45,24 @@ async def _call_host_reserve(
     host: Host,
     request: ReservationRequest,
 ) -> dict[str, Any]:
-    """Proxy a reservation request to a Solar Host (S-034 POST /resources/reserve)."""
+    """Proxy a reservation request to a Solar Host (S-034 POST /resources/reservations)."""
     payload: dict[str, Any] = {
         "vram_gb": request.vram_gb,
+        "ram_gb": request.ram_gb or 0.0,
         "job_id": request.job_id,
         "workload_type": request.workload_type,
         "requester": request.requester,
     }
-    if request.ram_gb is not None:
-        payload["ram_gb"] = request.ram_gb
     if request.disk_gb is not None:
         payload["disk_gb"] = request.disk_gb
     if request.ttl_seconds is not None:
         payload["ttl_seconds"] = request.ttl_seconds
     if request.expiration is not None:
-        payload["expiration"] = request.expiration
+        payload["expires_at"] = request.expiration
 
     try:
         async with aiohttp.ClientSession() as session:
-            url = f"{host.url.rstrip('/')}/resources/reserve"
+            url = f"{host.url.rstrip('/')}/resources/reservations"
             headers = {
                 "X-API-Key": host.api_key,
                 "Content-Type": "application/json",
@@ -103,11 +102,11 @@ async def _call_host_release(
     host: Host,
     host_reservation_id: str,
 ) -> dict[str, Any]:
-    """Proxy reservation release to Solar Host (S-034 DELETE /resources/reserve/{id})."""
+    """Proxy reservation release to Solar Host (S-034 DELETE /resources/reservations/{id})."""
     try:
         async with aiohttp.ClientSession() as session:
             url = (
-                f"{host.url.rstrip('/')}/resources/reserve/"
+                f"{host.url.rstrip('/')}/resources/reservations/"
                 f"{host_reservation_id}"
             )
             headers = {"X-API-Key": host.api_key}
@@ -401,7 +400,7 @@ async def reserve_resources(
         disk_gb=request.disk_gb,
         workload_type=request.workload_type,
         priority=request.priority,
-        expiration=host_result.get("expiration"),
+        expiration=host_result.get("expires_at"),
         migrated=bool(migration_details),
         migrations=migration_details,
     )
@@ -413,7 +412,7 @@ async def release_reservation(
     """Release a reservation by ID, proxying to the host.
 
     Looks up the reservation tracking data in Redis, then calls
-    DELETE /resources/reserve/{id} on the target host.
+    DELETE /resources/reservations/{id} on the target host.
     """
     reservation = await _get_reservation(reservation_id)
     if not reservation:

--- a/app/services/reservation.py
+++ b/app/services/reservation.py
@@ -293,9 +293,9 @@ async def reserve_resources(
 
                             if mig_result.status == "completed":
                                 # Re-fetch snapshot for source host
-                                snapshots[
-                                    host.id
-                                ] = await _fetch_host_resource_snapshot(host)
+                                snapshots[host.id] = (
+                                    await _fetch_host_resource_snapshot(host)
+                                )
                                 # Check if this host now fits
                                 if fits_resources(
                                     snapshots[host.id],

--- a/app/services/reservation.py
+++ b/app/services/reservation.py
@@ -28,7 +28,6 @@ from app.models.reservation import (
 )
 from app.redis_state.connection import redis_client
 from app.services.placement import (
-    can_displace,
     find_candidates,
     find_displaceable_instances,
     fits_resources,
@@ -105,10 +104,7 @@ async def _call_host_release(
     """Proxy reservation release to Solar Host (S-034 DELETE /resources/reservations/{id})."""
     try:
         async with aiohttp.ClientSession() as session:
-            url = (
-                f"{host.url.rstrip('/')}/resources/reservations/"
-                f"{host_reservation_id}"
-            )
+            url = f"{host.url.rstrip('/')}/resources/reservations/{host_reservation_id}"
             headers = {"X-API-Key": host.api_key}
             async with session.delete(
                 url,
@@ -212,9 +208,7 @@ async def reserve_resources(
     snapshots_list: list[HostResourceSnapshot] = await asyncio.gather(
         *[_fetch_host_resource_snapshot(h) for h in hosts]
     )
-    snapshots: dict[str, HostResourceSnapshot] = {
-        s.host_id: s for s in snapshots_list
-    }
+    snapshots: dict[str, HostResourceSnapshot] = {s.host_id: s for s in snapshots_list}
 
     # ── 3. Find candidates ──────────────────────────────────────
     candidates = await find_candidates(
@@ -262,13 +256,8 @@ async def reserve_resources(
 
             # Try migrating the lowest-priority displaceable instance
             for inst in displaceable:
-                inst_id = (
-                    inst.get("instance_id") or inst.get("id", "")
-                )
-                inst_alias = (
-                    inst.get("config", inst).get("alias")
-                    or inst.get("alias")
-                )
+                inst_id = inst.get("instance_id") or inst.get("id", "")
+                inst_alias = inst.get("config", inst).get("alias") or inst.get("alias")
                 if not inst_id:
                     continue
 
@@ -282,9 +271,7 @@ async def reserve_resources(
 
                     # Check if other host can take this instance
                     inst_vram = float(inst.get("vram_gb", 0) or 0)
-                    if fits_resources(
-                        other_snap, inst_vram, None, None
-                    ):
+                    if fits_resources(other_snap, inst_vram, None, None):
                         migration_evaluated += 1
                         try:
                             mig_result = await execute_migration(
@@ -306,11 +293,9 @@ async def reserve_resources(
 
                             if mig_result.status == "completed":
                                 # Re-fetch snapshot for source host
-                                snapshots[host.id] = (
-                                    await _fetch_host_resource_snapshot(
-                                        host
-                                    )
-                                )
+                                snapshots[
+                                    host.id
+                                ] = await _fetch_host_resource_snapshot(host)
                                 # Check if this host now fits
                                 if fits_resources(
                                     snapshots[host.id],
@@ -348,11 +333,7 @@ async def reserve_resources(
                     detail=(
                         f"No host with sufficient capacity for "
                         f"{request.vram_gb} GB VRAM"
-                        + (
-                            f" ({request.ram_gb} GB RAM)"
-                            if request.ram_gb
-                            else ""
-                        )
+                        + (f" ({request.ram_gb} GB RAM)" if request.ram_gb else "")
                         + (
                             f" across {len(hosts)} hosts. "
                             f"Evaluated {migration_evaluated} migration "
@@ -380,9 +361,7 @@ async def reserve_resources(
         )
 
     host_result = await _call_host_reserve(target_host, request)
-    host_reservation_id = (
-        host_result.get("reservation_id") or host_result.get("id", "")
-    )
+    host_reservation_id = host_result.get("reservation_id") or host_result.get("id", "")
 
     # ── 6. Store tracking metadata ──────────────────────────────
     await _store_reservation(
@@ -426,10 +405,7 @@ async def release_reservation(
     if not host:
         raise HTTPException(
             status_code=404,
-            detail=(
-                f"Host '{host_id}' not found for "
-                f"reservation '{reservation_id}'"
-            ),
+            detail=(f"Host '{host_id}' not found for reservation '{reservation_id}'"),
         )
 
     host_reservation_id = reservation["host_reservation_id"]
@@ -443,10 +419,7 @@ async def release_reservation(
             host_reservation_id=host_reservation_id,
             host_id=host_id,
             released=True,
-            message=(
-                f"Reservation '{reservation_id}' released "
-                f"on host '{host.name}'"
-            ),
+            message=(f"Reservation '{reservation_id}' released on host '{host.name}'"),
         )
     except HTTPException:
         # Still remove from tracking even if host release failed

--- a/app/services/reservation.py
+++ b/app/services/reservation.py
@@ -1,0 +1,456 @@
+"""Cluster-level reservation coordinator (S-038).
+
+Orchestrates resource reservation across Solar Hosts by:
+1. Querying aggregated resources (S-035)
+2. Finding candidate hosts via placement policy (shared with S-041)
+3. Evaluating lower-priority migration (S-037) when no immediate capacity
+4. Proxying reservation calls to the selected Solar Host (S-034)
+5. Tracking reservation→host mapping in Redis for release/cancel
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import aiohttp
+from fastapi import HTTPException
+
+from app.database.hosts import host_db
+from app.models import Host, HostResourceSnapshot
+from app.models.reservation import (
+    ReservationFailure,
+    ReservationReleaseResponse,
+    ReservationRequest,
+    ReservationResponse,
+)
+from app.redis_state.connection import redis_client
+from app.services.placement import (
+    can_displace,
+    find_candidates,
+    find_displaceable_instances,
+    fits_resources,
+)
+from app.services.migration import execute_migration
+
+logger = logging.getLogger(__name__)
+
+# Redis key for reservation tracking
+RESERVATION_MAP = "solar:reservations"  # reservation_id → {host_id, ...}
+
+
+async def _call_host_reserve(
+    host: Host,
+    request: ReservationRequest,
+) -> dict[str, Any]:
+    """Proxy a reservation request to a Solar Host (S-034 POST /resources/reserve)."""
+    payload: dict[str, Any] = {
+        "vram_gb": request.vram_gb,
+        "job_id": request.job_id,
+        "workload_type": request.workload_type,
+        "requester": request.requester,
+    }
+    if request.ram_gb is not None:
+        payload["ram_gb"] = request.ram_gb
+    if request.disk_gb is not None:
+        payload["disk_gb"] = request.disk_gb
+    if request.ttl_seconds is not None:
+        payload["ttl_seconds"] = request.ttl_seconds
+    if request.expiration is not None:
+        payload["expiration"] = request.expiration
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = f"{host.url.rstrip('/')}/resources/reserve"
+            headers = {
+                "X-API-Key": host.api_key,
+                "Content-Type": "application/json",
+            }
+            async with session.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status in (200, 201):
+                    return await response.json()
+                text = await response.text()
+                raise HTTPException(
+                    status_code=response.status,
+                    detail=f"Host '{host.name}' reservation failed: {text}",
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host.name}' is unreachable at {host.url}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach host '{host.name}': {e}",
+        )
+
+
+async def _call_host_release(
+    host: Host,
+    host_reservation_id: str,
+) -> dict[str, Any]:
+    """Proxy reservation release to Solar Host (S-034 DELETE /resources/reserve/{id})."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            url = (
+                f"{host.url.rstrip('/')}/resources/reserve/"
+                f"{host_reservation_id}"
+            )
+            headers = {"X-API-Key": host.api_key}
+            async with session.delete(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as response:
+                if response.status in (200, 204):
+                    return {"status": "released"}
+                text = await response.text()
+                raise HTTPException(
+                    status_code=response.status,
+                    detail=f"Host '{host.name}' release failed: {text}",
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ):
+        raise HTTPException(
+            status_code=502,
+            detail=f"Host '{host.name}' is unreachable at {host.url}",
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Cannot reach host '{host.name}': {e}",
+        )
+
+
+async def _store_reservation(
+    reservation_id: str,
+    host_id: str,
+    host_reservation_id: str,
+    request: ReservationRequest,
+) -> None:
+    """Store reservation metadata in Redis for later release/cancel."""
+    r = redis_client()
+    data = {
+        "reservation_id": reservation_id,
+        "host_id": host_id,
+        "host_reservation_id": host_reservation_id,
+        "job_id": request.job_id,
+        "requester": request.requester,
+        "vram_gb": request.vram_gb,
+        "ram_gb": request.ram_gb,
+        "disk_gb": request.disk_gb,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    await r.hset(RESERVATION_MAP, reservation_id, json.dumps(data))
+
+
+async def _get_reservation(reservation_id: str) -> dict[str, Any] | None:
+    """Retrieve reservation metadata from Redis."""
+    r = redis_client()
+    raw = await r.hget(RESERVATION_MAP, reservation_id)
+    if raw is None:
+        return None
+    return json.loads(raw)
+
+
+async def _remove_reservation(reservation_id: str) -> None:
+    """Remove reservation metadata from Redis."""
+    r = redis_client()
+    await r.hdel(RESERVATION_MAP, reservation_id)
+
+
+async def reserve_resources(
+    request: ReservationRequest,
+) -> ReservationResponse:
+    """Execute the cluster-level reservation workflow.
+
+    1. Fetch all hosts and resource snapshots (S-035)
+    2. Find candidate hosts via placement policy (§8.4)
+    3. If no candidates, evaluate migration of lower-priority workloads (S-037)
+    4. Call host reservation endpoint (S-034)
+    5. Return reservation details
+    """
+    reservation_id = str(uuid.uuid4())
+
+    # ── 1. Fetch hosts ──────────────────────────────────────────
+    hosts = await host_db.get_all_hosts()
+
+    if not hosts:
+        raise HTTPException(
+            status_code=409,
+            detail=ReservationFailure(
+                reason="no_hosts",
+                detail="No Solar Hosts are registered in the cluster",
+                hosts_checked=0,
+                eligible_hosts=0,
+            ).model_dump(),
+        )
+
+    # ── 2. Fetch resource snapshots ─────────────────────────────
+    from app.routes.management.resources import (  # noqa: F811
+        _fetch_host_resource_snapshot,
+    )
+
+    snapshots_list: list[HostResourceSnapshot] = await asyncio.gather(
+        *[_fetch_host_resource_snapshot(h) for h in hosts]
+    )
+    snapshots: dict[str, HostResourceSnapshot] = {
+        s.host_id: s for s in snapshots_list
+    }
+
+    # ── 3. Find candidates ──────────────────────────────────────
+    candidates = await find_candidates(
+        hosts,
+        snapshots,
+        roles=request.host_roles,
+        gpu_type=request.gpu_type,
+        host_allow=request.host_allow if request.host_allow else None,
+        host_deny=request.host_deny if request.host_deny else None,
+        vram_gb=request.vram_gb,
+        ram_gb=request.ram_gb,
+        disk_gb=request.disk_gb,
+        exclude_alias=request.preserve_alias,
+    )
+
+    migration_details: list[dict[str, Any]] = []
+    target_host: Host | None = None
+    target_snapshot: HostResourceSnapshot | None = None
+
+    if candidates:
+        target_host, target_snapshot = candidates[0]
+    else:
+        # ── 4. No immediate candidate — evaluate migration ──────
+        logger.info(
+            "No immediate candidate for reservation %s (vram=%.1f GB), "
+            "evaluating migration of lower-priority workloads",
+            reservation_id,
+            request.vram_gb,
+        )
+
+        migration_evaluated = 0
+        for host in hosts:
+            snap = snapshots.get(host.id)
+            if snap is None or not snap.reachable:
+                continue
+
+            displaceable = await find_displaceable_instances(
+                host.id,
+                request.priority,
+                preserve_alias=request.preserve_alias,
+            )
+
+            if not displaceable:
+                continue
+
+            # Try migrating the lowest-priority displaceable instance
+            for inst in displaceable:
+                inst_id = (
+                    inst.get("instance_id") or inst.get("id", "")
+                )
+                inst_alias = (
+                    inst.get("config", inst).get("alias")
+                    or inst.get("alias")
+                )
+                if not inst_id:
+                    continue
+
+                # Find a target host for migration
+                for other_host in hosts:
+                    if other_host.id == host.id:
+                        continue
+                    other_snap = snapshots.get(other_host.id)
+                    if other_snap is None or not other_snap.reachable:
+                        continue
+
+                    # Check if other host can take this instance
+                    inst_vram = float(inst.get("vram_gb", 0) or 0)
+                    if fits_resources(
+                        other_snap, inst_vram, None, None
+                    ):
+                        migration_evaluated += 1
+                        try:
+                            mig_result = await execute_migration(
+                                instance_id=inst_id,
+                                source_host_id=host.id,
+                                target_host_id=other_host.id,
+                                allow_production=False,
+                            )
+                            migration_details.append(
+                                {
+                                    "migration_id": mig_result.migration_id,
+                                    "status": mig_result.status,
+                                    "source_host_id": host.id,
+                                    "target_host_id": other_host.id,
+                                    "instance_id": inst_id,
+                                    "alias": inst_alias,
+                                }
+                            )
+
+                            if mig_result.status == "completed":
+                                # Re-fetch snapshot for source host
+                                snapshots[host.id] = (
+                                    await _fetch_host_resource_snapshot(
+                                        host
+                                    )
+                                )
+                                # Check if this host now fits
+                                if fits_resources(
+                                    snapshots[host.id],
+                                    request.vram_gb,
+                                    request.ram_gb,
+                                    request.disk_gb,
+                                ):
+                                    target_host = host
+                                    target_snapshot = snapshots[host.id]
+                                    break
+                        except Exception as e:
+                            logger.warning(
+                                "Migration attempt failed: %s → %s: %s",
+                                host.id,
+                                other_host.id,
+                                e,
+                            )
+                            continue
+
+                if target_host is not None:
+                    break
+
+            if target_host is not None:
+                break
+
+        if target_host is None:
+            raise HTTPException(
+                status_code=409,
+                detail=ReservationFailure(
+                    reason=(
+                        "insufficient_capacity"
+                        if migration_evaluated == 0
+                        else "migration_insufficient"
+                    ),
+                    detail=(
+                        f"No host with sufficient capacity for "
+                        f"{request.vram_gb} GB VRAM"
+                        + (
+                            f" ({request.ram_gb} GB RAM)"
+                            if request.ram_gb
+                            else ""
+                        )
+                        + (
+                            f" across {len(hosts)} hosts. "
+                            f"Evaluated {migration_evaluated} migration "
+                            f"candidates but none freed enough capacity."
+                            if migration_evaluated > 0
+                            else (
+                                f" across {len(hosts)} hosts. "
+                                "No lower-priority workloads available "
+                                "for migration."
+                            )
+                        )
+                    ),
+                    requested=request,
+                    eligible_hosts=0,
+                    hosts_checked=len(hosts),
+                    migration_candidates=migration_evaluated,
+                ).model_dump(),
+            )
+
+    # ── 5. Call host reservation endpoint ───────────────────────
+    if target_host is None or target_snapshot is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Internal error: no target host after placement",
+        )
+
+    host_result = await _call_host_reserve(target_host, request)
+    host_reservation_id = (
+        host_result.get("reservation_id") or host_result.get("id", "")
+    )
+
+    # ── 6. Store tracking metadata ──────────────────────────────
+    await _store_reservation(
+        reservation_id, target_host.id, host_reservation_id, request
+    )
+
+    return ReservationResponse(
+        reservation_id=reservation_id,
+        host_reservation_id=host_reservation_id,
+        host_id=target_host.id,
+        host_name=target_host.name,
+        host_url=target_host.url,
+        vram_gb=request.vram_gb,
+        ram_gb=request.ram_gb,
+        disk_gb=request.disk_gb,
+        workload_type=request.workload_type,
+        priority=request.priority,
+        expiration=host_result.get("expiration"),
+        migrated=bool(migration_details),
+        migrations=migration_details,
+    )
+
+
+async def release_reservation(
+    reservation_id: str,
+) -> ReservationReleaseResponse:
+    """Release a reservation by ID, proxying to the host.
+
+    Looks up the reservation tracking data in Redis, then calls
+    DELETE /resources/reserve/{id} on the target host.
+    """
+    reservation = await _get_reservation(reservation_id)
+    if not reservation:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Reservation '{reservation_id}' not found",
+        )
+
+    host_id = reservation["host_id"]
+    host = await host_db.get_host(host_id)
+    if not host:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Host '{host_id}' not found for "
+                f"reservation '{reservation_id}'"
+            ),
+        )
+
+    host_reservation_id = reservation["host_reservation_id"]
+
+    try:
+        await _call_host_release(host, host_reservation_id)
+        await _remove_reservation(reservation_id)
+
+        return ReservationReleaseResponse(
+            reservation_id=reservation_id,
+            host_reservation_id=host_reservation_id,
+            host_id=host_id,
+            released=True,
+            message=(
+                f"Reservation '{reservation_id}' released "
+                f"on host '{host.name}'"
+            ),
+        )
+    except HTTPException:
+        # Still remove from tracking even if host release failed
+        # (the host will expire it via TTL)
+        await _remove_reservation(reservation_id)
+        raise

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -270,9 +270,7 @@ async def test_find_candidates_alias_conflict(host_a100, host_mps):
         # A100 already runs the alias
         mock_store.get_host_instances = AsyncMock(
             side_effect=lambda hid: (
-                [{"config": {"alias": "test-model:v1"}}]
-                if hid == "h-a100"
-                else []
+                [{"config": {"alias": "test-model:v1"}}] if hid == "h-a100" else []
             )
         )
 

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -1,0 +1,457 @@
+"""Tests for shared placement policy (S-038 / S-041)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from app.models import Host, HostStatus, HostResourceSnapshot
+from app.services.placement import (
+    find_candidates,
+    can_displace,
+    find_displaceable_instances,
+    fits_resources,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def host_a100() -> Host:
+    return Host(
+        id="h-a100",
+        name="A100 Node",
+        url="http://a100:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="nvidia_cuda",
+        roles=["inference", "training"],
+    )
+
+
+@pytest.fixture
+def host_mps() -> Host:
+    return Host(
+        id="h-mps",
+        name="MPS Node",
+        url="http://mps:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="apple_mps",
+        roles=["inference"],
+    )
+
+
+@pytest.fixture
+def host_offline() -> Host:
+    return Host(
+        id="h-off",
+        name="Offline Node",
+        url="http://off:8000",
+        api_key="k",
+        status=HostStatus.OFFLINE,
+        gpu_type="nvidia_cuda",
+        roles=["inference"],
+    )
+
+
+def _make_snap(
+    host: Host,
+    *,
+    vram_available=80.0,
+    ram_available=200.0,
+    instances=0,
+) -> HostResourceSnapshot:
+    return HostResourceSnapshot(
+        host_id=host.id,
+        host_name=host.name,
+        url=host.url,
+        status=host.status,
+        roles=host.roles or [],
+        gpu_type=host.gpu_type,
+        reachable=True,
+        vram_available_gb=vram_available,
+        ram_available_gb=ram_available,
+        running_instance_count=instances,
+    )
+
+
+# ── fits_resources ──────────────────────────────────────────────
+
+
+def test_fits_resources_sufficient():
+    snap = HostResourceSnapshot(
+        host_id="h1",
+        host_name="test",
+        url="http://h:8000",
+        status=HostStatus.ONLINE,
+        reachable=True,
+        vram_available_gb=80.0,
+        ram_available_gb=200.0,
+        disk_available_gb=500.0,
+    )
+    assert fits_resources(snap, 20.0, 64.0, 50.0) is True
+
+
+def test_fits_resources_insufficient_vram():
+    snap = HostResourceSnapshot(
+        host_id="h1",
+        host_name="test",
+        url="http://h:8000",
+        status=HostStatus.ONLINE,
+        reachable=True,
+        vram_available_gb=4.0,
+    )
+    assert fits_resources(snap, 20.0, None, None) is False
+
+
+def test_fits_resources_unreachable():
+    snap = HostResourceSnapshot(
+        host_id="h1",
+        host_name="test",
+        url="http://h:8000",
+        status=HostStatus.OFFLINE,
+        reachable=False,
+        vram_available_gb=80.0,
+    )
+    assert fits_resources(snap, 10.0, None, None) is False
+
+
+def test_fits_resources_none_optional():
+    """None values for optional resources should skip those checks."""
+    snap = HostResourceSnapshot(
+        host_id="h1",
+        host_name="test",
+        url="http://h:8000",
+        status=HostStatus.ONLINE,
+        reachable=True,
+        vram_available_gb=80.0,
+        ram_available_gb=None,  # unknown
+        disk_available_gb=None,  # unknown
+    )
+    assert fits_resources(snap, 20.0, None, None) is True
+
+
+# ── find_candidates ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_find_candidates_basic(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100, vram_available=80.0),
+        host_mps.id: _make_snap(host_mps, vram_available=40.0),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+        )
+
+        assert len(candidates) == 2
+        # A100 should rank first (more VRAM)
+        assert candidates[0][0].id == "h-a100"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_role_filter(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100),
+        host_mps.id: _make_snap(host_mps),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["training"],
+            vram_gb=6.0,
+        )
+
+        # Only host_a100 has "training" role
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-a100"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_gpu_filter(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100),
+        host_mps.id: _make_snap(host_mps),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            gpu_type="apple_mps",
+            vram_gb=6.0,
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-mps"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_insufficient_vram(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100, vram_available=4.0),
+        host_mps.id: _make_snap(host_mps, vram_available=2.0),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=20.0,
+        )
+
+        assert len(candidates) == 0
+
+
+@pytest.mark.anyio
+async def test_find_candidates_allow_deny(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100),
+        host_mps.id: _make_snap(host_mps),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        # host_allow restricts to a100
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+            host_allow=["h-a100"],
+        )
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-a100"
+
+        # host_deny excludes a100
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+            host_deny=["h-a100"],
+        )
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-mps"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_alias_conflict(host_a100, host_mps):
+    hosts = [host_a100, host_mps]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100),
+        host_mps.id: _make_snap(host_mps),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        # A100 already runs the alias
+        mock_store.get_host_instances = AsyncMock(
+            side_effect=lambda hid: (
+                [{"config": {"alias": "test-model:v1"}}]
+                if hid == "h-a100"
+                else []
+            )
+        )
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+            exclude_alias="test-model:v1",
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-mps"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_offline_excluded(host_a100, host_offline):
+    """Offline hosts should not be candidates even with resources."""
+    hosts = [host_a100, host_offline]
+    snapshots = {
+        host_a100.id: _make_snap(host_a100),
+        host_offline.id: HostResourceSnapshot(
+            host_id=host_offline.id,
+            host_name=host_offline.name,
+            url=host_offline.url,
+            status=host_offline.status,
+            reachable=False,
+            vram_available_gb=999.0,
+        ),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0][0].id == "h-a100"
+
+
+@pytest.mark.anyio
+async def test_find_candidates_ranking(host_a100, host_mps):
+    """Rank by VRAM (desc), then instances (asc), then host_id."""
+    hosts = [host_mps, host_a100]  # Deliberately out of order
+    snapshots = {
+        host_a100.id: _make_snap(host_a100, vram_available=80.0, instances=3),
+        host_mps.id: _make_snap(host_mps, vram_available=80.0, instances=1),
+    }
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=["inference"],
+            vram_gb=6.0,
+        )
+
+        # Same VRAM, fewer instances wins
+        assert candidates[0][0].id == "h-mps"
+        assert candidates[1][0].id == "h-a100"
+
+
+# ── can_displace ────────────────────────────────────────────────
+
+
+def test_can_displace_production_over_staging():
+    assert can_displace("production", "staging") is True
+
+
+def test_can_displace_production_over_ephemeral():
+    assert can_displace("production", "ephemeral") is True
+
+
+def test_can_displace_staging_over_ephemeral():
+    assert can_displace("staging", "ephemeral") is True
+
+
+def test_can_displace_equal_not_allowed():
+    assert can_displace("staging", "staging") is False
+    assert can_displace("production", "production") is False
+
+
+def test_can_displace_lower_not_allowed():
+    assert can_displace("staging", "production") is False
+    assert can_displace("ephemeral", "staging") is False
+
+
+def test_can_displace_unknown_priority():
+    assert can_displace("unknown", "staging") is False
+    assert can_displace("staging", "unknown") is False
+
+
+# ── find_displaceable_instances ─────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_find_displaceable_basic():
+    instances = [
+        {"config": {"alias": "m1", "priority": "ephemeral"}, "vram_gb": 4},
+        {"config": {"alias": "m2", "priority": "staging"}, "vram_gb": 6},
+        {"config": {"alias": "m3", "priority": "production"}, "vram_gb": 8},
+    ]
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=instances)
+
+        result = await find_displaceable_instances("h1", "production")
+
+        # Both ephemeral and staging are displaceable by production
+        assert len(result) == 2
+        # ephemeral should sort first (lowest priority)
+        assert result[0].get("config", {}).get("priority") == "ephemeral"
+
+
+@pytest.mark.anyio
+async def test_find_displaceable_staging_only():
+    """Staging can only displace ephemeral."""
+    instances = [
+        {"config": {"alias": "m1", "priority": "ephemeral"}, "vram_gb": 4},
+        {"config": {"alias": "m2", "priority": "staging"}, "vram_gb": 6},
+    ]
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=instances)
+
+        result = await find_displaceable_instances("h1", "staging")
+
+        assert len(result) == 1
+        assert result[0].get("config", {}).get("priority") == "ephemeral"
+
+
+@pytest.mark.anyio
+async def test_find_displaceable_preserve_alias():
+    instances = [
+        {
+            "config": {"alias": "iris:v1", "priority": "ephemeral"},
+            "vram_gb": 4,
+        },
+        # Only one replica of "iris:v1" — should be preserved
+    ]
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=instances)
+
+        result = await find_displaceable_instances(
+            "h1", "production", preserve_alias="iris:v1"
+        )
+
+        # Must preserve at least one — and there's only one
+        assert len(result) == 0
+
+
+@pytest.mark.anyio
+async def test_find_displaceable_preserve_alias_extra_replica():
+    """With two replicas, one can be displaced while one is preserved."""
+    instances = [
+        {
+            "config": {"alias": "iris:v1", "priority": "ephemeral"},
+            "vram_gb": 4,
+        },
+        {
+            "config": {"alias": "iris:v1", "priority": "ephemeral"},
+            "vram_gb": 4,
+        },
+    ]
+
+    with patch("app.services.placement.host_store") as mock_store:
+        mock_store.get_host_instances = AsyncMock(return_value=instances)
+
+        result = await find_displaceable_instances(
+            "h1", "production", preserve_alias="iris:v1"
+        )
+
+        # Both are displaceable (more than one replica exists)
+        assert len(result) == 2

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -11,7 +11,6 @@ from app.services.placement import (
     fits_resources,
 )
 
-
 # ── Fixtures ────────────────────────────────────────────────────
 
 

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -1,0 +1,381 @@
+"""Tests for reservation coordinator (S-038)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+from app.models import Host, HostStatus
+from app.models.reservation import (
+    ReservationRequest,
+    ReservationResponse,
+)
+from app.services.reservation import reserve_resources, release_reservation
+
+
+# ── Fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def host_gpu() -> Host:
+    return Host(
+        id="h-gpu",
+        name="GPU Node",
+        url="http://gpu:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="nvidia_cuda",
+        roles=["training"],
+    )
+
+
+@pytest.fixture
+def host_gpu2() -> Host:
+    return Host(
+        id="h-gpu2",
+        name="GPU Node 2",
+        url="http://gpu2:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="nvidia_cuda",
+        roles=["training"],
+    )
+
+
+@pytest.fixture
+def reservation_request() -> ReservationRequest:
+    return ReservationRequest(
+        requester="supernova",
+        job_id="job-001",
+        vram_gb=20.0,
+        ram_gb=64.0,
+        workload_type="training",
+        priority="production",
+        host_roles=["training"],
+    )
+
+
+def _snap(
+    host: Host,
+    *,
+    vram_avail=80.0,
+    ram_avail=200.0,
+    disk_avail=500.0,
+):
+    from app.models import HostResourceSnapshot
+
+    return HostResourceSnapshot(
+        host_id=host.id,
+        host_name=host.name,
+        url=host.url,
+        status=host.status,
+        roles=host.roles or [],
+        gpu_type=host.gpu_type,
+        reachable=True,
+        vram_total_gb=80.0,
+        vram_available_gb=vram_avail,
+        ram_total_gb=256.0,
+        ram_available_gb=ram_avail,
+        disk_total_gb=1000.0,
+        disk_available_gb=disk_avail,
+        running_instance_count=0,
+    )
+
+
+# ── reserve_resources ───────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_reserve_happy_path(host_gpu, reservation_request):
+    """Simple reservation succeeds when capacity is available."""
+    with (
+        patch(
+            "app.services.reservation.host_db"
+        ) as mock_db,
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+        patch(
+            "app.services.reservation._call_host_reserve"
+        ) as mock_reserve,
+        patch(
+            "app.services.reservation._store_reservation"
+        ) as mock_store,
+        patch(
+            "app.services.placement.host_store"
+        ) as mock_host_store,
+    ):
+        mock_db.get_all_hosts = AsyncMock(return_value=[host_gpu])
+        mock_fetch.return_value = _snap(host_gpu)
+        mock_reserve.return_value = {
+            "reservation_id": "host-res-1",
+            "expiration": "2026-08-01T00:00:00Z",
+        }
+        mock_store.return_value = None
+        mock_host_store.get_host_instances = AsyncMock(return_value=[])
+
+        result = await reserve_resources(reservation_request)
+
+        assert isinstance(result, ReservationResponse)
+        assert result.host_id == "h-gpu"
+        assert result.host_name == "GPU Node"
+        assert result.migrated is False
+        assert result.vram_gb == 20.0
+        assert result.ram_gb == 64.0
+        mock_reserve.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_reserve_no_hosts():
+    """No hosts registered returns deterministic failure."""
+    with patch("app.services.reservation.host_db") as mock_db:
+        mock_db.get_all_hosts = AsyncMock(return_value=[])
+
+        with pytest.raises(HTTPException) as exc:
+            await reserve_resources(
+                ReservationRequest(
+                    requester="test",
+                    job_id="j1",
+                    vram_gb=10.0,
+                    host_roles=["training"],
+                )
+            )
+
+        assert exc.value.status_code == 409
+        failure = exc.value.detail
+        assert failure["reason"] == "no_hosts"
+
+
+@pytest.mark.anyio
+async def test_reserve_insufficient_capacity(
+    host_gpu, reservation_request
+):
+    """Host exists but doesn't have enough VRAM."""
+    with (
+        patch(
+            "app.services.reservation.host_db"
+        ) as mock_db,
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+        patch(
+            "app.services.placement.host_store"
+        ) as mock_host_store,
+    ):
+        mock_db.get_all_hosts = AsyncMock(return_value=[host_gpu])
+        mock_fetch.return_value = _snap(host_gpu, vram_avail=5.0)
+        mock_host_store.get_host_instances = AsyncMock(return_value=[])
+
+        with pytest.raises(HTTPException) as exc:
+            await reserve_resources(reservation_request)
+
+        assert exc.value.status_code == 409
+        failure = exc.value.detail
+        assert failure["reason"] == "insufficient_capacity"
+        assert failure["hosts_checked"] == 1
+
+
+@pytest.mark.anyio
+async def test_reserve_with_migration(
+    host_gpu, host_gpu2, reservation_request
+):
+    """When no host has capacity, migration frees capacity."""
+    with (
+        patch(
+            "app.services.reservation.host_db"
+        ) as mock_db,
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+        patch(
+            "app.services.reservation._call_host_reserve"
+        ) as mock_reserve,
+        patch(
+            "app.services.reservation._store_reservation"
+        ) as mock_store,
+        patch(
+            "app.services.placement.host_store"
+        ) as mock_host_store,
+        patch(
+            "app.services.reservation.execute_migration"
+        ) as mock_migrate,
+    ):
+        # Both hosts have low VRAM initially — triggers migration path
+        # host_gpu2 has VRAM for displaced instance but not enough RAM for the request
+        mock_db.get_all_hosts = AsyncMock(
+            return_value=[host_gpu, host_gpu2]
+        )
+        mock_fetch.side_effect = [
+            _snap(host_gpu, vram_avail=5.0, ram_avail=10.0),
+            _snap(host_gpu2, vram_avail=30.0, ram_avail=10.0),
+            # After migration re-fetch: now host_gpu has capacity
+            _snap(host_gpu, vram_avail=90.0, ram_avail=200.0),
+        ]
+
+        # host_gpu has a displaceable ephemeral instance
+        mock_host_store.get_host_instances = AsyncMock(
+            return_value=[
+                {
+                    "instance_id": "inst-ephem",
+                    "config": {"alias": "old-model", "priority": "ephemeral"},
+                    "vram_gb": 6,
+                }
+            ]
+        )
+
+        from app.models.migration import MigrationResult
+        mock_migrate.return_value = MigrationResult(
+            migration_id="mig-1",
+            status="completed",
+            source_host_id="h-gpu",
+            source_host_name="GPU Node",
+            target_host_id="h-gpu2",
+            target_host_name="GPU Node 2",
+            source_instance_id="inst-ephem",
+            target_instance_id="new-inst",
+            alias="old-model",
+            model_source="repo://old:v1",
+            priority="ephemeral",
+        )
+
+        mock_reserve.return_value = {"reservation_id": "host-res-1"}
+        mock_store.return_value = None
+
+        result = await reserve_resources(reservation_request)
+
+        assert result.host_id == "h-gpu"
+        assert result.migrated is True
+        assert len(result.migrations) == 1
+        assert result.migrations[0]["status"] == "completed"
+
+
+# ── release_reservation ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_release_reservation_success(host_gpu):
+    """Release finds the reservation and proxies to the host."""
+    with (
+        patch(
+            "app.services.reservation._get_reservation"
+        ) as mock_get,
+        patch("app.services.reservation.host_db") as mock_db,
+        patch(
+            "app.services.reservation._call_host_release"
+        ) as mock_release,
+        patch(
+            "app.services.reservation._remove_reservation"
+        ) as mock_remove,
+    ):
+        mock_get.return_value = {
+            "reservation_id": "res-1",
+            "host_id": "h-gpu",
+            "host_reservation_id": "host-res-1",
+        }
+        mock_db.get_host = AsyncMock(return_value=host_gpu)
+        mock_release.return_value = {"status": "released"}
+        mock_remove.return_value = None
+
+        result = await release_reservation("res-1")
+
+        assert result.released is True
+        assert result.host_id == "h-gpu"
+
+
+@pytest.mark.anyio
+async def test_release_not_found():
+    """Release with unknown reservation ID returns 404."""
+    with patch(
+        "app.services.reservation._get_reservation",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await release_reservation("nonexistent")
+        assert exc.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_release_host_not_found():
+    """Release when host no longer exists returns 404."""
+    with (
+        patch(
+            "app.services.reservation._get_reservation"
+        ) as mock_get,
+        patch("app.services.reservation.host_db") as mock_db,
+    ):
+        mock_get.return_value = {
+            "reservation_id": "res-1",
+            "host_id": "h-missing",
+            "host_reservation_id": "host-res-1",
+        }
+        mock_db.get_host = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc:
+            await release_reservation("res-1")
+        assert exc.value.status_code == 404
+
+
+# ── With GPU type filtering ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_reserve_gpu_type_filter(reservation_request):
+    """Only hosts with matching GPU type are candidates."""
+    host_cuda = Host(
+        id="h-cuda",
+        name="CUDA",
+        url="http://cuda:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="nvidia_cuda",
+        roles=["training"],
+    )
+    host_mps = Host(
+        id="h-mps",
+        name="MPS",
+        url="http://mps:8000",
+        api_key="k",
+        status=HostStatus.ONLINE,
+        gpu_type="apple_mps",
+        roles=["training"],
+    )
+
+    req = ReservationRequest(
+        requester="test",
+        job_id="j1",
+        vram_gb=10.0,
+        host_roles=["training"],
+        gpu_type="nvidia_cuda",
+    )
+
+    with (
+        patch(
+            "app.services.reservation.host_db"
+        ) as mock_db,
+        patch(
+            "app.routes.management.resources._fetch_host_resource_snapshot"
+        ) as mock_fetch,
+        patch(
+            "app.services.reservation._call_host_reserve"
+        ) as mock_reserve,
+        patch(
+            "app.services.reservation._store_reservation"
+        ) as mock_store,
+        patch(
+            "app.services.placement.host_store"
+        ) as mock_host_store,
+    ):
+        mock_db.get_all_hosts = AsyncMock(
+            return_value=[host_cuda, host_mps]
+        )
+        mock_fetch.side_effect = [
+            _snap(host_cuda),
+            _snap(host_mps),
+        ]
+        mock_reserve.return_value = {"reservation_id": "hr-1"}
+        mock_store.return_value = None
+        mock_host_store.get_host_instances = AsyncMock(return_value=[])
+
+        result = await reserve_resources(req)
+
+        assert result.host_id == "h-cuda"

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -89,21 +89,13 @@ def _snap(
 async def test_reserve_happy_path(host_gpu, reservation_request):
     """Simple reservation succeeds when capacity is available."""
     with (
-        patch(
-            "app.services.reservation.host_db"
-        ) as mock_db,
+        patch("app.services.reservation.host_db") as mock_db,
         patch(
             "app.routes.management.resources._fetch_host_resource_snapshot"
         ) as mock_fetch,
-        patch(
-            "app.services.reservation._call_host_reserve"
-        ) as mock_reserve,
-        patch(
-            "app.services.reservation._store_reservation"
-        ) as mock_store,
-        patch(
-            "app.services.placement.host_store"
-        ) as mock_host_store,
+        patch("app.services.reservation._call_host_reserve") as mock_reserve,
+        patch("app.services.reservation._store_reservation") as mock_store,
+        patch("app.services.placement.host_store") as mock_host_store,
     ):
         mock_db.get_all_hosts = AsyncMock(return_value=[host_gpu])
         mock_fetch.return_value = _snap(host_gpu)
@@ -147,20 +139,14 @@ async def test_reserve_no_hosts():
 
 
 @pytest.mark.anyio
-async def test_reserve_insufficient_capacity(
-    host_gpu, reservation_request
-):
+async def test_reserve_insufficient_capacity(host_gpu, reservation_request):
     """Host exists but doesn't have enough VRAM."""
     with (
-        patch(
-            "app.services.reservation.host_db"
-        ) as mock_db,
+        patch("app.services.reservation.host_db") as mock_db,
         patch(
             "app.routes.management.resources._fetch_host_resource_snapshot"
         ) as mock_fetch,
-        patch(
-            "app.services.placement.host_store"
-        ) as mock_host_store,
+        patch("app.services.placement.host_store") as mock_host_store,
     ):
         mock_db.get_all_hosts = AsyncMock(return_value=[host_gpu])
         mock_fetch.return_value = _snap(host_gpu, vram_avail=5.0)
@@ -176,35 +162,21 @@ async def test_reserve_insufficient_capacity(
 
 
 @pytest.mark.anyio
-async def test_reserve_with_migration(
-    host_gpu, host_gpu2, reservation_request
-):
+async def test_reserve_with_migration(host_gpu, host_gpu2, reservation_request):
     """When no host has capacity, migration frees capacity."""
     with (
-        patch(
-            "app.services.reservation.host_db"
-        ) as mock_db,
+        patch("app.services.reservation.host_db") as mock_db,
         patch(
             "app.routes.management.resources._fetch_host_resource_snapshot"
         ) as mock_fetch,
-        patch(
-            "app.services.reservation._call_host_reserve"
-        ) as mock_reserve,
-        patch(
-            "app.services.reservation._store_reservation"
-        ) as mock_store,
-        patch(
-            "app.services.placement.host_store"
-        ) as mock_host_store,
-        patch(
-            "app.services.reservation.execute_migration"
-        ) as mock_migrate,
+        patch("app.services.reservation._call_host_reserve") as mock_reserve,
+        patch("app.services.reservation._store_reservation") as mock_store,
+        patch("app.services.placement.host_store") as mock_host_store,
+        patch("app.services.reservation.execute_migration") as mock_migrate,
     ):
         # Both hosts have low VRAM initially — triggers migration path
         # host_gpu2 has VRAM for displaced instance but not enough RAM for the request
-        mock_db.get_all_hosts = AsyncMock(
-            return_value=[host_gpu, host_gpu2]
-        )
+        mock_db.get_all_hosts = AsyncMock(return_value=[host_gpu, host_gpu2])
         mock_fetch.side_effect = [
             _snap(host_gpu, vram_avail=5.0, ram_avail=10.0),
             _snap(host_gpu2, vram_avail=30.0, ram_avail=10.0),
@@ -224,6 +196,7 @@ async def test_reserve_with_migration(
         )
 
         from app.models.migration import MigrationResult
+
         mock_migrate.return_value = MigrationResult(
             migration_id="mig-1",
             status="completed",
@@ -256,16 +229,10 @@ async def test_reserve_with_migration(
 async def test_release_reservation_success(host_gpu):
     """Release finds the reservation and proxies to the host."""
     with (
-        patch(
-            "app.services.reservation._get_reservation"
-        ) as mock_get,
+        patch("app.services.reservation._get_reservation") as mock_get,
         patch("app.services.reservation.host_db") as mock_db,
-        patch(
-            "app.services.reservation._call_host_release"
-        ) as mock_release,
-        patch(
-            "app.services.reservation._remove_reservation"
-        ) as mock_remove,
+        patch("app.services.reservation._call_host_release") as mock_release,
+        patch("app.services.reservation._remove_reservation") as mock_remove,
     ):
         mock_get.return_value = {
             "reservation_id": "res-1",
@@ -298,9 +265,7 @@ async def test_release_not_found():
 async def test_release_host_not_found():
     """Release when host no longer exists returns 404."""
     with (
-        patch(
-            "app.services.reservation._get_reservation"
-        ) as mock_get,
+        patch("app.services.reservation._get_reservation") as mock_get,
         patch("app.services.reservation.host_db") as mock_db,
     ):
         mock_get.return_value = {
@@ -349,25 +314,15 @@ async def test_reserve_gpu_type_filter(reservation_request):
     )
 
     with (
-        patch(
-            "app.services.reservation.host_db"
-        ) as mock_db,
+        patch("app.services.reservation.host_db") as mock_db,
         patch(
             "app.routes.management.resources._fetch_host_resource_snapshot"
         ) as mock_fetch,
-        patch(
-            "app.services.reservation._call_host_reserve"
-        ) as mock_reserve,
-        patch(
-            "app.services.reservation._store_reservation"
-        ) as mock_store,
-        patch(
-            "app.services.placement.host_store"
-        ) as mock_host_store,
+        patch("app.services.reservation._call_host_reserve") as mock_reserve,
+        patch("app.services.reservation._store_reservation") as mock_store,
+        patch("app.services.placement.host_store") as mock_host_store,
     ):
-        mock_db.get_all_hosts = AsyncMock(
-            return_value=[host_cuda, host_mps]
-        )
+        mock_db.get_all_hosts = AsyncMock(return_value=[host_cuda, host_mps])
         mock_fetch.side_effect = [
             _snap(host_cuda),
             _snap(host_mps),

--- a/tests/test_reservations.py
+++ b/tests/test_reservations.py
@@ -12,7 +12,6 @@ from app.models.reservation import (
 )
 from app.services.reservation import reserve_resources, release_reservation
 
-
 # ── Fixtures ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Description

Implements the cluster-level resource reservation coordinator for Solar Control (S-038). SuperNova can now call a single Solar Control API to reserve resources without knowing individual Solar Hosts. Solar Control evaluates host resources, roles, priorities, and migration options, then returns an assigned host or a deterministic failure reason.

The placement policy is extracted into a shared `app/services/placement.py` module so both this reservation coordinator and the future S-041 intent reconciler share one algorithm — not two independent implementations.

## Changes

- **`app/models/reservation.py`** — New Pydantic models: `ReservationRequest`, `ReservationResponse`, `ReservationFailure`, `ReservationReleaseResponse`, `MigrationCandidate`
- **`app/models/__init__.py`** — Export all new reservation models
- **`app/routes/management/reservations.py`** — New route module:
  - `POST /api/resources/reservations` — reserve resources across the cluster
  - `DELETE /api/resources/reservations/{id}` — release a reservation
- **`app/routes/management/__init__.py`** — Register reservations router
- **`app/main.py`** — Add `/api/resources/reservations` to root endpoint discovery
- **`app/services/placement.py`** — Shared placement policy helper:
  - `fits_resources()` — check sufficient available VRAM/RAM/disk
  - `find_candidates()` — filter + rank hosts by constraints (roles, GPU type, allow/deny, alias uniqueness), sorted by most free VRAM → fewest instances → host ID
  - `can_displace()` — priority-based displacement check (production > staging > ephemeral)
  - `find_displaceable_instances()` — list displaceable instances on a host, with one-replica-per-host preservation
- **`app/services/reservation.py`** — Cluster-level reservation coordinator:
  - Queries aggregated resources (S-035) across all hosts
  - Applies placement policy to find candidate hosts
  - When no immediate capacity exists, evaluates migration (S-037) of lower-priority workloads
  - Proxies reservation/release calls to the selected Solar Host (S-034)
  - Tracks reservation→host mapping in Redis for release/cancel
  - Returns deterministic `ReservationFailure` reasons (`no_hosts`, `insufficient_capacity`, `migration_insufficient`)
- **`tests/test_placement.py`** — 13 tests covering fits_resources, find_candidates (role/GPU/VRAM filtering, allow/deny, alias conflict, offline exclusion, ranking), can_displace (all priority combinations), find_displaceable_instances (basic, staging-only, preserve-alias, multi-replica)
- **`tests/test_reservations.py`** — 8 tests covering happy-path reservation, no-hosts failure, insufficient-capacity failure, migration-assisted reservation, release success, release not-found, release host-not-found, GPU-type filtering

## Related Issues

Closes #39