### PR TITLE
feat(api): add declarative deployment intent CRUD API (S-040)

### DIFF
--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -3,6 +3,7 @@ from .hosts import host_db
 from .endpoints import endpoint_db
 from .logs import gateway_logger
 from .jobs import job_db
+from .intents import intent_db
 
 __all__ = [
     "get_engine",
@@ -13,4 +14,5 @@ __all__ = [
     "endpoint_db",
     "gateway_logger",
     "job_db",
+    "intent_db",
 ]

--- a/app/database/intents.py
+++ b/app/database/intents.py
@@ -1,0 +1,190 @@
+"""PostgreSQL-backed intent CRUD operations (S-040)."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+
+from app.models.intent import (
+    IntentPhase,
+    IntentResponse,
+    IntentStatus,
+    PlacementConstraints,
+    ReconcileState,
+    ResourceRequirements,
+)
+from .connection import get_session_factory
+from .tables import IntentRow
+
+
+class IntentDB:
+    """Database-backed intent management."""
+
+    def _session(self):
+        return get_session_factory()()
+
+    def _row_to_response(self, row: IntentRow) -> IntentResponse:
+        status = row.status_json or {}
+        return IntentResponse(
+            id=str(row.id),
+            alias=row.alias,
+            model_source=row.model_source,
+            replicas=row.replicas,
+            priority=row.priority,
+            strategy=row.strategy,
+            backend=row.backend or {},
+            placement=PlacementConstraints(**(row.placement or {})),
+            resources=ResourceRequirements(**(row.resources or {})),
+            metadata=row.metadata_ or {},
+            status=IntentStatus(
+                phase=IntentPhase(row.phase),
+                reconcile=ReconcileState(row.reconcile),
+                desired_replicas=row.replicas,
+                observed_replicas=status.get("observed_replicas", 0),
+                ready_replicas=status.get("ready_replicas", 0),
+                updated_replicas=status.get("updated_replicas", 0),
+                available=status.get("available", False),
+                shortfall=status.get("shortfall", 0),
+                replica_set=status.get("replica_set", []),
+                conditions=status.get("conditions", []),
+                strategy_progress=status.get("strategy_progress"),
+                last_error=status.get("last_error"),
+                created_at=row.created_at.isoformat() if row.created_at else None,
+                updated_at=row.updated_at.isoformat() if row.updated_at else None,
+                last_reconciled_at=(
+                    row.last_reconciled_at.isoformat()
+                    if row.last_reconciled_at
+                    else None
+                ),
+                ready_at=row.ready_at.isoformat() if row.ready_at else None,
+            ),
+        )
+
+    def _build_status_json(self) -> dict[str, Any]:
+        """Build the initial status JSON for a new intent."""
+        return {
+            "observed_replicas": 0,
+            "ready_replicas": 0,
+            "updated_replicas": 0,
+            "available": False,
+            "shortfall": 0,
+            "replica_set": [],
+            "conditions": [],
+            "strategy_progress": None,
+            "last_error": None,
+        }
+
+    async def create_intent(
+        self,
+        *,
+        alias: str,
+        model_source: str,
+        replicas: int,
+        priority: str,
+        strategy: str,
+        backend: dict[str, Any],
+        placement: dict[str, Any],
+        resources: dict[str, Any],
+        metadata: dict[str, str],
+    ) -> IntentResponse:
+        """Insert a new intent with phase='pending'."""
+        now = datetime.now(timezone.utc)
+        async with self._session() as session:
+            row = IntentRow(
+                alias=alias,
+                model_source=model_source,
+                replicas=replicas,
+                priority=priority,
+                strategy=strategy,
+                backend=backend,
+                placement=placement,
+                resources=resources,
+                metadata_=metadata,
+                phase="pending",
+                reconcile="idle",
+                status_json=self._build_status_json(),
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return self._row_to_response(row)
+
+    async def get_intent(self, intent_id: str) -> IntentResponse | None:
+        """Get a single intent by ID (excluding soft-deleted)."""
+        async with self._session() as session:
+            row = await session.get(IntentRow, intent_id)
+            if row is None or row.deleted_at is not None:
+                return None
+            return self._row_to_response(row)
+
+    async def get_intent_by_alias(self, alias: str) -> IntentResponse | None:
+        """Get an active (non-deleted) intent by alias."""
+        async with self._session() as session:
+            result = await session.execute(
+                select(IntentRow).where(
+                    IntentRow.alias == alias,
+                    IntentRow.deleted_at.is_(None),
+                )
+            )
+            row = result.scalar_one_or_none()
+            return self._row_to_response(row) if row else None
+
+    async def list_intents(
+        self,
+        *,
+        alias: str | None = None,
+        priority: str | None = None,
+        phase: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[IntentResponse]:
+        """List active (non-deleted) intents with optional filters."""
+        async with self._session() as session:
+            stmt = select(IntentRow).where(IntentRow.deleted_at.is_(None))
+
+            if alias:
+                stmt = stmt.where(IntentRow.alias == alias)
+            if priority:
+                stmt = stmt.where(IntentRow.priority == priority)
+            if phase:
+                stmt = stmt.where(IntentRow.phase == phase)
+
+            stmt = stmt.order_by(IntentRow.created_at.desc()).limit(limit).offset(offset)
+            result = await session.execute(stmt)
+            return [self._row_to_response(row) for row in result.scalars()]
+
+    async def soft_delete_intent(self, intent_id: str) -> IntentResponse | None:
+        """Mark an intent as deleted (soft-delete with deleted_at timestamp)."""
+        now = datetime.now(timezone.utc)
+        async with self._session() as session:
+            row = await session.get(IntentRow, intent_id)
+            if row is None or row.deleted_at is not None:
+                return None
+            row.phase = "deleting"
+            row.deleted_at = now
+            row.updated_at = now
+            await session.commit()
+            await session.refresh(row)
+            return self._row_to_response(row)
+
+    async def check_alias_conflict(
+        self, alias: str, *, exclude_id: str | None = None
+    ) -> bool:
+        """Return True if an active (non-deleted) intent already uses this alias."""
+        async with self._session() as session:
+            stmt = select(IntentRow).where(
+                IntentRow.alias == alias,
+                IntentRow.deleted_at.is_(None),
+            )
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+            if row is None:
+                return False
+            if exclude_id and str(row.id) == exclude_id:
+                return False
+            return True
+
+
+intent_db = IntentDB()

--- a/app/database/intents.py
+++ b/app/database/intents.py
@@ -151,7 +151,9 @@ class IntentDB:
             if phase:
                 stmt = stmt.where(IntentRow.phase == phase)
 
-            stmt = stmt.order_by(IntentRow.created_at.desc()).limit(limit).offset(offset)
+            stmt = (
+                stmt.order_by(IntentRow.created_at.desc()).limit(limit).offset(offset)
+            )
             result = await session.execute(stmt)
             return [self._row_to_response(row) for row in result.scalars()]
 

--- a/app/database/migrations/versions/0004_add_intents_table.py
+++ b/app/database/migrations/versions/0004_add_intents_table.py
@@ -48,9 +48,7 @@ def upgrade() -> None:
             sa.Column(
                 "priority", sa.Text(), nullable=False, server_default="production"
             ),
-            sa.Column(
-                "strategy", sa.Text(), nullable=False, server_default="rolling"
-            ),
+            sa.Column("strategy", sa.Text(), nullable=False, server_default="rolling"),
             sa.Column(
                 "backend",
                 postgresql.JSONB(),
@@ -75,12 +73,8 @@ def upgrade() -> None:
                 nullable=False,
                 server_default=sa.text("'{}'::jsonb"),
             ),
-            sa.Column(
-                "phase", sa.Text(), nullable=False, server_default="pending"
-            ),
-            sa.Column(
-                "reconcile", sa.Text(), nullable=False, server_default="idle"
-            ),
+            sa.Column("phase", sa.Text(), nullable=False, server_default="pending"),
+            sa.Column("reconcile", sa.Text(), nullable=False, server_default="idle"),
             sa.Column(
                 "status",
                 postgresql.JSONB(),

--- a/app/database/migrations/versions/0004_add_intents_table.py
+++ b/app/database/migrations/versions/0004_add_intents_table.py
@@ -1,0 +1,130 @@
+"""Add intents table for declarative deployment intents (S-040)
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-07-24 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0004"
+down_revision: Union[str, None] = "0003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    result = conn.execute(
+        sa.text(
+            "SELECT EXISTS ("
+            "  SELECT 1 FROM information_schema.tables"
+            "  WHERE table_name = :name"
+            ")"
+        ),
+        {"name": table_name},
+    )
+    return result.scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _table_exists(conn, "intents"):
+        op.create_table(
+            "intents",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=False),
+                server_default=sa.func.gen_random_uuid(),
+                primary_key=True,
+            ),
+            sa.Column("alias", sa.Text(), nullable=False),
+            sa.Column("model_source", sa.Text(), nullable=False),
+            sa.Column("replicas", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column(
+                "priority", sa.Text(), nullable=False, server_default="production"
+            ),
+            sa.Column(
+                "strategy", sa.Text(), nullable=False, server_default="rolling"
+            ),
+            sa.Column(
+                "backend",
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "placement",
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "resources",
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "metadata",
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "phase", sa.Text(), nullable=False, server_default="pending"
+            ),
+            sa.Column(
+                "reconcile", sa.Text(), nullable=False, server_default="idle"
+            ),
+            sa.Column(
+                "status",
+                postgresql.JSONB(),
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "last_reconciled_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+            sa.Column(
+                "ready_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+            sa.Column(
+                "deleted_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+
+        op.create_index("idx_intents_alias", "intents", ["alias"])
+        op.create_index("idx_intents_phase", "intents", ["phase"])
+        op.create_index("idx_intents_priority", "intents", ["priority"])
+        op.create_index("idx_intents_created_at", "intents", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_intents_alias", table_name="intents")
+    op.drop_index("idx_intents_phase", table_name="intents")
+    op.drop_index("idx_intents_priority", table_name="intents")
+    op.drop_index("idx_intents_created_at", table_name="intents")
+    op.drop_table("intents")

--- a/app/database/tables.py
+++ b/app/database/tables.py
@@ -166,3 +166,62 @@ class JobRow(Base):
     completed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+
+
+class IntentRow(Base):
+    """A declarative deployment intent (S-040)."""
+
+    __tablename__ = "intents"
+    __table_args__ = (
+        Index("idx_intents_alias", "alias"),
+        Index("idx_intents_phase", "phase"),
+        Index("idx_intents_priority", "priority"),
+        Index("idx_intents_created_at", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        PG_UUID(as_uuid=False), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    alias: Mapped[str] = mapped_column(Text, nullable=False)
+    model_source: Mapped[str] = mapped_column(Text, nullable=False)
+    replicas: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    priority: Mapped[str] = mapped_column(Text, nullable=False, default="production")
+    strategy: Mapped[str] = mapped_column(Text, nullable=False, default="rolling")
+    backend: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    placement: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    resources: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    metadata_: Mapped[dict] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    phase: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    reconcile: Mapped[str] = mapped_column(Text, nullable=False, default="idle")
+    status_json: Mapped[dict] = mapped_column(
+        "status",
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    last_reconciled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    ready_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -160,6 +160,8 @@ async def root():
                 "/api/resources",
                 "/api/instances/migrate",
                 "/api/resources/reservations",
+                "/api/intents",
+                "/api/intents/{id}",
             ],
             "realtime": [
                 "Socket.IO /hosts (host connections)",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -36,6 +36,16 @@ from .reservation import (
     ReservationRequest as ReservationRequest,
     ReservationResponse as ReservationResponse,
 )
+from .intent import (
+    IntentCreate as IntentCreate,
+    IntentDeletedResponse as IntentDeletedResponse,
+    IntentPhase as IntentPhase,
+    IntentResponse as IntentResponse,
+    IntentStatus as IntentStatus,
+    PlacementConstraints as PlacementConstraints,
+    ReconcileState as ReconcileState,
+    ResourceRequirements as ResourceRequirements,
+)
 from .socketio import (
     HostHealthPayload as HostHealthPayload,
     HostPendingPayload as HostPendingPayload,

--- a/app/models/intent.py
+++ b/app/models/intent.py
@@ -1,13 +1,12 @@
 """Pydantic models for deployment intents (S-040)."""
 
-from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
 
-
 # ── Enums ──────────────────────────────────────────────────────
+
 
 class IntentPhase(str, Enum):
     PENDING = "pending"
@@ -28,23 +27,33 @@ class ReconcileState(str, Enum):
 
 VALID_PRIORITIES: frozenset[str] = frozenset({"production", "staging", "ephemeral"})
 VALID_STRATEGIES: frozenset[str] = frozenset({"rolling", "immediate"})
-VALID_BACKEND_TYPES: frozenset[str] = frozenset({
-    "llamacpp",
-    "huggingface_causal",
-    "huggingface_classification",
-    "huggingface_embedding",
-    "huggingface_vision",
-})
+VALID_BACKEND_TYPES: frozenset[str] = frozenset(
+    {
+        "llamacpp",
+        "huggingface_causal",
+        "huggingface_classification",
+        "huggingface_embedding",
+        "huggingface_vision",
+    }
+)
 VALID_MODEL_SOURCE_SCHEMES: frozenset[str] = frozenset({"repo", "huggingface", "local"})
-FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset({
-    "alias", "model_source", "host", "port", "api_key",
-})
+FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset(
+    {
+        "alias",
+        "model_source",
+        "host",
+        "port",
+        "api_key",
+    }
+)
 
 
 # ── Request models ─────────────────────────────────────────────
 
+
 class PlacementConstraints(BaseModel):
     """Placement constraints for intent (S-039 §4.5)."""
+
     roles: list[str] = Field(default_factory=lambda: ["inference"])
     gpu_type: str | None = None
     host_allow: list[str] = Field(default_factory=list)
@@ -53,12 +62,14 @@ class PlacementConstraints(BaseModel):
 
 class ResourceRequirements(BaseModel):
     """Resource hints for placement (S-039 §4.6)."""
+
     vram_gb: float | None = None
     ram_gb: float | None = None
 
 
 class IntentCreate(BaseModel):
     """Request body for POST /api/intents (S-039 §4.1)."""
+
     alias: str = Field(..., min_length=1)
     model_source: str = Field(..., min_length=1)
     replicas: int = Field(default=1, ge=0)
@@ -72,8 +83,10 @@ class IntentCreate(BaseModel):
 
 # ── Response models ────────────────────────────────────────────
 
+
 class ReplicaEntry(BaseModel):
     """Per-replica detail in status.replica_set (S-039 §10.1)."""
+
     host_id: str | None = None
     host_name: str | None = None
     instance_id: str | None = None
@@ -86,6 +99,7 @@ class ReplicaEntry(BaseModel):
 
 class Condition(BaseModel):
     """Machine-readable condition (S-039 §10.3)."""
+
     type: str
     status: bool
     reason: str
@@ -95,6 +109,7 @@ class Condition(BaseModel):
 
 class StrategyProgress(BaseModel):
     """In-flight strategy progress (S-039 §11.4)."""
+
     strategy: str
     target_model_source: str | None = None
     step: str | None = None
@@ -106,6 +121,7 @@ class StrategyProgress(BaseModel):
 
 class LastError(BaseModel):
     """Most recent reconciliation error (S-039 §10.2)."""
+
     code: str
     message: str
     host_id: str | None = None
@@ -115,6 +131,7 @@ class LastError(BaseModel):
 
 class IntentStatus(BaseModel):
     """Server-managed status object (S-039 §10.1–10.2)."""
+
     phase: IntentPhase = IntentPhase.PENDING
     reconcile: ReconcileState = ReconcileState.IDLE
     desired_replicas: int = 0
@@ -135,6 +152,7 @@ class IntentStatus(BaseModel):
 
 class IntentResponse(BaseModel):
     """Full intent record returned by GET/POST (S-039 §10.1)."""
+
     id: str
     alias: str
     model_source: str
@@ -150,6 +168,7 @@ class IntentResponse(BaseModel):
 
 class IntentDeletedResponse(BaseModel):
     """Response for DELETE /api/intents/{id} (S-039 §12.4)."""
+
     id: str
     alias: str
     phase: IntentPhase = IntentPhase.DELETING

--- a/app/models/intent.py
+++ b/app/models/intent.py
@@ -1,0 +1,156 @@
+"""Pydantic models for deployment intents (S-040)."""
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ── Enums ──────────────────────────────────────────────────────
+
+class IntentPhase(str, Enum):
+    PENDING = "pending"
+    RECONCILING = "reconciling"
+    READY = "ready"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+    DELETING = "deleting"
+    DELETED = "deleted"
+
+
+class ReconcileState(str, Enum):
+    IDLE = "idle"
+    IN_PROGRESS = "in_progress"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+VALID_PRIORITIES: frozenset[str] = frozenset({"production", "staging", "ephemeral"})
+VALID_STRATEGIES: frozenset[str] = frozenset({"rolling", "immediate"})
+VALID_BACKEND_TYPES: frozenset[str] = frozenset({
+    "llamacpp",
+    "huggingface_causal",
+    "huggingface_classification",
+    "huggingface_embedding",
+    "huggingface_vision",
+})
+VALID_MODEL_SOURCE_SCHEMES: frozenset[str] = frozenset({"repo", "huggingface", "local"})
+FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset({
+    "alias", "model_source", "host", "port", "api_key",
+})
+
+
+# ── Request models ─────────────────────────────────────────────
+
+class PlacementConstraints(BaseModel):
+    """Placement constraints for intent (S-039 §4.5)."""
+    roles: list[str] = Field(default_factory=lambda: ["inference"])
+    gpu_type: str | None = None
+    host_allow: list[str] = Field(default_factory=list)
+    host_deny: list[str] = Field(default_factory=list)
+
+
+class ResourceRequirements(BaseModel):
+    """Resource hints for placement (S-039 §4.6)."""
+    vram_gb: float | None = None
+    ram_gb: float | None = None
+
+
+class IntentCreate(BaseModel):
+    """Request body for POST /api/intents (S-039 §4.1)."""
+    alias: str = Field(..., min_length=1)
+    model_source: str = Field(..., min_length=1)
+    replicas: int = Field(default=1, ge=0)
+    priority: str = Field(default="production")
+    strategy: str = Field(default="rolling")
+    backend: dict[str, Any] = Field(...)
+    placement: PlacementConstraints = Field(default_factory=PlacementConstraints)
+    resources: ResourceRequirements = Field(default_factory=ResourceRequirements)
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+# ── Response models ────────────────────────────────────────────
+
+class ReplicaEntry(BaseModel):
+    """Per-replica detail in status.replica_set (S-039 §10.1)."""
+    host_id: str | None = None
+    host_name: str | None = None
+    instance_id: str | None = None
+    state: str | None = None
+    model_source: str | None = None
+    healthy: bool = False
+    message: str | None = None
+    updated_at: str | None = None
+
+
+class Condition(BaseModel):
+    """Machine-readable condition (S-039 §10.3)."""
+    type: str
+    status: bool
+    reason: str
+    message: str
+    last_transition: str
+
+
+class StrategyProgress(BaseModel):
+    """In-flight strategy progress (S-039 §11.4)."""
+    strategy: str
+    target_model_source: str | None = None
+    step: str | None = None
+    updated: int = 0
+    in_progress: int = 0
+    failed: int = 0
+    message: str | None = None
+
+
+class LastError(BaseModel):
+    """Most recent reconciliation error (S-039 §10.2)."""
+    code: str
+    message: str
+    host_id: str | None = None
+    source_uri: str | None = None
+    at: str
+
+
+class IntentStatus(BaseModel):
+    """Server-managed status object (S-039 §10.1–10.2)."""
+    phase: IntentPhase = IntentPhase.PENDING
+    reconcile: ReconcileState = ReconcileState.IDLE
+    desired_replicas: int = 0
+    observed_replicas: int = 0
+    ready_replicas: int = 0
+    updated_replicas: int = 0
+    available: bool = False
+    shortfall: int = 0
+    replica_set: list[ReplicaEntry] = Field(default_factory=list)
+    conditions: list[Condition] = Field(default_factory=list)
+    strategy_progress: StrategyProgress | None = None
+    last_error: LastError | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    last_reconciled_at: str | None = None
+    ready_at: str | None = None
+
+
+class IntentResponse(BaseModel):
+    """Full intent record returned by GET/POST (S-039 §10.1)."""
+    id: str
+    alias: str
+    model_source: str
+    replicas: int
+    priority: str
+    strategy: str
+    backend: dict[str, Any]
+    placement: PlacementConstraints
+    resources: ResourceRequirements
+    metadata: dict[str, str] = Field(default_factory=dict)
+    status: IntentStatus
+
+
+class IntentDeletedResponse(BaseModel):
+    """Response for DELETE /api/intents/{id} (S-039 §12.4)."""
+    id: str
+    alias: str
+    phase: IntentPhase = IntentPhase.DELETING
+    message: str = "Intent deletion initiated"

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 from app.jobs import router as jobs_router
-from . import hosts, endpoints, gateway, models, resources, instances, reservations
+from . import hosts, endpoints, gateway, models, resources, instances, reservations, intents
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)
@@ -11,3 +11,4 @@ router.include_router(jobs_router.router)
 router.include_router(resources.router)
 router.include_router(instances.router)
 router.include_router(reservations.router)
+router.include_router(intents.router)

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -1,6 +1,15 @@
 from fastapi import APIRouter
 from app.jobs import router as jobs_router
-from . import hosts, endpoints, gateway, models, resources, instances, reservations, intents
+from . import (
+    hosts,
+    endpoints,
+    gateway,
+    models,
+    resources,
+    instances,
+    reservations,
+    intents,
+)
 
 router = APIRouter(prefix="/api", tags=["management"])
 router.include_router(hosts.router)

--- a/app/routes/management/intents.py
+++ b/app/routes/management/intents.py
@@ -1,0 +1,124 @@
+"""Intent API routes (S-040).
+
+POST   /api/intents          — submit a deployment intent
+GET    /api/intents          — list active intents
+GET    /api/intents/{id}     — get a single intent
+DELETE /api/intents/{id}     — delete an intent (soft-delete)
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from app.models.intent import IntentCreate, IntentDeletedResponse, IntentPhase, IntentResponse
+from app.database.intents import intent_db
+from app.validation import validate_intent_create
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/intents", tags=["intents"])
+
+
+@router.post("", response_model=IntentResponse, status_code=201)
+async def create_intent(request: Request, body: IntentCreate) -> IntentResponse:
+    """Submit a desired-state deployment intent (S-039 §12.1).
+
+    The intent is stored with phase='pending' and will be reconciled
+    once S-041 reconciliation ships.
+    """
+    data = body.model_dump()
+
+    # Validate
+    errors = validate_intent_create(data)
+    if errors:
+        raise HTTPException(
+            status_code=422,
+            detail={"detail": "Invalid intent", "errors": errors},
+        )
+
+    # Check alias conflict
+    conflict = await intent_db.check_alias_conflict(data["alias"])
+    if conflict:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "detail": f"An active intent already exists for alias '{data['alias']}'"
+            },
+        )
+
+    intent = await intent_db.create_intent(
+        alias=data["alias"],
+        model_source=data["model_source"],
+        replicas=data.get("replicas", 1),
+        priority=data.get("priority", "production"),
+        strategy=data.get("strategy", "rolling"),
+        backend=data["backend"],
+        placement=data.get("placement", {}),
+        resources=data.get("resources", {}),
+        metadata=data.get("metadata", {}),
+    )
+
+    logger.info("Intent created: id=%s alias=%s", intent.id, intent.alias)
+    return intent
+
+
+@router.get("", response_model=list[IntentResponse])
+async def list_intents(
+    request: Request,
+    alias: str | None = Query(None),
+    priority: str | None = Query(None),
+    phase: str | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+) -> list[IntentResponse]:
+    """List active intents with optional filters (S-039 §12.2)."""
+    return await intent_db.list_intents(
+        alias=alias,
+        priority=priority,
+        phase=phase,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{intent_id}", response_model=IntentResponse)
+async def get_intent(request: Request, intent_id: str) -> IntentResponse:
+    """Get a single intent by ID (S-039 §12.3)."""
+    intent = await intent_db.get_intent(intent_id)
+    if intent is None:
+        raise HTTPException(status_code=404, detail="Intent not found")
+    return intent
+
+
+@router.delete(
+    "/{intent_id}",
+    response_model=IntentDeletedResponse,
+    status_code=202,
+)
+async def delete_intent(
+    request: Request,
+    intent_id: str,
+    orphan: bool = Query(False),
+) -> IntentDeletedResponse:
+    """Delete an intent (S-039 §12.4).
+
+    Marks the intent as 'deleting'. The S-041 reconciler will stop
+    managed instances (or orphan them if ?orphan=true).
+    """
+    intent = await intent_db.soft_delete_intent(intent_id)
+    if intent is None:
+        raise HTTPException(status_code=404, detail="Intent not found")
+
+    logger.info(
+        "Intent deleted: id=%s alias=%s orphan=%s", intent_id, intent.alias, orphan
+    )
+    return IntentDeletedResponse(
+        id=intent.id,
+        alias=intent.alias,
+        phase=IntentPhase.DELETING,
+        message=(
+            "Intent deletion initiated. Managed instances will be orphaned."
+            if orphan
+            else "Intent deletion initiated. Managed instances will be stopped."
+        ),
+    )

--- a/app/routes/management/intents.py
+++ b/app/routes/management/intents.py
@@ -10,7 +10,12 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Query, Request
 
-from app.models.intent import IntentCreate, IntentDeletedResponse, IntentPhase, IntentResponse
+from app.models.intent import (
+    IntentCreate,
+    IntentDeletedResponse,
+    IntentPhase,
+    IntentResponse,
+)
 from app.database.intents import intent_db
 from app.validation import validate_intent_create
 

--- a/app/validation.py
+++ b/app/validation.py
@@ -12,17 +12,25 @@ from fastapi import HTTPException
 
 VALID_PRIORITIES: frozenset[str] = frozenset({"production", "staging", "ephemeral"})
 VALID_STRATEGIES: frozenset[str] = frozenset({"rolling", "immediate"})
-VALID_BACKEND_TYPES: frozenset[str] = frozenset({
-    "llamacpp",
-    "huggingface_causal",
-    "huggingface_classification",
-    "huggingface_embedding",
-    "huggingface_vision",
-})
+VALID_BACKEND_TYPES: frozenset[str] = frozenset(
+    {
+        "llamacpp",
+        "huggingface_causal",
+        "huggingface_classification",
+        "huggingface_embedding",
+        "huggingface_vision",
+    }
+)
 VALID_MODEL_SOURCE_SCHEMES: frozenset[str] = frozenset({"repo", "huggingface", "local"})
-FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset({
-    "alias", "model_source", "host", "port", "api_key",
-})
+FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset(
+    {
+        "alias",
+        "model_source",
+        "host",
+        "port",
+        "api_key",
+    }
+)
 
 
 def validate_priority(instance_data: dict[str, Any]) -> None:
@@ -49,7 +57,9 @@ def validate_intent_create(data: dict[str, Any]) -> list[dict[str, str]]:
     # alias
     alias = data.get("alias")
     if not alias or not isinstance(alias, str) or not alias.strip():
-        errors.append({"field": "alias", "message": "alias is required and must be non-empty"})
+        errors.append(
+            {"field": "alias", "message": "alias is required and must be non-empty"}
+        )
 
     # model_source
     model_source = data.get("model_source", "")
@@ -58,13 +68,15 @@ def validate_intent_create(data: dict[str, Any]) -> list[dict[str, str]]:
     else:
         parsed = urlparse(model_source)
         if parsed.scheme not in VALID_MODEL_SOURCE_SCHEMES:
-            errors.append({
-                "field": "model_source",
-                "message": (
-                    f"unsupported scheme '{parsed.scheme}'. "
-                    f"Must be one of: {', '.join(sorted(VALID_MODEL_SOURCE_SCHEMES))}"
-                ),
-            })
+            errors.append(
+                {
+                    "field": "model_source",
+                    "message": (
+                        f"unsupported scheme '{parsed.scheme}'. "
+                        f"Must be one of: {', '.join(sorted(VALID_MODEL_SOURCE_SCHEMES))}"
+                    ),
+                }
+            )
 
     # replicas
     replicas = data.get("replicas", 1)
@@ -74,24 +86,28 @@ def validate_intent_create(data: dict[str, Any]) -> list[dict[str, str]]:
     # priority
     priority = data.get("priority", "production")
     if priority not in VALID_PRIORITIES:
-        errors.append({
-            "field": "priority",
-            "message": (
-                f"'{priority}' is not a valid priority. "
-                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
-            ),
-        })
+        errors.append(
+            {
+                "field": "priority",
+                "message": (
+                    f"'{priority}' is not a valid priority. "
+                    f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+                ),
+            }
+        )
 
     # strategy
     strategy = data.get("strategy", "rolling")
     if strategy not in VALID_STRATEGIES:
-        errors.append({
-            "field": "strategy",
-            "message": (
-                f"'{strategy}' is not a valid strategy. "
-                f"Must be one of: {', '.join(sorted(VALID_STRATEGIES))}"
-            ),
-        })
+        errors.append(
+            {
+                "field": "strategy",
+                "message": (
+                    f"'{strategy}' is not a valid strategy. "
+                    f"Must be one of: {', '.join(sorted(VALID_STRATEGIES))}"
+                ),
+            }
+        )
 
     # backend
     backend = data.get("backend", {})
@@ -100,32 +116,40 @@ def validate_intent_create(data: dict[str, Any]) -> list[dict[str, str]]:
     else:
         backend_type = backend.get("backend_type")
         if not backend_type:
-            errors.append({"field": "backend.backend_type", "message": "backend_type is required"})
+            errors.append(
+                {"field": "backend.backend_type", "message": "backend_type is required"}
+            )
         elif backend_type not in VALID_BACKEND_TYPES:
-            errors.append({
-                "field": "backend.backend_type",
-                "message": (
-                    f"'{backend_type}' is not a supported backend_type. "
-                    f"Must be one of: {', '.join(sorted(VALID_BACKEND_TYPES))}"
-                ),
-            })
+            errors.append(
+                {
+                    "field": "backend.backend_type",
+                    "message": (
+                        f"'{backend_type}' is not a supported backend_type. "
+                        f"Must be one of: {', '.join(sorted(VALID_BACKEND_TYPES))}"
+                    ),
+                }
+            )
 
         # Forbidden fields
         for forbidden in FORBIDDEN_BACKEND_FIELDS:
             if forbidden in backend:
-                errors.append({
-                    "field": f"backend.{forbidden}",
-                    "message": f"'{forbidden}' is server-derived and must not be set by the client",
-                })
+                errors.append(
+                    {
+                        "field": f"backend.{forbidden}",
+                        "message": f"'{forbidden}' is server-derived and must not be set by the client",
+                    }
+                )
 
     # placement
     placement = data.get("placement", {})
     if isinstance(placement, dict):
         roles = placement.get("roles", ["inference"])
         if not isinstance(roles, list) or len(roles) == 0:
-            errors.append({
-                "field": "placement.roles",
-                "message": "placement.roles must be a non-empty list",
-            })
+            errors.append(
+                {
+                    "field": "placement.roles",
+                    "message": "placement.roles must be a non-empty list",
+                }
+            )
 
     return errors

--- a/app/validation.py
+++ b/app/validation.py
@@ -1,4 +1,4 @@
-"""Shared validation helpers (S-036).
+"""Shared validation helpers (S-036, S-040).
 
 Centralized validators used by route handlers and services so
 priorities, constraints, and error formats stay consistent across
@@ -6,10 +6,23 @@ the codebase.
 """
 
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import HTTPException
 
 VALID_PRIORITIES: frozenset[str] = frozenset({"production", "staging", "ephemeral"})
+VALID_STRATEGIES: frozenset[str] = frozenset({"rolling", "immediate"})
+VALID_BACKEND_TYPES: frozenset[str] = frozenset({
+    "llamacpp",
+    "huggingface_causal",
+    "huggingface_classification",
+    "huggingface_embedding",
+    "huggingface_vision",
+})
+VALID_MODEL_SOURCE_SCHEMES: frozenset[str] = frozenset({"repo", "huggingface", "local"})
+FORBIDDEN_BACKEND_FIELDS: frozenset[str] = frozenset({
+    "alias", "model_source", "host", "port", "api_key",
+})
 
 
 def validate_priority(instance_data: dict[str, Any]) -> None:
@@ -23,3 +36,96 @@ def validate_priority(instance_data: dict[str, Any]) -> None:
                 f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
             ),
         )
+
+
+def validate_intent_create(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Validate an intent creation request (S-039 §4.7).
+
+    Returns a list of {field, message} errors. Empty list means valid.
+    Does NOT raise — the route handler decides the HTTP status.
+    """
+    errors: list[dict[str, str]] = []
+
+    # alias
+    alias = data.get("alias")
+    if not alias or not isinstance(alias, str) or not alias.strip():
+        errors.append({"field": "alias", "message": "alias is required and must be non-empty"})
+
+    # model_source
+    model_source = data.get("model_source", "")
+    if not model_source:
+        errors.append({"field": "model_source", "message": "model_source is required"})
+    else:
+        parsed = urlparse(model_source)
+        if parsed.scheme not in VALID_MODEL_SOURCE_SCHEMES:
+            errors.append({
+                "field": "model_source",
+                "message": (
+                    f"unsupported scheme '{parsed.scheme}'. "
+                    f"Must be one of: {', '.join(sorted(VALID_MODEL_SOURCE_SCHEMES))}"
+                ),
+            })
+
+    # replicas
+    replicas = data.get("replicas", 1)
+    if not isinstance(replicas, int) or replicas < 0:
+        errors.append({"field": "replicas", "message": "replicas must be >= 0"})
+
+    # priority
+    priority = data.get("priority", "production")
+    if priority not in VALID_PRIORITIES:
+        errors.append({
+            "field": "priority",
+            "message": (
+                f"'{priority}' is not a valid priority. "
+                f"Must be one of: {', '.join(sorted(VALID_PRIORITIES))}"
+            ),
+        })
+
+    # strategy
+    strategy = data.get("strategy", "rolling")
+    if strategy not in VALID_STRATEGIES:
+        errors.append({
+            "field": "strategy",
+            "message": (
+                f"'{strategy}' is not a valid strategy. "
+                f"Must be one of: {', '.join(sorted(VALID_STRATEGIES))}"
+            ),
+        })
+
+    # backend
+    backend = data.get("backend", {})
+    if not isinstance(backend, dict):
+        errors.append({"field": "backend", "message": "backend must be an object"})
+    else:
+        backend_type = backend.get("backend_type")
+        if not backend_type:
+            errors.append({"field": "backend.backend_type", "message": "backend_type is required"})
+        elif backend_type not in VALID_BACKEND_TYPES:
+            errors.append({
+                "field": "backend.backend_type",
+                "message": (
+                    f"'{backend_type}' is not a supported backend_type. "
+                    f"Must be one of: {', '.join(sorted(VALID_BACKEND_TYPES))}"
+                ),
+            })
+
+        # Forbidden fields
+        for forbidden in FORBIDDEN_BACKEND_FIELDS:
+            if forbidden in backend:
+                errors.append({
+                    "field": f"backend.{forbidden}",
+                    "message": f"'{forbidden}' is server-derived and must not be set by the client",
+                })
+
+    # placement
+    placement = data.get("placement", {})
+    if isinstance(placement, dict):
+        roles = placement.get("roles", ["inference"])
+        if not isinstance(roles, list) or len(roles) == 0:
+            errors.append({
+                "field": "placement.roles",
+                "message": "placement.roles must be a non-empty list",
+            })
+
+    return errors

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -1,0 +1,542 @@
+"""Tests for intent API (S-040)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+from app.models.intent import (
+    IntentCreate,
+    IntentPhase,
+    IntentResponse,
+    IntentStatus,
+    PlacementConstraints,
+    ReconcileState,
+    ResourceRequirements,
+)
+from app.validation import validate_intent_create
+
+
+# ── Validation unit tests ──────────────────────────────────────
+
+def test_validate_intent_create_valid_minimal():
+    """Minimal valid intent passes validation."""
+    data = {
+        "alias": "test-model",
+        "model_source": "repo://test:v1",
+        "backend": {"backend_type": "huggingface_classification"},
+    }
+    errors = validate_intent_create(data)
+    assert errors == []
+
+
+def test_validate_intent_create_valid_full():
+    """Full intent with all optional fields passes."""
+    data = {
+        "alias": "test-model",
+        "model_source": "huggingface://org/model",
+        "replicas": 3,
+        "priority": "staging",
+        "strategy": "immediate",
+        "backend": {
+            "backend_type": "llamacpp",
+            "dtype": "float16",
+            "max_length": 512,
+        },
+        "placement": {
+            "roles": ["inference"],
+            "gpu_type": "nvidia_cuda",
+            "host_allow": ["h1"],
+            "host_deny": ["h2"],
+        },
+        "resources": {"vram_gb": 8.0, "ram_gb": 16.0},
+        "metadata": {"source": "supernova"},
+    }
+    errors = validate_intent_create(data)
+    assert errors == []
+
+
+def test_validate_intent_missing_alias():
+    errors = validate_intent_create({
+        "model_source": "repo://x:v1",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "alias" for e in errors)
+
+
+def test_validate_intent_missing_model_source():
+    errors = validate_intent_create({
+        "alias": "x",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "model_source" for e in errors)
+
+
+def test_validate_intent_invalid_scheme():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "http://example.com/model",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "model_source" for e in errors)
+
+
+def test_validate_intent_local_scheme():
+    """local:// is a valid scheme."""
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "local:///opt/models/model.gguf",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert errors == []
+
+
+def test_validate_intent_huggingface_scheme():
+    """huggingface:// is a valid scheme."""
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "huggingface://meta-llama/Llama-2-7b-hf",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert errors == []
+
+
+def test_validate_intent_negative_replicas():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "replicas": -1,
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "replicas" for e in errors)
+
+
+def test_validate_intent_zero_replicas():
+    """replicas=0 is valid (pre-create then scale up)."""
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "replicas": 0,
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert errors == []
+
+
+def test_validate_intent_invalid_priority():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "priority": "critical",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "priority" for e in errors)
+
+
+def test_validate_intent_all_valid_priorities():
+    """All three valid priorities pass."""
+    for p in ["production", "staging", "ephemeral"]:
+        errors = validate_intent_create({
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "priority": p,
+            "backend": {"backend_type": "llamacpp"},
+        })
+        assert errors == [], f"Priority '{p}' should be valid"
+
+
+def test_validate_intent_invalid_strategy():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "strategy": "blue-green",
+        "backend": {"backend_type": "llamacpp"},
+    })
+    assert any(e["field"] == "strategy" for e in errors)
+
+
+def test_validate_intent_all_valid_strategies():
+    """Both valid strategies pass."""
+    for s in ["rolling", "immediate"]:
+        errors = validate_intent_create({
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "strategy": s,
+            "backend": {"backend_type": "llamacpp"},
+        })
+        assert errors == [], f"Strategy '{s}' should be valid"
+
+
+def test_validate_intent_missing_backend_type():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "backend": {},
+    })
+    assert any(e["field"] == "backend.backend_type" for e in errors)
+
+
+def test_validate_intent_invalid_backend_type():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "backend": {"backend_type": "unknown_type"},
+    })
+    assert any(e["field"] == "backend.backend_type" for e in errors)
+
+
+def test_validate_intent_all_valid_backend_types():
+    """All five valid backend types pass."""
+    for bt in [
+        "llamacpp",
+        "huggingface_causal",
+        "huggingface_classification",
+        "huggingface_embedding",
+        "huggingface_vision",
+    ]:
+        errors = validate_intent_create({
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "backend": {"backend_type": bt},
+        })
+        assert errors == [], f"backend_type '{bt}' should be valid"
+
+
+def test_validate_intent_forbidden_backend_fields():
+    """Server-derived fields must not appear in backend."""
+    for forbidden in ["alias", "model_source", "host", "port", "api_key"]:
+        errors = validate_intent_create({
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "backend": {"backend_type": "llamacpp", forbidden: "value"},
+        })
+        assert any(
+            e["field"] == f"backend.{forbidden}" for e in errors
+        ), f"Expected error for backend.{forbidden}"
+
+
+def test_validate_intent_empty_placement_roles():
+    errors = validate_intent_create({
+        "alias": "x",
+        "model_source": "repo://x:v1",
+        "backend": {"backend_type": "llamacpp"},
+        "placement": {"roles": []},
+    })
+    assert any(e["field"] == "placement.roles" for e in errors)
+
+
+# ── Model unit tests ────────────────────────────────────────────
+
+def test_intent_create_defaults():
+    """IntentCreate applies correct defaults."""
+    intent = IntentCreate(
+        alias="m",
+        model_source="repo://m:v1",
+        backend={"backend_type": "llamacpp"},
+    )
+    assert intent.replicas == 1
+    assert intent.priority == "production"
+    assert intent.strategy == "rolling"
+    assert intent.placement.roles == ["inference"]
+    assert intent.resources.vram_gb is None
+
+
+def test_intent_status_defaults():
+    """IntentStatus has correct new-intent defaults."""
+    status = IntentStatus()
+    assert status.phase == IntentPhase.PENDING
+    assert status.reconcile == ReconcileState.IDLE
+    assert status.observed_replicas == 0
+    assert status.ready_replicas == 0
+    assert status.available is False
+
+
+# ── Route integration tests (mock IntentDB) ────────────────────
+
+
+@pytest.fixture
+def valid_intent_create() -> IntentCreate:
+    return IntentCreate(
+        alias="test-model",
+        model_source="repo://test:v1",
+        replicas=2,
+        priority="production",
+        strategy="rolling",
+        backend={"backend_type": "huggingface_classification", "max_length": 512},
+        placement=PlacementConstraints(roles=["inference"], gpu_type="nvidia_cuda"),
+        resources=ResourceRequirements(vram_gb=6.0),
+    )
+
+
+@pytest.fixture
+def mock_intent_response() -> IntentResponse:
+    return IntentResponse(
+        id="550e8400-e29b-41d4-a716-446655440000",
+        alias="test-model",
+        model_source="repo://test:v1",
+        replicas=2,
+        priority="production",
+        strategy="rolling",
+        backend={"backend_type": "huggingface_classification", "max_length": 512},
+        placement=PlacementConstraints(roles=["inference"], gpu_type="nvidia_cuda"),
+        resources=ResourceRequirements(vram_gb=6.0),
+        metadata={},
+        status=IntentStatus(
+            phase=IntentPhase.PENDING,
+            reconcile=ReconcileState.IDLE,
+            desired_replicas=2,
+            observed_replicas=0,
+            ready_replicas=0,
+            updated_replicas=0,
+            available=False,
+            shortfall=0,
+            created_at="2026-07-24T00:00:00Z",
+            updated_at="2026-07-24T00:00:00Z",
+        ),
+    )
+
+
+@pytest.mark.anyio
+async def test_create_intent_success(valid_intent_create, mock_intent_response):
+    """POST /api/intents returns 201 with pending status."""
+    from fastapi.testclient import TestClient
+
+    with (
+        patch(
+            "app.routes.management.intents.intent_db.create_intent",
+            new=AsyncMock(return_value=mock_intent_response),
+        ),
+        patch(
+            "app.routes.management.intents.intent_db.check_alias_conflict",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        from app.main import app
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/intents",
+            json=valid_intent_create.model_dump(),
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["id"] == mock_intent_response.id
+        assert data["alias"] == "test-model"
+        assert data["status"]["phase"] == "pending"
+        assert data["status"]["reconcile"] == "idle"
+
+
+@pytest.mark.anyio
+async def test_create_intent_alias_conflict(valid_intent_create):
+    """POST with duplicate alias returns 409."""
+    with patch(
+        "app.routes.management.intents.intent_db.check_alias_conflict",
+        new=AsyncMock(return_value=True),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/intents",
+            json=valid_intent_create.model_dump(),
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_create_intent_validation_error():
+    """POST with invalid data returns 422."""
+    with patch(
+        "app.routes.management.intents.intent_db.check_alias_conflict",
+        new=AsyncMock(return_value=False),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/intents",
+            json={
+                "alias": "valid-alias",
+                "model_source": "http://bad",
+                "backend": {"backend_type": "invalid_type"},
+            },
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert "detail" in data
+        assert "errors" in data["detail"]
+        assert len(data["detail"]["errors"]) >= 2  # bad scheme + bad backend_type
+
+
+@pytest.mark.anyio
+async def test_create_intent_unauthorized(valid_intent_create):
+    """POST without API key returns 401."""
+    from app.main import app
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/intents",
+        json=valid_intent_create.model_dump(),
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_list_intents(mock_intent_response):
+    """GET /api/intents returns list."""
+    with patch(
+        "app.routes.management.intents.intent_db.list_intents",
+        new=AsyncMock(return_value=[mock_intent_response]),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.get(
+            "/api/intents",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["id"] == mock_intent_response.id
+
+
+@pytest.mark.anyio
+async def test_get_intent_found(mock_intent_response):
+    """GET /api/intents/{id} returns the intent."""
+    with patch(
+        "app.routes.management.intents.intent_db.get_intent",
+        new=AsyncMock(return_value=mock_intent_response),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.get(
+            "/api/intents/550e8400-e29b-41d4-a716-446655440000",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] == mock_intent_response.id
+
+
+@pytest.mark.anyio
+async def test_get_intent_not_found():
+    """GET /api/intents/{id} with unknown ID returns 404."""
+    with patch(
+        "app.routes.management.intents.intent_db.get_intent",
+        new=AsyncMock(return_value=None),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.get(
+            "/api/intents/nonexistent",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_intent_success(mock_intent_response):
+    """DELETE /api/intents/{id} returns 202 with deleting phase."""
+    mock_intent_response.status.phase = IntentPhase.DELETING
+    with patch(
+        "app.routes.management.intents.intent_db.soft_delete_intent",
+        new=AsyncMock(return_value=mock_intent_response),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.delete(
+            "/api/intents/550e8400-e29b-41d4-a716-446655440000",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["phase"] == "deleting"
+
+
+@pytest.mark.anyio
+async def test_delete_intent_not_found():
+    """DELETE with unknown ID returns 404."""
+    with patch(
+        "app.routes.management.intents.intent_db.soft_delete_intent",
+        new=AsyncMock(return_value=None),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.delete(
+            "/api/intents/nonexistent",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_intent_with_orphan(mock_intent_response):
+    """DELETE with ?orphan=true returns 202 with orphan message."""
+    mock_intent_response.status.phase = IntentPhase.DELETING
+    with patch(
+        "app.routes.management.intents.intent_db.soft_delete_intent",
+        new=AsyncMock(return_value=mock_intent_response),
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.delete(
+            "/api/intents/550e8400-e29b-41d4-a716-446655440000?orphan=true",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 202
+        data = response.json()
+        assert "orphaned" in data["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_list_intents_with_filters(mock_intent_response):
+    """GET /api/intents passes query params to list_intents."""
+    mock_list = AsyncMock(return_value=[mock_intent_response])
+    with patch(
+        "app.routes.management.intents.intent_db.list_intents",
+        new=mock_list,
+    ):
+        from app.main import app
+        from fastapi.testclient import TestClient
+
+        client = TestClient(app)
+        response = client.get(
+            "/api/intents?priority=production&phase=pending&limit=10&offset=0",
+            headers={"X-API-Key": "change-me-management"},
+        )
+
+        assert response.status_code == 200
+        mock_list.assert_called_once_with(
+            alias=None,
+            priority="production",
+            phase="pending",
+            limit=10,
+            offset=0,
+        )

--- a/tests/test_intents.py
+++ b/tests/test_intents.py
@@ -3,7 +3,6 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 
-from fastapi import HTTPException
 
 from app.models.intent import (
     IntentCreate,
@@ -16,8 +15,8 @@ from app.models.intent import (
 )
 from app.validation import validate_intent_create
 
-
 # ── Validation unit tests ──────────────────────────────────────
+
 
 def test_validate_intent_create_valid_minimal():
     """Minimal valid intent passes validation."""
@@ -57,130 +56,156 @@ def test_validate_intent_create_valid_full():
 
 
 def test_validate_intent_missing_alias():
-    errors = validate_intent_create({
-        "model_source": "repo://x:v1",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "model_source": "repo://x:v1",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "alias" for e in errors)
 
 
 def test_validate_intent_missing_model_source():
-    errors = validate_intent_create({
-        "alias": "x",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "model_source" for e in errors)
 
 
 def test_validate_intent_invalid_scheme():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "http://example.com/model",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "http://example.com/model",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "model_source" for e in errors)
 
 
 def test_validate_intent_local_scheme():
     """local:// is a valid scheme."""
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "local:///opt/models/model.gguf",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "local:///opt/models/model.gguf",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert errors == []
 
 
 def test_validate_intent_huggingface_scheme():
     """huggingface:// is a valid scheme."""
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "huggingface://meta-llama/Llama-2-7b-hf",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "huggingface://meta-llama/Llama-2-7b-hf",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert errors == []
 
 
 def test_validate_intent_negative_replicas():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "replicas": -1,
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "replicas": -1,
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "replicas" for e in errors)
 
 
 def test_validate_intent_zero_replicas():
     """replicas=0 is valid (pre-create then scale up)."""
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "replicas": 0,
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "replicas": 0,
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert errors == []
 
 
 def test_validate_intent_invalid_priority():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "priority": "critical",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "priority": "critical",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "priority" for e in errors)
 
 
 def test_validate_intent_all_valid_priorities():
     """All three valid priorities pass."""
     for p in ["production", "staging", "ephemeral"]:
-        errors = validate_intent_create({
-            "alias": "x",
-            "model_source": "repo://x:v1",
-            "priority": p,
-            "backend": {"backend_type": "llamacpp"},
-        })
+        errors = validate_intent_create(
+            {
+                "alias": "x",
+                "model_source": "repo://x:v1",
+                "priority": p,
+                "backend": {"backend_type": "llamacpp"},
+            }
+        )
         assert errors == [], f"Priority '{p}' should be valid"
 
 
 def test_validate_intent_invalid_strategy():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "strategy": "blue-green",
-        "backend": {"backend_type": "llamacpp"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "strategy": "blue-green",
+            "backend": {"backend_type": "llamacpp"},
+        }
+    )
     assert any(e["field"] == "strategy" for e in errors)
 
 
 def test_validate_intent_all_valid_strategies():
     """Both valid strategies pass."""
     for s in ["rolling", "immediate"]:
-        errors = validate_intent_create({
-            "alias": "x",
-            "model_source": "repo://x:v1",
-            "strategy": s,
-            "backend": {"backend_type": "llamacpp"},
-        })
+        errors = validate_intent_create(
+            {
+                "alias": "x",
+                "model_source": "repo://x:v1",
+                "strategy": s,
+                "backend": {"backend_type": "llamacpp"},
+            }
+        )
         assert errors == [], f"Strategy '{s}' should be valid"
 
 
 def test_validate_intent_missing_backend_type():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "backend": {},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "backend": {},
+        }
+    )
     assert any(e["field"] == "backend.backend_type" for e in errors)
 
 
 def test_validate_intent_invalid_backend_type():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "backend": {"backend_type": "unknown_type"},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "backend": {"backend_type": "unknown_type"},
+        }
+    )
     assert any(e["field"] == "backend.backend_type" for e in errors)
 
 
@@ -193,38 +218,45 @@ def test_validate_intent_all_valid_backend_types():
         "huggingface_embedding",
         "huggingface_vision",
     ]:
-        errors = validate_intent_create({
-            "alias": "x",
-            "model_source": "repo://x:v1",
-            "backend": {"backend_type": bt},
-        })
+        errors = validate_intent_create(
+            {
+                "alias": "x",
+                "model_source": "repo://x:v1",
+                "backend": {"backend_type": bt},
+            }
+        )
         assert errors == [], f"backend_type '{bt}' should be valid"
 
 
 def test_validate_intent_forbidden_backend_fields():
     """Server-derived fields must not appear in backend."""
     for forbidden in ["alias", "model_source", "host", "port", "api_key"]:
-        errors = validate_intent_create({
-            "alias": "x",
-            "model_source": "repo://x:v1",
-            "backend": {"backend_type": "llamacpp", forbidden: "value"},
-        })
+        errors = validate_intent_create(
+            {
+                "alias": "x",
+                "model_source": "repo://x:v1",
+                "backend": {"backend_type": "llamacpp", forbidden: "value"},
+            }
+        )
         assert any(
             e["field"] == f"backend.{forbidden}" for e in errors
         ), f"Expected error for backend.{forbidden}"
 
 
 def test_validate_intent_empty_placement_roles():
-    errors = validate_intent_create({
-        "alias": "x",
-        "model_source": "repo://x:v1",
-        "backend": {"backend_type": "llamacpp"},
-        "placement": {"roles": []},
-    })
+    errors = validate_intent_create(
+        {
+            "alias": "x",
+            "model_source": "repo://x:v1",
+            "backend": {"backend_type": "llamacpp"},
+            "placement": {"roles": []},
+        }
+    )
     assert any(e["field"] == "placement.roles" for e in errors)
 
 
 # ── Model unit tests ────────────────────────────────────────────
+
 
 def test_intent_create_defaults():
     """IntentCreate applies correct defaults."""


### PR DESCRIPTION
## Description

Implements the intent persistence and basic lifecycle API for declarative deployment management in Solar Control. Clients (Solar WebUI, SuperNova) can now submit desired deployment state via `POST /api/intents`, list active intents, fetch individual intents, and delete them. Intents are validated against the S-039 specification, persisted in PostgreSQL, and reported as `pending`/`unreconciled` until the S-041 reconciliation engine ships — no workloads are silently created.

## Changes

- **`app/models/intent.py`** — Pydantic models: `IntentCreate` (S-039 §4.1 request schema), `IntentResponse` (full record with §10.1 status), `IntentStatus` (phase/reconcile/replicas/conditions), `PlacementConstraints`, `ResourceRequirements`, `IntentDeletedResponse`
- **`app/database/tables.py`** — `IntentRow` ORM model with soft-delete support (`deleted_at`, `phase`, `reconcile`, `status_json`)
- **`app/database/intents.py`** — `IntentDB` CRUD singleton: `create_intent`, `get_intent`, `get_intent_by_alias`, `list_intents` (with alias/priority/phase filters + pagination), `soft_delete_intent`, `check_alias_conflict`
- **`app/database/migrations/versions/0004_add_intents_table.py`** — Alembic migration creating the `intents` table with indexes on alias/phase/priority/created_at
- **`app/routes/management/intents.py`** — Route handlers:
  - `POST /api/intents` → 201 with pending status, 409 on alias conflict, 422 on validation errors
  - `GET /api/intents` → 200 list with optional `?alias`, `?priority`, `?phase`, `?limit`, `?offset` filters
  - `GET /api/intents/{id}` → 200 full record / 404
  - `DELETE /api/intents/{id}` → 202 with `?orphan=true` support, soft-deletes
- **`app/validation.py`** — `validate_intent_create()` enforcing all S-039 §4.7 rules: required fields, supported priorities/strategies/backend types, model source URI scheme, forbidden backend fields, non-empty placement roles
- **`app/routes/management/__init__.py`**, **`app/models/__init__.py`**, **`app/database/__init__.py`**, **`app/main.py`** — Wiring: route registration, model exports, DB singleton export, root endpoint discovery listing
- **`tests/test_intents.py`** — 31 tests: 18 validation unit tests + 13 route integration tests (create success/conflict/validation/unauthorized, list, get found/not-found, delete success/not-found/orphan, list with filters)

## Related Issues

Closes #40