### PR TITLE
feat(api): implement intent reconciliation engine (S-041)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,4 +50,8 @@ class Settings(BaseSettings):
     job_step_image_tag: str = "latest"
 
 
+    # Reconciliation (S-041)
+    reconcile_interval_s: float = 10.0
+
+
 settings = Settings()

--- a/app/config.py
+++ b/app/config.py
@@ -49,7 +49,6 @@ class Settings(BaseSettings):
     job_step_image_registry: str = ""
     job_step_image_tag: str = "latest"
 
-
     # Reconciliation (S-041)
     reconcile_interval_s: float = 10.0
 

--- a/app/database/intents.py
+++ b/app/database/intents.py
@@ -3,7 +3,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import case, select
 
 from app.models.intent import (
     IntentPhase,
@@ -171,6 +171,29 @@ class IntentDB:
             await session.refresh(row)
             return self._row_to_response(row)
 
+    async def list_active_for_reconciliation(self) -> list[IntentResponse]:
+        """List all non-deleted intents, ordered by priority for reconciliation.
+
+        Higher-priority intents (production) are reconciled first so they
+        can claim capacity before lower-priority intents.
+        """
+        async with self._session() as session:
+            stmt = (
+                select(IntentRow)
+                .where(IntentRow.deleted_at.is_(None))
+                .order_by(
+                    case(
+                        (IntentRow.priority == "production", 0),
+                        (IntentRow.priority == "staging", 1),
+                        (IntentRow.priority == "ephemeral", 2),
+                        else_=3,
+                    ),
+                    IntentRow.created_at.asc(),
+                )
+            )
+            result = await session.execute(stmt)
+            return [self._row_to_response(row) for row in result.scalars()]
+
     async def check_alias_conflict(
         self, alias: str, *, exclude_id: str | None = None
     ) -> bool:
@@ -187,6 +210,44 @@ class IntentDB:
             if exclude_id and str(row.id) == exclude_id:
                 return False
             return True
+
+    async def update_status(
+        self,
+        intent_id: str,
+        *,
+        phase: str | None = None,
+        reconcile: str | None = None,
+        status_json: dict[str, Any] | None = None,
+        last_reconciled_at: datetime | None = None,
+        ready_at: datetime | str | None = None,
+    ) -> IntentResponse | None:
+        """Update an intent's status fields atomically.
+
+        Only the provided non-None kwargs are written; all others are
+        left unchanged.  Returns the updated intent or None if the
+        intent is deleted/unknown.
+        """
+        now = datetime.now(timezone.utc)
+        async with self._session() as session:
+            row = await session.get(IntentRow, intent_id)
+            if row is None or row.deleted_at is not None:
+                return None
+            if phase is not None:
+                row.phase = phase
+            if reconcile is not None:
+                row.reconcile = reconcile
+            if status_json is not None:
+                row.status_json = status_json
+            if last_reconciled_at is not None:
+                row.last_reconciled_at = last_reconciled_at
+            if ready_at is not None:
+                if isinstance(ready_at, str):
+                    ready_at = datetime.fromisoformat(ready_at)
+                row.ready_at = ready_at
+            row.updated_at = now
+            await session.commit()
+            await session.refresh(row)
+            return self._row_to_response(row)
 
 
 intent_db = IntentDB()

--- a/app/database/intents.py
+++ b/app/database/intents.py
@@ -160,7 +160,13 @@ class IntentDB:
     async def soft_delete_intent(
         self, intent_id: str, *, orphan: bool = False
     ) -> IntentResponse | None:
-        """Mark an intent as deleted (soft-delete with deleted_at timestamp).
+        """Transition an intent to 'deleting' so the reconciler cleans it up.
+
+        The reconciler (S-041) will stop or disown managed instances, then
+        transition the phase to 'deleted'.  ``deleted_at`` is set by
+        ``update_status()`` once reconciliation confirms zero observed
+        replicas — setting it here would exclude the intent from
+        ``list_active_for_reconciliation()`` and block cleanup.
 
         If *orphan* is True, the reconciler will clear ownership markers
         instead of stopping managed instances.
@@ -171,7 +177,6 @@ class IntentDB:
             if row is None or row.deleted_at is not None:
                 return None
             row.phase = "deleting"
-            row.deleted_at = now
             row.updated_at = now
             # Store orphan flag in metadata so the reconciler can read it
             if orphan:
@@ -236,15 +241,25 @@ class IntentDB:
 
         Only the provided non-None kwargs are written; all others are
         left unchanged.  Returns the updated intent or None if the
-        intent is deleted/unknown.
+        intent is unknown or has already been soft-deleted.
+
+        When *phase* transitions to ``"deleted"``, ``deleted_at`` is set
+        automatically so ``list_active_for_reconciliation()`` excludes
+        the intent from future reconciliation passes.
         """
         now = datetime.now(timezone.utc)
         async with self._session() as session:
             row = await session.get(IntentRow, intent_id)
-            if row is None or row.deleted_at is not None:
+            if row is None:
+                return None
+            # Once soft-deleted, status updates are rejected
+            if row.deleted_at is not None:
                 return None
             if phase is not None:
                 row.phase = phase
+                # Auto-soft-delete when the reconciler confirms cleanup
+                if phase == "deleted":
+                    row.deleted_at = now
             if reconcile is not None:
                 row.reconcile = reconcile
             if status_json is not None:

--- a/app/database/intents.py
+++ b/app/database/intents.py
@@ -157,8 +157,14 @@ class IntentDB:
             result = await session.execute(stmt)
             return [self._row_to_response(row) for row in result.scalars()]
 
-    async def soft_delete_intent(self, intent_id: str) -> IntentResponse | None:
-        """Mark an intent as deleted (soft-delete with deleted_at timestamp)."""
+    async def soft_delete_intent(
+        self, intent_id: str, *, orphan: bool = False
+    ) -> IntentResponse | None:
+        """Mark an intent as deleted (soft-delete with deleted_at timestamp).
+
+        If *orphan* is True, the reconciler will clear ownership markers
+        instead of stopping managed instances.
+        """
         now = datetime.now(timezone.utc)
         async with self._session() as session:
             row = await session.get(IntentRow, intent_id)
@@ -167,6 +173,11 @@ class IntentDB:
             row.phase = "deleting"
             row.deleted_at = now
             row.updated_at = now
+            # Store orphan flag in metadata so the reconciler can read it
+            if orphan:
+                meta = dict(row.metadata_ or {})
+                meta["orphan"] = "true"
+                row.metadata_ = meta
             await session.commit()
             await session.refresh(row)
             return self._row_to_response(row)

--- a/app/main.py
+++ b/app/main.py
@@ -59,6 +59,12 @@ async def lifespan(app: FastAPI):
     # Start gateway background tasks (registry refresh + health probes)
     await gateway.start_background_tasks()
 
+    # Start reconciliation engine (S-041)
+    from app.services.reconciliation import reconciler
+
+    await reconciler.start()
+    logger.info("Reconciliation engine started")
+
     logger.info("Solar Control started successfully")
 
     yield
@@ -74,6 +80,11 @@ async def lifespan(app: FastAPI):
         await gateway_logger.stop()
     except Exception as e:
         logger.error("Error stopping gateway logger: %s", e)
+
+    try:
+        await reconciler.stop()
+    except Exception as e:
+        logger.error("Error stopping reconciler: %s", e)
 
     await close_redis()
     await close_db()

--- a/app/routes/management/intents.py
+++ b/app/routes/management/intents.py
@@ -64,6 +64,10 @@ async def create_intent(request: Request, body: IntentCreate) -> IntentResponse:
     )
 
     logger.info("Intent created: id=%s alias=%s", intent.id, intent.alias)
+    # Wake reconciler to process the new intent immediately
+    from app.services.reconciliation import reconciler
+
+    reconciler.wake()
     return intent
 
 
@@ -117,6 +121,10 @@ async def delete_intent(
     logger.info(
         "Intent deleted: id=%s alias=%s orphan=%s", intent_id, intent.alias, orphan
     )
+    # Wake reconciler to process the deletion immediately
+    from app.services.reconciliation import reconciler
+
+    reconciler.wake()
     return IntentDeletedResponse(
         id=intent.id,
         alias=intent.alias,

--- a/app/routes/management/intents.py
+++ b/app/routes/management/intents.py
@@ -114,7 +114,7 @@ async def delete_intent(
     Marks the intent as 'deleting'. The S-041 reconciler will stop
     managed instances (or orphan them if ?orphan=true).
     """
-    intent = await intent_db.soft_delete_intent(intent_id)
+    intent = await intent_db.soft_delete_intent(intent_id, orphan=orphan)
     if intent is None:
         raise HTTPException(status_code=404, detail="Intent not found")
 

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -134,16 +134,12 @@ class Reconciler:
             r = redis_client()
             acquired = await r.set(lock_key, "1", nx=True, ex=_LOCK_TTL)
             if not acquired:
-                logger.debug(
-                    "Intent %s locked by another replica, skipping", intent.id
-                )
+                logger.debug("Intent %s locked by another replica, skipping", intent.id)
                 continue
             try:
                 await self._reconcile_one(intent)
             except Exception:
-                logger.exception(
-                    "Reconciliation failed for intent %s", intent.id
-                )
+                logger.exception("Reconciliation failed for intent %s", intent.id)
             finally:
                 await r.delete(lock_key)
 
@@ -418,6 +414,8 @@ class Reconciler:
                         )
                     )
 
+        # Sort by priority so stops execute before creates
+        actions.sort(key=lambda a: a.priority)
         return actions
 
     # ── Act ────────────────────────────────────────────────────
@@ -445,9 +443,7 @@ class Reconciler:
                 return None
             host = await host_db.get_host(action.host_id)
             if host is None:
-                logger.warning(
-                    "Host %s not found for stop action", action.host_id
-                )
+                logger.warning("Host %s not found for stop action", action.host_id)
                 return None
             logger.info(
                 "Stopping instance %s on %s (reason: %s)",
@@ -463,9 +459,7 @@ class Reconciler:
                 return None
             host = await host_db.get_host(action.host_id)
             if host is None:
-                logger.warning(
-                    "Host %s not found for create action", action.host_id
-                )
+                logger.warning("Host %s not found for create action", action.host_id)
                 return None
 
             instance_config = self._build_instance_config(intent, host)

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -714,6 +714,13 @@ class Reconciler:
                 action.reason,
             )
             result = await create_instance_on_host(host, instance_config)
+            # The host wraps the response in {"instance": {...}};
+            # extract the instance and start it (host creates in stopped state).
+            created = result.get("instance", result)
+            instance_id = created.get("id") or created.get("instance_id")
+            if instance_id:
+                logger.info("Starting instance %s on %s", instance_id, host.name)
+                await self._start_instance(host, instance_id)
             return result
 
         if action.type == ActionType.REPLACE:
@@ -817,6 +824,38 @@ class Reconciler:
 
         return None
 
+    # ── Start instance ──────────────────────────────────────────
+
+    async def _start_instance(self, host: Any, instance_id: str) -> None:
+        """Start a stopped instance on *host* via POST /instances/{id}/start."""
+        import aiohttp
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{host.url.rstrip('/')}/instances/{instance_id}/start"
+                headers = {"X-API-Key": host.api_key}
+                async with session.post(
+                    url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=30),
+                ) as resp:
+                    if resp.status != 200:
+                        text = await resp.text()
+                        logger.warning(
+                            "Failed to start instance %s on %s: HTTP %s %s",
+                            instance_id,
+                            host.name,
+                            resp.status,
+                            text,
+                        )
+        except Exception as e:
+            logger.warning(
+                "Failed to start instance %s on %s: %s",
+                instance_id,
+                host.name,
+                e,
+            )
+
     # ── Build instance config ──────────────────────────────────
 
     def _build_instance_config(self, intent: Any, host: Any) -> dict[str, Any]:
@@ -824,14 +863,14 @@ class Reconciler:
 
         Implements deployment-intent.md §6 mapping: alias, model_source,
         priority, managed_by, intent_id, plus backend runtime params.
+
+        The host expects ``managed_by``, ``intent_id``, and ``priority``
+        at the TOP LEVEL (outside ``config``), matching the Instance model.
         """
         config: dict[str, Any] = {
             "backend_type": intent.backend.get("backend_type", "llamacpp"),
             "alias": intent.alias,
             "model_source": intent.model_source,
-            "priority": intent.priority,
-            "managed_by": "intent",
-            "intent_id": intent.id,
         }
 
         # Copy backend runtime params, excluding backend_type (already set)
@@ -840,7 +879,12 @@ class Reconciler:
                 continue
             config[key] = value
 
-        return {"config": config}
+        return {
+            "config": config,
+            "managed_by": "intent",
+            "intent_id": intent.id,
+            "priority": intent.priority,
+        }
 
     # ── Update status ──────────────────────────────────────────
 

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -637,12 +637,18 @@ class Reconciler:
             return None
 
         if action.type == ActionType.DISOWN:
-            # Clear ownership markers so the instance becomes unmanaged
+            # Clear ownership markers from the instance in Redis so the
+            # reconciler stops tracking it.  The underlying Solar Host
+            # instance config retains the markers (there is no host-side
+            # PATCH for running instances), but the stale reference is
+            # harmless: the intent is being deleted and will not be
+            # reconciled again.
             if not action.host_id or not action.instance_id:
                 return None
             from app.redis_state import host_store as _hs
 
             instances = await _hs.get_host_instances(action.host_id)
+            found = False
             for inst in instances:
                 iid = inst.get("instance_id") or inst.get("id")
                 if iid == action.instance_id:
@@ -653,7 +659,10 @@ class Reconciler:
                         inst["config"] = cfg
                     inst.pop("managed_by", None)
                     inst.pop("intent_id", None)
+                    found = True
                     break
+            if found:
+                await _hs.set_host_instances(action.host_id, instances)
             logger.info(
                 "Disowned instance %s on host %s (reason: %s)",
                 action.instance_id,

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -39,6 +39,8 @@ class ActionType:
     STOP = "stop"
     REPLACE = "replace"
     RECREATE = "recreate"
+    MIGRATE = "migrate"
+    DISOWN = "disown"
     NOOP = "noop"
 
 
@@ -51,9 +53,16 @@ class Action:
     alias: str
     host_id: str | None = None
     host_name: str | None = None
-    instance_id: str | None = None  # for stop / replace / recreate
+    instance_id: str | None = None  # for stop / replace / recreate / migrate / disown
+    target_host_id: str | None = None  # for migrate: where to move the instance
+    target_host_name: str | None = None  # for migrate
     reason: str = ""
     priority: int = 0  # lower executes first (stops before creates)
+
+
+# Exponential backoff bounds (seconds)
+_BACKOFF_MIN_S = 10
+_BACKOFF_MAX_S = 300
 
 
 # ── Reconciler ─────────────────────────────────────────────────
@@ -66,6 +75,8 @@ class Reconciler:
         self._task: asyncio.Task[None] | None = None
         self._wake_event = asyncio.Event()
         self._running = False
+        # Per-intent exponential backoff: {intent_id: {"failures": N, "next_retry_at": iso}}
+        self._backoff: dict[str, dict[str, Any]] = {}
 
     # ── Lifecycle ──────────────────────────────────────────────
 
@@ -95,6 +106,43 @@ class Reconciler:
     def wake(self) -> None:
         """Trigger an immediate reconciliation pass (event-driven)."""
         self._wake_event.set()
+
+    # ── Backoff ────────────────────────────────────────────────
+
+    def _backoff_clear(self, intent_id: str) -> None:
+        """Clear backoff state for *intent_id* after a successful tick."""
+        self._backoff.pop(intent_id, None)
+
+    def _backoff_record_failure(self, intent_id: str) -> None:
+        """Record a failure and set the next retry time with exponential backoff."""
+        now = datetime.now(timezone.utc)
+        entry = self._backoff.get(intent_id, {"failures": 0})
+        entry["failures"] = entry.get("failures", 0) + 1
+        delay = min(_BACKOFF_MIN_S * (2 ** (entry["failures"] - 1)), _BACKOFF_MAX_S)
+        entry["next_retry_at"] = (
+            datetime.fromtimestamp(now.timestamp() + delay, tz=timezone.utc)
+        ).isoformat()
+        self._backoff[intent_id] = entry
+        logger.debug(
+            "Backoff for intent %s: failures=%d delay=%.0fs",
+            intent_id,
+            entry["failures"],
+            delay,
+        )
+
+    def _backoff_active(self, intent_id: str) -> bool:
+        """Return True if backoff is active and retry should be skipped."""
+        entry = self._backoff.get(intent_id)
+        if not entry:
+            return False
+        next_retry = entry.get("next_retry_at")
+        if not next_retry:
+            return False
+        try:
+            retry_at = datetime.fromisoformat(next_retry)
+            return datetime.now(timezone.utc) < retry_at
+        except (ValueError, TypeError):
+            return False
 
     # ── Main loop ──────────────────────────────────────────────
 
@@ -150,6 +198,11 @@ class Reconciler:
 
         Implements deployment-intent.md §8.1 reconciliation loop.
         """
+        # Check backoff before acting
+        if self._backoff_active(intent.id):
+            logger.debug("Intent %s in backoff, skipping", intent.id)
+            return
+
         # 1. Observe
         observed = await self._observe(intent)
 
@@ -174,11 +227,13 @@ class Reconciler:
         )
 
         last_error = None
+        action_succeeded = False
         try:
             result = await self._act(intent, action)
+            action_succeeded = True
 
-            # If we created an instance, re-observe for fresh state
-            if action.type == ActionType.CREATE and result:
+            # If we created/migrated, re-observe for fresh state
+            if action.type in (ActionType.CREATE, ActionType.MIGRATE) and result:
                 await asyncio.sleep(0.5)
                 observed = await self._observe(intent)
         except Exception as e:
@@ -196,6 +251,12 @@ class Reconciler:
                 "at": datetime.now(timezone.utc).isoformat(),
             }
 
+        # Update backoff state
+        if action_succeeded and last_error is None:
+            self._backoff_clear(intent.id)
+        elif last_error is not None:
+            self._backoff_record_failure(intent.id)
+
         # 4. Update status
         await self._update_status(intent, observed, last_error=last_error)
 
@@ -207,13 +268,17 @@ class Reconciler:
         Returns a dict with:
             managed_instances: instances with managed_by='intent' and intent_id==intent.id
             alias_instances: ALL instances serving this alias (managed + manual)
+            manual_conflicts: manual instances serving this alias
             hosts: list of Host models
             snapshots: dict[host_id, HostResourceSnapshot]
             gateway_aliases: set of aliases registered in gateway
+            candidates: list of (Host, snapshot) pairs from shared placement policy
+            displaceable_map: dict[host_id, list[dict]] of displaceable instances
         """
         from app.database.hosts import host_db
         from app.redis_state import host_store, registry_store
         from app.routes.management.resources import _fetch_host_resource_snapshot
+        from app.services.placement import find_candidates, find_displaceable_instances
 
         alias = intent.alias
 
@@ -227,6 +292,7 @@ class Reconciler:
         # 2. Collect all instances for this alias across all hosts
         managed_instances: list[dict[str, Any]] = []
         alias_instances: list[dict[str, Any]] = []
+        manual_conflicts: list[dict[str, Any]] = []
         for host in hosts:
             instances = await host_store.get_host_instances(host.id)
             for inst in instances:
@@ -244,6 +310,9 @@ class Reconciler:
                 intent_id = cfg.get("intent_id") or inst.get("intent_id")
                 if managed_by == "intent" and intent_id == intent.id:
                     managed_instances.append(inst)
+                elif managed_by != "intent" or intent_id != intent.id:
+                    # Manual instance or owned by a different intent
+                    manual_conflicts.append(inst)
 
         # 3. Gateway registry — which aliases are registered?
         gateway_aliases: set[str] = set()
@@ -254,12 +323,74 @@ class Reconciler:
         except Exception:
             logger.warning("Failed to read gateway registry", exc_info=True)
 
+        # 4. Compute placement candidates using shared policy (§8.4)
+        placement = intent.placement
+        resources = intent.resources
+        req_vram = (
+            float(resources.vram_gb or 0) if hasattr(resources, "vram_gb") else 0.0
+        )
+        req_ram = (
+            float(resources.ram_gb)
+            if hasattr(resources, "ram_gb") and resources.ram_gb
+            else None
+        )
+        req_roles = list(placement.roles) if placement.roles else ["inference"]
+        req_gpu = (
+            placement.gpu_type
+            if hasattr(placement, "gpu_type") and placement.gpu_type
+            else None
+        )
+        req_allow = (
+            list(placement.host_allow)
+            if hasattr(placement, "host_allow") and placement.host_allow
+            else None
+        )
+        req_deny = (
+            list(placement.host_deny)
+            if hasattr(placement, "host_deny") and placement.host_deny
+            else None
+        )
+
+        candidates = await find_candidates(
+            hosts,
+            snapshots,
+            roles=req_roles,
+            gpu_type=req_gpu,
+            host_allow=req_allow,
+            host_deny=req_deny,
+            vram_gb=req_vram,
+            ram_gb=req_ram,
+            exclude_alias=alias,
+        )
+
+        # 5. Compute displaceable instances per host (for displacement evaluation)
+        displaceable_map: dict[str, list[dict[str, Any]]] = {}
+        intent_priority = intent.priority
+        candidate_host_ids = {h.id for h, _ in candidates}
+        for host in hosts:
+            if host.id in candidate_host_ids or host.status != "online":
+                continue
+            # Check if host has right roles/GPU (basic pre-filter)
+            host_roles = host.roles or []
+            if not all(r in host_roles for r in req_roles):
+                continue
+            if req_gpu and host.gpu_type != req_gpu:
+                continue
+            displaced = await find_displaceable_instances(
+                host.id, intent_priority, preserve_alias=alias
+            )
+            if displaced:
+                displaceable_map[host.id] = displaced
+
         return {
             "managed_instances": managed_instances,
             "alias_instances": alias_instances,
+            "manual_conflicts": manual_conflicts,
             "hosts": hosts,
             "snapshots": snapshots,
             "gateway_aliases": gateway_aliases,
+            "candidates": candidates,
+            "displaceable_map": displaceable_map,
         }
 
     # ── Diff ───────────────────────────────────────────────────
@@ -272,20 +403,35 @@ class Reconciler:
         """Compare desired vs observed state and produce actions.
 
         Implements deployment-intent.md §8.2 diff and actions table.
+        Uses shared placement policy candidates and evaluates
+        priority-aware displacement when capacity is insufficient.
         """
         desired = intent.replicas
         managed = observed["managed_instances"]
-        alias_instances = observed["alias_instances"]
-        hosts = observed["hosts"]
+        is_orphan = _intent_orphan(intent)
 
         observed_count = len(managed)
         actions: list[Action] = []
 
-        # ── Deleting intent: stop all managed instances ──────────
-        if intent.status.phase.value == "deleting":
+        # ── Deleting intent ──────────────────────────────────────
+        if _intent_phase(intent) == "deleting":
             for inst in managed:
                 inst_id = inst.get("instance_id") or inst.get("id")
-                if inst_id:
+                if not inst_id:
+                    continue
+                if is_orphan:
+                    actions.append(
+                        Action(
+                            type=ActionType.DISOWN,
+                            intent_id=intent.id,
+                            alias=intent.alias,
+                            host_id=inst.get("_host_id"),
+                            instance_id=inst_id,
+                            reason="Intent deleted (orphan)",
+                            priority=1,
+                        )
+                    )
+                else:
                     actions.append(
                         Action(
                             type=ActionType.STOP,
@@ -317,13 +463,15 @@ class Reconciler:
                     )
             return actions
 
-        # ── Check for drift (model_source change) ────────────────
+        # ── Check for drift (model_source + backend config) ──────
         for inst in managed:
             cfg = inst.get("config", inst)
             inst_source = cfg.get("model_source") or inst.get("model_source")
             inst_id = inst.get("instance_id") or inst.get("id")
+            has_source_drift = inst_source and inst_source != intent.model_source
+            has_backend_drift = _detect_backend_drift(intent, cfg)
 
-            if inst_source and inst_source != intent.model_source:
+            if has_source_drift:
                 actions.append(
                     Action(
                         type=ActionType.REPLACE,
@@ -335,6 +483,18 @@ class Reconciler:
                             f"model_source drift: {inst_source} → "
                             f"{intent.model_source}"
                         ),
+                        priority=20,
+                    )
+                )
+            elif has_backend_drift and not has_source_drift:
+                actions.append(
+                    Action(
+                        type=ActionType.REPLACE,
+                        intent_id=intent.id,
+                        alias=intent.alias,
+                        host_id=inst.get("_host_id"),
+                        instance_id=inst_id,
+                        reason="backend config drift",
                         priority=20,
                     )
                 )
@@ -358,24 +518,12 @@ class Reconciler:
                         )
                     )
 
-        # ── Observed < Desired → CREATE ──────────────────────────
+        # ── Observed < Desired → CREATE (placement policy) ───────
         shortfall = desired - observed_count
         if shortfall > 0:
-            # Build set of hosts already serving this alias (one-replica-per-host)
-            occupied_host_ids: set[str] = set()
-            for inst in alias_instances:
-                hid = inst.get("_host_id")
-                if hid:
-                    occupied_host_ids.add(hid)
-
-            eligible = [
-                h
-                for h in hosts
-                if h.id not in occupied_host_ids and h.status == "online"
-            ]
-
-            for i in range(min(shortfall, len(eligible))):
-                host = eligible[i]
+            candidates = observed.get("candidates", [])
+            for i in range(min(shortfall, len(candidates))):
+                host, _snap = candidates[i]
                 actions.append(
                     Action(
                         type=ActionType.CREATE,
@@ -387,6 +535,40 @@ class Reconciler:
                         priority=50,
                     )
                 )
+
+            # If still short, evaluate priority-aware displacement (§8.5)
+            remaining = shortfall - min(shortfall, len(candidates))
+            if remaining > 0:
+                displaceable_map = observed.get("displaceable_map", {})
+                for host_id, displaceable_list in displaceable_map.items():
+                    if remaining <= 0:
+                        break
+                    if not displaceable_list:
+                        continue
+                    inst = displaceable_list[0]
+                    inst_id = inst.get("instance_id") or inst.get("id", "")
+                    inst_alias = inst.get("config", inst).get("alias") or inst.get(
+                        "alias", ""
+                    )
+                    if not inst_id:
+                        continue
+                    actions.append(
+                        Action(
+                            type=ActionType.MIGRATE,
+                            intent_id=intent.id,
+                            alias=inst_alias,
+                            host_id=host_id,
+                            instance_id=inst_id,
+                            reason=(
+                                f"Displacing {inst_alias} "
+                                f"({inst.get('_priority', '?')}) "
+                                f"to free capacity for {intent.alias} "
+                                f"({intent.priority})"
+                            ),
+                            priority=25,
+                        )
+                    )
+                    remaining -= 1
 
         # ── Observed > Desired → STOP surplus ────────────────────
         surplus = observed_count - desired
@@ -414,7 +596,7 @@ class Reconciler:
                         )
                     )
 
-        # Sort by priority so stops execute before creates
+        # Sort by priority so stops/disowns execute before migrates/creates
         actions.sort(key=lambda a: a.priority)
         return actions
 
@@ -452,6 +634,32 @@ class Reconciler:
                 action.reason,
             )
             await stop_source_instance(host, action.instance_id)
+            return None
+
+        if action.type == ActionType.DISOWN:
+            # Clear ownership markers so the instance becomes unmanaged
+            if not action.host_id or not action.instance_id:
+                return None
+            from app.redis_state import host_store as _hs
+
+            instances = await _hs.get_host_instances(action.host_id)
+            for inst in instances:
+                iid = inst.get("instance_id") or inst.get("id")
+                if iid == action.instance_id:
+                    cfg = inst.get("config", inst)
+                    if isinstance(cfg, dict):
+                        cfg.pop("managed_by", None)
+                        cfg.pop("intent_id", None)
+                        inst["config"] = cfg
+                    inst.pop("managed_by", None)
+                    inst.pop("intent_id", None)
+                    break
+            logger.info(
+                "Disowned instance %s on host %s (reason: %s)",
+                action.instance_id,
+                action.host_id,
+                action.reason,
+            )
             return None
 
         if action.type == ActionType.CREATE:
@@ -498,6 +706,67 @@ class Reconciler:
                     )
                     await stop_source_instance(host, action.instance_id)
             return None
+
+        if action.type == ActionType.MIGRATE:
+            # Migrate = use S-037 to move instance off this host, freeing capacity
+            if not action.instance_id or not action.host_id:
+                return None
+            from app.services.placement import find_candidates
+            from app.services.migration import execute_migration
+            from app.routes.management.resources import _fetch_host_resource_snapshot
+
+            # Select a target host using placement policy
+            all_hosts = await host_db.get_all_hosts()
+            snapshots_list = await asyncio.gather(
+                *[_fetch_host_resource_snapshot(h) for h in all_hosts]
+            )
+            snapshots_map = {s.host_id: s for s in snapshots_list}
+
+            target_candidates = await find_candidates(
+                all_hosts,
+                snapshots_map,
+                roles=["inference"],
+                vram_gb=0.0,
+                exclude_alias=action.alias,
+            )
+            # Exclude the source host from candidates
+            target_candidates = [
+                (h, s) for h, s in target_candidates if h.id != action.host_id
+            ]
+
+            if not target_candidates:
+                logger.warning(
+                    "No migration target found for instance %s (alias=%s)",
+                    action.instance_id,
+                    action.alias,
+                )
+                return None
+
+            target_host, _tsnap = target_candidates[0]
+            logger.info(
+                "Migrating instance %s (%s) from %s to %s (reason: %s)",
+                action.instance_id,
+                action.alias,
+                action.host_id,
+                target_host.name,
+                action.reason,
+            )
+            try:
+                result = await execute_migration(
+                    instance_id=action.instance_id,
+                    source_host_id=action.host_id,
+                    target_host_id=target_host.id,
+                    allow_production=False,
+                )
+                return {"migration_id": result.migration_id, "status": result.status}
+            except Exception:
+                logger.exception(
+                    "Migration failed for instance %s: %s → %s",
+                    action.instance_id,
+                    action.host_id,
+                    target_host.id,
+                )
+                raise
 
         return None
 
@@ -629,6 +898,29 @@ class Reconciler:
                 ).model_dump()
             )
 
+        # Conflict condition for manual instances (§5.3)
+        manual_conflicts = observed.get("manual_conflicts", [])
+        if manual_conflicts:
+            conflict_hosts = sorted(
+                {
+                    m.get("_host_name") or m.get("_host_id", "?")
+                    for m in manual_conflicts
+                }
+            )
+            conditions.append(
+                Condition(
+                    type="Conflict",
+                    status=True,
+                    reason="ManualInstanceConflict",
+                    message=(
+                        f"Manual instance(s) serving '{alias}' on host(s): "
+                        f"{', '.join(conflict_hosts[:5])}"
+                        f"{'...' if len(conflict_hosts) > 5 else ''}"
+                    ),
+                    last_transition=now_iso,
+                ).model_dump()
+            )
+
         # Build last_error
         last_error_model = None
         if last_error:
@@ -641,12 +933,18 @@ class Reconciler:
             )
 
         # Build status_json
+        # Shortfall = desired - placeable (accounting for displacement candidates)
+        candidates = observed.get("candidates", [])
+        displaceable_map = observed.get("displaceable_map", {})
+        placeable = len(candidates) + len(displaceable_map)
+        structural_shortfall = max(0, desired - observed_count - placeable)
+
         status_json = {
             "observed_replicas": observed_count,
             "ready_replicas": ready_count,
             "updated_replicas": updated_count,
             "available": ready_count >= 1,
-            "shortfall": max(0, desired - observed_count),
+            "shortfall": structural_shortfall,
             "replica_set": replica_set,
             "conditions": conditions,
             "strategy_progress": None,
@@ -678,6 +976,53 @@ class Reconciler:
             last_reconciled_at=now,
             ready_at=ready_at,
         )
+
+
+# ── Helpers ────────────────────────────────────────────────────
+
+
+def _intent_phase(intent: Any) -> str:
+    """Safely extract the intent phase as a string."""
+    try:
+        return intent.status.phase.value
+    except (AttributeError, TypeError):
+        return str(getattr(intent, "phase", "pending"))
+
+
+def _intent_orphan(intent: Any) -> bool:
+    """Check if the intent was deleted with orphan=true."""
+    try:
+        return intent.metadata.get("orphan") == "true"
+    except (AttributeError, TypeError):
+        return False
+
+
+def _detect_backend_drift(intent: Any, instance_config: dict[str, Any]) -> bool:
+    """Check if the instance's backend config has drifted from the intent.
+
+    Compares the intent's backend fields (excluding identity/server-derived
+    fields) against the instance config for the same keys.
+    """
+    intent_backend = intent.backend if isinstance(intent.backend, dict) else {}
+    _skip_keys = {
+        "backend_type",
+        "alias",
+        "model_source",
+        "host",
+        "port",
+        "api_key",
+        "managed_by",
+        "intent_id",
+        "model",
+        "model_id",
+    }
+    for key, value in intent_backend.items():
+        if key in _skip_keys:
+            continue
+        inst_value = instance_config.get(key)
+        if inst_value != value:
+            return True
+    return False
 
 
 # Singleton

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -1,0 +1,268 @@
+"""Intent reconciliation engine (S-041).
+
+Level-triggered reconciliation loop that compares desired state
+(intents) with observed state (instances + gateway registry) and
+converges the cluster by creating, stopping, and migrating instances.
+
+Design:
+- Periodic tick (configurable interval) + event-driven wake-ups.
+- Per-intent Redis lock prevents concurrent reconciliation from
+  multiple Solar Control replicas.
+- Reuses shared placement policy (app.services.placement) and
+  migration orchestrator (app.services.migration).
+- Stateless/restart-safe: recomputes managed(I) from observed state
+  on every pass; never trusts memory alone.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.config import settings
+from app.redis_state.connection import redis_client
+
+logger = logging.getLogger(__name__)
+
+# Per-intent lock key prefix and TTL.
+# _LOCK_TTL auto-expires so a crashed reconciler doesn't block forever.
+_LOCK_PREFIX = "solar:reconcile:lock:"
+_LOCK_TTL = 30
+
+
+# ── Action model ───────────────────────────────────────────────
+
+
+class ActionType:
+    CREATE = "create"
+    STOP = "stop"
+    REPLACE = "replace"
+    RECREATE = "recreate"
+    NOOP = "noop"
+
+
+@dataclass
+class Action:
+    """A single reconciliation action to execute on a host."""
+
+    type: str
+    intent_id: str
+    alias: str
+    host_id: str | None = None
+    host_name: str | None = None
+    instance_id: str | None = None  # for stop / replace / recreate
+    reason: str = ""
+    priority: int = 0  # lower executes first (stops before creates)
+
+
+# ── Reconciler ─────────────────────────────────────────────────
+
+
+class Reconciler:
+    """Periodic + event-driven intent reconciliation engine."""
+
+    def __init__(self) -> None:
+        self._task: asyncio.Task[None] | None = None
+        self._wake_event = asyncio.Event()
+        self._running = False
+
+    # ── Lifecycle ──────────────────────────────────────────────
+
+    async def start(self) -> None:
+        """Start the background reconciliation loop."""
+        if self._running:
+            return
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "Reconciler started (interval=%.1fs)", settings.reconcile_interval_s
+        )
+
+    async def stop(self) -> None:
+        """Stop the background reconciliation loop."""
+        self._running = False
+        self._wake_event.set()  # unblock any sleep
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Reconciler stopped")
+
+    def wake(self) -> None:
+        """Trigger an immediate reconciliation pass (event-driven)."""
+        self._wake_event.set()
+
+    # ── Main loop ──────────────────────────────────────────────
+
+    async def _loop(self) -> None:
+        """Main loop: sleep → reconcile → repeat."""
+        while self._running:
+            try:
+                await self._reconcile_all()
+            except Exception:
+                logger.exception("Reconciliation pass failed")
+
+            # Wait for the next interval or an event-driven wake-up
+            try:
+                self._wake_event.clear()
+                await asyncio.wait_for(
+                    self._wake_event.wait(),
+                    timeout=settings.reconcile_interval_s,
+                )
+            except asyncio.TimeoutError:
+                pass  # interval elapsed — normal
+
+    async def _reconcile_all(self) -> None:
+        """Fetch all active intents and reconcile each one."""
+        from app.database.intents import intent_db
+
+        intents = await intent_db.list_active_for_reconciliation()
+        if not intents:
+            return
+
+        logger.debug("Reconciling %d active intent(s)", len(intents))
+        for intent in intents:
+            if not self._running:
+                break
+
+            # Acquire per-intent lock to avoid concurrent reconciliation
+            lock_key = f"{_LOCK_PREFIX}{intent.id}"
+            r = redis_client()
+            acquired = await r.set(lock_key, "1", nx=True, ex=_LOCK_TTL)
+            if not acquired:
+                logger.debug(
+                    "Intent %s locked by another replica, skipping", intent.id
+                )
+                continue
+            try:
+                await self._reconcile_one(intent)
+            except Exception:
+                logger.exception(
+                    "Reconciliation failed for intent %s", intent.id
+                )
+            finally:
+                await r.delete(lock_key)
+
+    # ── Per-intent reconciliation ──────────────────────────────
+
+    async def _reconcile_one(self, intent: Any) -> None:
+        """Reconcile a single intent.  To be implemented in later tasks."""
+        pass
+
+    # ── Observe ────────────────────────────────────────────────
+
+    async def _observe(self, intent: Any) -> dict[str, Any]:
+        """Collect observed state for *intent*.
+
+        Returns a dict with:
+            managed_instances: instances with managed_by='intent' and intent_id==intent.id
+            alias_instances: ALL instances serving this alias (managed + manual)
+            hosts: list of Host models
+            snapshots: dict[host_id, HostResourceSnapshot]
+            gateway_aliases: set of aliases registered in gateway
+        """
+        from app.database.hosts import host_db
+        from app.redis_state import host_store, registry_store
+        from app.routes.management.resources import _fetch_host_resource_snapshot
+
+        alias = intent.alias
+
+        # 1. Fetch all hosts and resource snapshots
+        hosts = await host_db.get_all_hosts()
+        snapshots_list = await asyncio.gather(
+            *[_fetch_host_resource_snapshot(h) for h in hosts]
+        )
+        snapshots: dict[str, Any] = {s.host_id: s for s in snapshots_list}
+
+        # 2. Collect all instances for this alias across all hosts
+        managed_instances: list[dict[str, Any]] = []
+        alias_instances: list[dict[str, Any]] = []
+        for host in hosts:
+            instances = await host_store.get_host_instances(host.id)
+            for inst in instances:
+                cfg = inst.get("config", inst)
+                inst_alias = cfg.get("alias") or inst.get("alias")
+                if inst_alias != alias:
+                    continue
+                # Annotate with host context
+                inst["_host_id"] = host.id
+                inst["_host_name"] = host.name
+                alias_instances.append(inst)
+
+                # Owned by this intent?
+                managed_by = cfg.get("managed_by") or inst.get("managed_by")
+                intent_id = cfg.get("intent_id") or inst.get("intent_id")
+                if managed_by == "intent" and intent_id == intent.id:
+                    managed_instances.append(inst)
+
+        # 3. Gateway registry — which aliases are registered?
+        gateway_aliases: set[str] = set()
+        try:
+            registry = await registry_store.get_registry()
+            if isinstance(registry, dict):
+                gateway_aliases = set(registry.keys())
+        except Exception:
+            logger.warning("Failed to read gateway registry", exc_info=True)
+
+        return {
+            "managed_instances": managed_instances,
+            "alias_instances": alias_instances,
+            "hosts": hosts,
+            "snapshots": snapshots,
+            "gateway_aliases": gateway_aliases,
+        }
+
+    # ── Diff ───────────────────────────────────────────────────
+
+    def _diff(
+        self,
+        intent: Any,
+        observed: dict[str, Any],
+    ) -> list[Action]:
+        """Compare desired vs observed state and produce actions.
+
+        Implements deployment-intent.md §8.2 diff and actions table.
+        """
+        raise NotImplementedError("_diff will be implemented in Task 6")
+
+    # ── Act ────────────────────────────────────────────────────
+
+    async def _act(
+        self,
+        intent: Any,
+        action: Action,
+    ) -> dict[str, Any] | None:
+        """Execute one reconciliation action via Solar Host primitives."""
+        raise NotImplementedError("_act will be implemented in Task 7")
+
+    # ── Build instance config ──────────────────────────────────
+
+    def _build_instance_config(self, intent: Any, host: Any) -> dict[str, Any]:
+        """Compose a Solar Host InstanceConfig from the intent.
+
+        Implements deployment-intent.md §6 mapping.
+        """
+        raise NotImplementedError(
+            "_build_instance_config will be implemented in Task 7"
+        )
+
+    # ── Update status ──────────────────────────────────────────
+
+    async def _update_status(
+        self,
+        intent: Any,
+        observed: dict[str, Any],
+        last_error: dict[str, Any] | None = None,
+    ) -> None:
+        """Compute and persist the intent status after reconciliation.
+
+        Implements deployment-intent.md §10.2 status fields.
+        """
+        raise NotImplementedError("_update_status will be implemented in Task 8")
+
+
+# Singleton
+reconciler = Reconciler()

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -367,8 +367,28 @@ class Reconciler:
         displaceable_map: dict[str, list[dict[str, Any]]] = {}
         intent_priority = intent.priority
         candidate_host_ids = {h.id for h, _ in candidates}
+        # Pre-collect hosts with active training jobs (non-displaceable per §8.5)
+        hosts_with_active_jobs: set[str] = set()
+        try:
+            from app.database.jobs import job_db
+            from app.models.job import JobStatus
+
+            for host in hosts:
+                jobs = await job_db.get_jobs_by_host(host.id)
+                if any(
+                    j.status in (JobStatus.PENDING, JobStatus.RUNNING) for j in jobs
+                ):
+                    hosts_with_active_jobs.add(host.id)
+        except Exception:
+            logger.warning(
+                "Failed to query active training jobs for displacement pre-filter",
+                exc_info=True,
+            )
         for host in hosts:
             if host.id in candidate_host_ids or host.status != "online":
+                continue
+            # Skip hosts with active training jobs (§8.5)
+            if host.id in hosts_with_active_jobs:
                 continue
             # Check if host has right roles/GPU (basic pre-filter)
             host_roles = host.roles or []
@@ -1003,6 +1023,29 @@ class Reconciler:
             last_reconciled_at=now,
             ready_at=ready_at,
         )
+
+        # ── Emit Socket.IO events for live WebUI updates (§10.4) ──
+        try:
+            from app.socketio_app import sio
+
+            # Fetch the updated intent so the event carries the full record
+            updated = await intent_db.get_intent(intent.id)
+            if updated:
+                await sio.emit(
+                    "intent_update",
+                    updated.model_dump(),
+                    namespace="/webui",
+                )
+                if phase == IntentPhase.DELETED:
+                    await sio.emit(
+                        "intent_removed",
+                        {"id": intent.id, "alias": intent.alias},
+                        namespace="/webui",
+                    )
+        except Exception:
+            logger.warning(
+                "Failed to emit intent_update event for %s", intent.id, exc_info=True
+            )
 
 
 # ── Helpers ────────────────────────────────────────────────────

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -668,7 +668,9 @@ class Reconciler:
             except Exception:
                 logger.warning(
                     "Failed to delete instance %s on %s after stop",
-                    action.instance_id, host.name, exc_info=True,
+                    action.instance_id,
+                    host.name,
+                    exc_info=True,
                 )
             return None
 
@@ -853,12 +855,17 @@ class Reconciler:
                         text = await resp.text()
                         logger.warning(
                             "Failed to start instance %s on %s: HTTP %s %s",
-                            instance_id, host.name, resp.status, text,
+                            instance_id,
+                            host.name,
+                            resp.status,
+                            text,
                         )
         except Exception as e:
             logger.warning(
                 "Failed to start instance %s on %s: %s",
-                instance_id, host.name, e,
+                instance_id,
+                host.name,
+                e,
             )
 
     async def _delete_instance(self, host: Any, instance_id: str) -> None:
@@ -878,12 +885,17 @@ class Reconciler:
                         text = await resp.text()
                         logger.warning(
                             "Failed to delete instance %s on %s: HTTP %s %s",
-                            instance_id, host.name, resp.status, text,
+                            instance_id,
+                            host.name,
+                            resp.status,
+                            text,
                         )
         except Exception as e:
             logger.warning(
                 "Failed to delete instance %s on %s: %s",
-                instance_id, host.name, e,
+                instance_id,
+                host.name,
+                e,
             )
 
     # ── Build instance config ──────────────────────────────────

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -17,6 +17,7 @@ Design:
 import asyncio
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from app.config import settings
@@ -149,8 +150,58 @@ class Reconciler:
     # ── Per-intent reconciliation ──────────────────────────────
 
     async def _reconcile_one(self, intent: Any) -> None:
-        """Reconcile a single intent.  To be implemented in later tasks."""
-        pass
+        """Reconcile a single intent: observe → diff → act → update status.
+
+        Implements deployment-intent.md §8.1 reconciliation loop.
+        """
+        # 1. Observe
+        observed = await self._observe(intent)
+
+        # 2. Diff
+        actions = self._diff(intent, observed)
+
+        if not actions:
+            # No actions needed — still update status to reflect current state
+            await self._update_status(intent, observed)
+            return
+
+        # 3. Act — execute at most one action per tick for gradual convergence
+        # Actions are sorted by priority (stops first, creates last)
+        actions.sort(key=lambda a: a.priority)
+        action = actions[0]
+        logger.info(
+            "Reconciling intent %s (%s): action=%s reason=%s",
+            intent.id,
+            intent.alias,
+            action.type,
+            action.reason,
+        )
+
+        last_error = None
+        try:
+            result = await self._act(intent, action)
+
+            # If we created an instance, re-observe for fresh state
+            if action.type == ActionType.CREATE and result:
+                await asyncio.sleep(0.5)
+                observed = await self._observe(intent)
+        except Exception as e:
+            logger.error(
+                "Action %s failed for intent %s: %s",
+                action.type,
+                intent.id,
+                e,
+            )
+            last_error = {
+                "code": type(e).__name__,
+                "message": str(e),
+                "host_id": action.host_id,
+                "source_uri": intent.model_source,
+                "at": datetime.now(timezone.utc).isoformat(),
+            }
+
+        # 4. Update status
+        await self._update_status(intent, observed, last_error=last_error)
 
     # ── Observe ────────────────────────────────────────────────
 
@@ -226,7 +277,148 @@ class Reconciler:
 
         Implements deployment-intent.md §8.2 diff and actions table.
         """
-        raise NotImplementedError("_diff will be implemented in Task 6")
+        desired = intent.replicas
+        managed = observed["managed_instances"]
+        alias_instances = observed["alias_instances"]
+        hosts = observed["hosts"]
+
+        observed_count = len(managed)
+        actions: list[Action] = []
+
+        # ── Deleting intent: stop all managed instances ──────────
+        if intent.status.phase.value == "deleting":
+            for inst in managed:
+                inst_id = inst.get("instance_id") or inst.get("id")
+                if inst_id:
+                    actions.append(
+                        Action(
+                            type=ActionType.STOP,
+                            intent_id=intent.id,
+                            alias=intent.alias,
+                            host_id=inst.get("_host_id"),
+                            instance_id=inst_id,
+                            reason="Intent deleted",
+                            priority=0,
+                        )
+                    )
+            return actions
+
+        # ── replicas == 0 → stop all managed instances ───────────
+        if desired == 0:
+            for inst in managed:
+                inst_id = inst.get("instance_id") or inst.get("id")
+                if inst_id:
+                    actions.append(
+                        Action(
+                            type=ActionType.STOP,
+                            intent_id=intent.id,
+                            alias=intent.alias,
+                            host_id=inst.get("_host_id"),
+                            instance_id=inst_id,
+                            reason="replicas=0",
+                            priority=0,
+                        )
+                    )
+            return actions
+
+        # ── Check for drift (model_source change) ────────────────
+        for inst in managed:
+            cfg = inst.get("config", inst)
+            inst_source = cfg.get("model_source") or inst.get("model_source")
+            inst_id = inst.get("instance_id") or inst.get("id")
+
+            if inst_source and inst_source != intent.model_source:
+                actions.append(
+                    Action(
+                        type=ActionType.REPLACE,
+                        intent_id=intent.id,
+                        alias=intent.alias,
+                        host_id=inst.get("_host_id"),
+                        instance_id=inst_id,
+                        reason=(
+                            f"model_source drift: {inst_source} → "
+                            f"{intent.model_source}"
+                        ),
+                        priority=20,
+                    )
+                )
+
+            # Check if instance failed/stopped unexpectedly
+            status = inst.get("status") or inst.get("state", "")
+            if status in ("failed", "stopped", "error"):
+                if not any(
+                    a.instance_id == inst_id and a.type == ActionType.REPLACE
+                    for a in actions
+                ):
+                    actions.append(
+                        Action(
+                            type=ActionType.RECREATE,
+                            intent_id=intent.id,
+                            alias=intent.alias,
+                            host_id=inst.get("_host_id"),
+                            instance_id=inst_id,
+                            reason=f"Instance {status}, recreating",
+                            priority=15,
+                        )
+                    )
+
+        # ── Observed < Desired → CREATE ──────────────────────────
+        shortfall = desired - observed_count
+        if shortfall > 0:
+            # Build set of hosts already serving this alias (one-replica-per-host)
+            occupied_host_ids: set[str] = set()
+            for inst in alias_instances:
+                hid = inst.get("_host_id")
+                if hid:
+                    occupied_host_ids.add(hid)
+
+            eligible = [
+                h
+                for h in hosts
+                if h.id not in occupied_host_ids and h.status == "online"
+            ]
+
+            for i in range(min(shortfall, len(eligible))):
+                host = eligible[i]
+                actions.append(
+                    Action(
+                        type=ActionType.CREATE,
+                        intent_id=intent.id,
+                        alias=intent.alias,
+                        host_id=host.id,
+                        host_name=host.name,
+                        reason=f"shortfall {i + 1}/{shortfall}",
+                        priority=50,
+                    )
+                )
+
+        # ── Observed > Desired → STOP surplus ────────────────────
+        surplus = observed_count - desired
+        if surplus > 0:
+            # Sort: unhealthy first, then newest (by created_at if available)
+            def _stop_sort_key(inst: dict[str, Any]) -> tuple[int, str]:
+                status = inst.get("status") or inst.get("state", "")
+                unhealthy = 0 if status in ("failed", "stopped", "error") else 1
+                created = inst.get("created_at") or "0"
+                return (unhealthy, created)
+
+            to_stop = sorted(managed, key=_stop_sort_key)[:surplus]
+            for inst in to_stop:
+                inst_id = inst.get("instance_id") or inst.get("id")
+                if inst_id:
+                    actions.append(
+                        Action(
+                            type=ActionType.STOP,
+                            intent_id=intent.id,
+                            alias=intent.alias,
+                            host_id=inst.get("_host_id"),
+                            instance_id=inst_id,
+                            reason="surplus replica",
+                            priority=0,
+                        )
+                    )
+
+        return actions
 
     # ── Act ────────────────────────────────────────────────────
 
@@ -235,19 +427,110 @@ class Reconciler:
         intent: Any,
         action: Action,
     ) -> dict[str, Any] | None:
-        """Execute one reconciliation action via Solar Host primitives."""
-        raise NotImplementedError("_act will be implemented in Task 7")
+        """Execute one reconciliation action via Solar Host primitives.
+
+        Returns the created instance dict on create, None otherwise.
+        """
+        from app.database.hosts import host_db
+        from app.services.migration import (
+            create_instance_on_host,
+            stop_source_instance,
+        )
+
+        if action.type == ActionType.NOOP:
+            return None
+
+        if action.type == ActionType.STOP:
+            if not action.host_id or not action.instance_id:
+                return None
+            host = await host_db.get_host(action.host_id)
+            if host is None:
+                logger.warning(
+                    "Host %s not found for stop action", action.host_id
+                )
+                return None
+            logger.info(
+                "Stopping instance %s on %s (reason: %s)",
+                action.instance_id,
+                host.name,
+                action.reason,
+            )
+            await stop_source_instance(host, action.instance_id)
+            return None
+
+        if action.type == ActionType.CREATE:
+            if not action.host_id:
+                return None
+            host = await host_db.get_host(action.host_id)
+            if host is None:
+                logger.warning(
+                    "Host %s not found for create action", action.host_id
+                )
+                return None
+
+            instance_config = self._build_instance_config(intent, host)
+
+            logger.info(
+                "Creating instance for alias=%s on %s (reason: %s)",
+                intent.alias,
+                host.name,
+                action.reason,
+            )
+            result = await create_instance_on_host(host, instance_config)
+            return result
+
+        if action.type == ActionType.REPLACE:
+            # Replace = stop old + create new on next tick
+            if action.instance_id and action.host_id:
+                host = await host_db.get_host(action.host_id)
+                if host:
+                    logger.info(
+                        "Stopping drifted instance %s on %s for replacement",
+                        action.instance_id,
+                        host.name,
+                    )
+                    await stop_source_instance(host, action.instance_id)
+            return None
+
+        if action.type == ActionType.RECREATE:
+            # Recreate = stop failed instance, next tick creates replacement
+            if action.instance_id and action.host_id:
+                host = await host_db.get_host(action.host_id)
+                if host:
+                    logger.info(
+                        "Stopping failed instance %s on %s for recreation",
+                        action.instance_id,
+                        host.name,
+                    )
+                    await stop_source_instance(host, action.instance_id)
+            return None
+
+        return None
 
     # ── Build instance config ──────────────────────────────────
 
     def _build_instance_config(self, intent: Any, host: Any) -> dict[str, Any]:
         """Compose a Solar Host InstanceConfig from the intent.
 
-        Implements deployment-intent.md §6 mapping.
+        Implements deployment-intent.md §6 mapping: alias, model_source,
+        priority, managed_by, intent_id, plus backend runtime params.
         """
-        raise NotImplementedError(
-            "_build_instance_config will be implemented in Task 7"
-        )
+        config: dict[str, Any] = {
+            "backend_type": intent.backend.get("backend_type", "llamacpp"),
+            "alias": intent.alias,
+            "model_source": intent.model_source,
+            "priority": intent.priority,
+            "managed_by": "intent",
+            "intent_id": intent.id,
+        }
+
+        # Copy backend runtime params, excluding backend_type (already set)
+        for key, value in intent.backend.items():
+            if key == "backend_type":
+                continue
+            config[key] = value
+
+        return {"config": config}
 
     # ── Update status ──────────────────────────────────────────
 
@@ -261,7 +544,146 @@ class Reconciler:
 
         Implements deployment-intent.md §10.2 status fields.
         """
-        raise NotImplementedError("_update_status will be implemented in Task 8")
+        from app.database.intents import intent_db
+        from app.models.intent import (
+            Condition,
+            IntentPhase,
+            LastError,
+            ReconcileState,
+            ReplicaEntry,
+        )
+
+        managed = observed["managed_instances"]
+        gateway_aliases = observed["gateway_aliases"]
+
+        observed_count = len(managed)
+        desired = intent.replicas
+        alias = intent.alias
+
+        # Count ready replicas (running AND in gateway registry)
+        ready_count = 0
+        updated_count = 0
+        replica_set: list[dict[str, Any]] = []
+
+        for inst in managed:
+            cfg = inst.get("config", inst)
+            status = inst.get("status") or inst.get("state", "")
+            inst_id = inst.get("instance_id") or inst.get("id")
+            inst_source = cfg.get("model_source") or inst.get("model_source")
+            healthy = status == "running" and alias in gateway_aliases
+            on_target_source = inst_source == intent.model_source
+
+            if healthy:
+                ready_count += 1
+                if on_target_source:
+                    updated_count += 1
+
+            replica_set.append(
+                ReplicaEntry(
+                    host_id=inst.get("_host_id"),
+                    host_name=inst.get("_host_name"),
+                    instance_id=inst_id,
+                    state=status,
+                    model_source=inst_source,
+                    healthy=healthy,
+                    message=None,
+                    updated_at=datetime.now(timezone.utc).isoformat(),
+                ).model_dump()
+            )
+
+        # Determine phase
+        current_phase = intent.status.phase.value
+        if current_phase == "deleting":
+            if observed_count == 0:
+                phase = IntentPhase.DELETED
+            else:
+                phase = IntentPhase.DELETING
+        elif desired == 0 and observed_count == 0:
+            phase = IntentPhase.READY
+        elif ready_count == desired and desired > 0:
+            phase = IntentPhase.READY
+        elif ready_count == 0 and desired > 0 and observed_count == 0:
+            phase = IntentPhase.RECONCILING
+        elif ready_count > 0:
+            phase = IntentPhase.DEGRADED
+        elif ready_count == 0 and (observed_count > 0 or desired > 0):
+            phase = IntentPhase.FAILED
+        else:
+            phase = IntentPhase.RECONCILING
+
+        # Build conditions
+        conditions: list[dict[str, Any]] = []
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if ready_count >= 1:
+            conditions.append(
+                Condition(
+                    type="Available",
+                    status=True,
+                    reason="MinimumReplicasAvailable",
+                    message=f"{ready_count}/{desired} ready",
+                    last_transition=now_iso,
+                ).model_dump()
+            )
+        if phase in (IntentPhase.RECONCILING, IntentPhase.DEGRADED):
+            conditions.append(
+                Condition(
+                    type="Progressing",
+                    status=True,
+                    reason="Reconciling",
+                    message="Reconciliation in progress",
+                    last_transition=now_iso,
+                ).model_dump()
+            )
+
+        # Build last_error
+        last_error_model = None
+        if last_error:
+            last_error_model = LastError(
+                code=last_error.get("code", "unknown"),
+                message=last_error.get("message", ""),
+                host_id=last_error.get("host_id"),
+                source_uri=last_error.get("source_uri"),
+                at=last_error.get("at", now_iso),
+            )
+
+        # Build status_json
+        status_json = {
+            "observed_replicas": observed_count,
+            "ready_replicas": ready_count,
+            "updated_replicas": updated_count,
+            "available": ready_count >= 1,
+            "shortfall": max(0, desired - observed_count),
+            "replica_set": replica_set,
+            "conditions": conditions,
+            "strategy_progress": None,
+            "last_error": last_error_model.model_dump() if last_error_model else None,
+        }
+
+        # Determine reconcile state
+        if last_error:
+            reconcile = ReconcileState.FAILED
+        elif phase in (IntentPhase.READY, IntentPhase.DEGRADED):
+            reconcile = ReconcileState.SUCCEEDED
+        else:
+            reconcile = ReconcileState.IN_PROGRESS
+
+        now = datetime.now(timezone.utc)
+
+        # Set ready_at when first reaching ready
+        ready_at = None
+        if phase == IntentPhase.READY:
+            ready_at = (
+                intent.status.ready_at if intent.status.ready_at else now.isoformat()
+            )
+
+        await intent_db.update_status(
+            intent.id,
+            phase=phase.value,
+            reconcile=reconcile.value,
+            status_json=status_json,
+            last_reconciled_at=now,
+            ready_at=ready_at,
+        )
 
 
 # Singleton

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -660,6 +660,16 @@ class Reconciler:
                 action.reason,
             )
             await stop_source_instance(host, action.instance_id)
+            # Delete the instance so the reconciler stops observing it.
+            # Without this, stopped instances persist and observed_replicas
+            # can never reach 0 for DELETE / scale-to-zero flows.
+            try:
+                await self._delete_instance(host, action.instance_id)
+            except Exception:
+                logger.warning(
+                    "Failed to delete instance %s on %s after stop",
+                    action.instance_id, host.name, exc_info=True,
+                )
             return None
 
         if action.type == ActionType.DISOWN:
@@ -824,7 +834,7 @@ class Reconciler:
 
         return None
 
-    # ── Start instance ──────────────────────────────────────────
+    # ── Start / Delete instance helpers ────────────────────────
 
     async def _start_instance(self, host: Any, instance_id: str) -> None:
         """Start a stopped instance on *host* via POST /instances/{id}/start."""
@@ -843,17 +853,37 @@ class Reconciler:
                         text = await resp.text()
                         logger.warning(
                             "Failed to start instance %s on %s: HTTP %s %s",
-                            instance_id,
-                            host.name,
-                            resp.status,
-                            text,
+                            instance_id, host.name, resp.status, text,
                         )
         except Exception as e:
             logger.warning(
                 "Failed to start instance %s on %s: %s",
-                instance_id,
-                host.name,
-                e,
+                instance_id, host.name, e,
+            )
+
+    async def _delete_instance(self, host: Any, instance_id: str) -> None:
+        """Delete an instance from *host* via DELETE /instances/{id}."""
+        import aiohttp
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{host.url.rstrip('/')}/instances/{instance_id}"
+                headers = {"X-API-Key": host.api_key}
+                async with session.delete(
+                    url,
+                    headers=headers,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    if resp.status not in (200, 204, 404):
+                        text = await resp.text()
+                        logger.warning(
+                            "Failed to delete instance %s on %s: HTTP %s %s",
+                            instance_id, host.name, resp.status, text,
+                        )
+        except Exception as e:
+            logger.warning(
+                "Failed to delete instance %s on %s: %s",
+                instance_id, host.name, e,
             )
 
     # ── Build instance config ──────────────────────────────────

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -724,6 +724,17 @@ class Reconciler:
             from app.services.migration import execute_migration
             from app.routes.management.resources import _fetch_host_resource_snapshot
 
+            # Look up the source host to inherit its GPU type and roles as
+            # placement constraints for the migration target (§8.5: move to
+            # "another eligible host" implies matching capabilities).
+            source_host = await host_db.get_host(action.host_id)
+            host_roles = (
+                source_host.roles
+                if source_host and source_host.roles
+                else ["inference"]
+            )
+            host_gpu = source_host.gpu_type if source_host else None
+
             # Select a target host using placement policy
             all_hosts = await host_db.get_all_hosts()
             snapshots_list = await asyncio.gather(
@@ -734,7 +745,8 @@ class Reconciler:
             target_candidates = await find_candidates(
                 all_hosts,
                 snapshots_map,
-                roles=["inference"],
+                roles=host_roles,
+                gpu_type=host_gpu,
                 vram_gb=0.0,
                 exclude_alias=action.alias,
             )

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -573,14 +573,20 @@ class Reconciler:
         # ── Observed > Desired → STOP surplus ────────────────────
         surplus = observed_count - desired
         if surplus > 0:
-            # Sort: unhealthy first, then newest (by created_at if available)
-            def _stop_sort_key(inst: dict[str, Any]) -> tuple[int, str]:
+            # Sort per §8.2: unhealthy/failed first (oldest→newest within
+            # that group), then healthy instances most-recently-created
+            # first so long-lived replicas survive.
+            unhealthy_insts: list[dict[str, Any]] = []
+            healthy_insts: list[dict[str, Any]] = []
+            for inst in managed:
                 status = inst.get("status") or inst.get("state", "")
-                unhealthy = 0 if status in ("failed", "stopped", "error") else 1
-                created = inst.get("created_at") or "0"
-                return (unhealthy, created)
-
-            to_stop = sorted(managed, key=_stop_sort_key)[:surplus]
+                if status in ("failed", "stopped", "error"):
+                    unhealthy_insts.append(inst)
+                else:
+                    healthy_insts.append(inst)
+            unhealthy_insts.sort(key=lambda i: i.get("created_at") or "0")
+            healthy_insts.sort(key=lambda i: i.get("created_at") or "0", reverse=True)
+            to_stop = (unhealthy_insts + healthy_insts)[:surplus]
             for inst in to_stop:
                 inst_id = inst.get("instance_id") or inst.get("id")
                 if inst_id:

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -484,6 +484,11 @@ async def host_instances_update(sid: str, data: dict[str, Any]):
     except Exception:
         pass
 
+    # Wake reconciler — instance changes may affect intent status
+    from app.services.reconciliation import reconciler
+
+    reconciler.wake()
+
 
 # ── Job event handlers (S-025 step_log, S-026 lifecycle) ────
 #

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -191,6 +191,10 @@ async def host_connect(
         )
 
         await _emit_host_status(host, connected=True)
+        # Wake reconciler — a new host may provide capacity for pending intents
+        from app.services.reconciliation import reconciler
+
+        reconciler.wake()
     else:
         pending_id = str(uuid.uuid4())
         pending_data: dict[str, Any] = {
@@ -239,6 +243,10 @@ async def host_disconnect(sid: str):
 
         if host:
             await _emit_host_status(host, connected=False)
+        # Wake reconciler — lost host may leave intents under-replicated
+        from app.services.reconciliation import reconciler
+
+        reconciler.wake()
         return
 
     pending_id = await host_store.remove_pending_by_sid(sid)

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -459,6 +459,11 @@ async def host_health(sid: str, data: dict[str, Any]):
     )
     await sio.emit("host_health", payload.model_dump(), namespace="/webui")
 
+    # Wake reconciler — health/resource changes may affect placement decisions
+    from app.services.reconciliation import reconciler
+
+    reconciler.wake()
+
 
 @sio.on("instances_update", namespace="/hosts")
 async def host_instances_update(sid: str, data: dict[str, Any]):

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -13,7 +13,13 @@ from app.models.intent import (
     ReconcileState,
     ResourceRequirements,
 )
-from app.services.reconciliation import ActionType, Reconciler
+from app.services.reconciliation import (
+    ActionType,
+    Reconciler,
+    _detect_backend_drift,
+    _intent_orphan,
+    _intent_phase,
+)
 
 # ── Simple host stub ────────────────────────────────────────────
 
@@ -31,6 +37,18 @@ class _HostStub:
     def __post_init__(self):
         if self.roles is None:
             self.roles = ["inference"]
+
+
+@dataclass
+class _SnapshotStub:
+    """Minimal snapshot stub for placement policy."""
+
+    host_id: str
+    reachable: bool = True
+    vram_available_gb: float = 10.0
+    ram_available_gb: float | None = None
+    disk_available_gb: float | None = None
+    running_instance_count: int = 0
 
 
 # ── Helpers ────────────────────────────────────────────────────
@@ -66,19 +84,27 @@ def _make_managed_instance(
     alias: str = "test-model",
     model_source: str = "repo://test:v1",
     status: str = "running",
+    **extra_config,
 ) -> dict:
-    """Build a managed instance dict (as stored in Redis)."""
+    """Build a managed instance dict (as stored in Redis).
+
+    Default config matches the default intent's backend so drift
+    detection doesn't fire on tests that don't care about drift.
+    """
+    config = {
+        "alias": alias,
+        "model_source": model_source,
+        "managed_by": "intent",
+        "intent_id": "intent-001",
+        "backend_type": "huggingface_classification",
+        "max_length": 512,
+    }
+    config.update(extra_config)
     return {
         "instance_id": instance_id,
         "id": instance_id,
         "status": status,
-        "config": {
-            "alias": alias,
-            "model_source": model_source,
-            "managed_by": "intent",
-            "intent_id": "intent-001",
-            "backend_type": "huggingface_classification",
-        },
+        "config": config,
         "_host_id": host_id,
         "_host_name": host_name,
     }
@@ -88,20 +114,82 @@ def _make_observed(
     managed: list | None = None,
     alias_instances: list | None = None,
     hosts: list | None = None,
+    snapshots: dict | None = None,
     gateway_aliases: set | None = None,
+    candidates: list | None = None,
+    displaceable_map: dict | None = None,
+    manual_conflicts: list | None = None,
 ) -> dict:
-    """Build an observed state dict for testing."""
+    """Build an observed state dict for testing.
+
+    For CREATE tests, provide *candidates* as a list of (host, snapshot) tuples.
+    For tests that don't test CREATE, leave candidates empty.
+    """
     if managed is None:
         managed = []
     if alias_instances is None:
         alias_instances = list(managed)
+    if candidates is None:
+        candidates = []
     return {
         "managed_instances": managed,
         "alias_instances": alias_instances,
         "hosts": hosts or [],
-        "snapshots": {},
+        "snapshots": snapshots or {},
         "gateway_aliases": gateway_aliases or set(),
+        "candidates": candidates,
+        "displaceable_map": displaceable_map or {},
+        "manual_conflicts": manual_conflicts or [],
     }
+
+
+# ── Helper function tests ──────────────────────────────────────
+
+
+class TestHelpers:
+    """Test standalone helper functions."""
+
+    def test_intent_phase_extracts_correctly(self):
+        intent = _make_intent(status=IntentStatus(phase=IntentPhase.READY))
+        assert _intent_phase(intent) == "ready"
+
+    def test_intent_phase_fallback(self):
+        """Fallback for objects without status.phase."""
+
+        class StubIntent:
+            phase = "pending"
+
+        assert _intent_phase(StubIntent()) == "pending"
+
+    def test_intent_orphan_true(self):
+        intent = _make_intent(metadata={"orphan": "true"})
+        assert _intent_orphan(intent) is True
+
+    def test_intent_orphan_false(self):
+        intent = _make_intent(metadata={})
+        assert _intent_orphan(intent) is False
+
+    def test_detect_backend_drift_no_change(self):
+        intent = _make_intent(backend={"backend_type": "hf", "max_length": 512})
+        instance_config = {"backend_type": "hf", "max_length": 512}
+        assert _detect_backend_drift(intent, instance_config) is False
+
+    def test_detect_backend_drift_changed(self):
+        intent = _make_intent(backend={"backend_type": "hf", "max_length": 1024})
+        instance_config = {"backend_type": "hf", "max_length": 512}
+        assert _detect_backend_drift(intent, instance_config) is True
+
+    def test_detect_backend_drift_skips_identity_fields(self):
+        """Identity/server fields (alias, model_source, etc.) are ignored."""
+        intent = _make_intent(
+            backend={"backend_type": "hf", "alias": "x", "model_source": "y"}
+        )
+        instance_config = {
+            "backend_type": "hf",
+            "alias": "different",
+            "model_source": "z",
+        }
+        assert _detect_backend_drift(intent, instance_config) is False
 
 
 # ── Diff tests ─────────────────────────────────────────────────
@@ -124,7 +212,23 @@ class TestDiff:
         assert actions == []
 
     def test_create_on_shortfall(self):
-        """When observed < desired, create actions are generated."""
+        """When observed < desired, create actions are generated from candidates."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=3)
+        observed = _make_observed(
+            managed=[_make_managed_instance("inst-1", host_id="h1")],
+            hosts=[_HostStub(id="h2"), _HostStub(id="h3")],
+            candidates=[
+                (_HostStub(id="h2", name="h2"), _SnapshotStub("h2")),
+                (_HostStub(id="h3", name="h3"), _SnapshotStub("h3")),
+            ],
+        )
+        actions = reconciler._diff(intent, observed)
+        creates = [a for a in actions if a.type == ActionType.CREATE]
+        assert len(creates) == 2  # shortfall of 2
+
+    def test_no_create_without_candidates(self):
+        """When no candidates in observed, no CREATE actions even if shortfall."""
         reconciler = Reconciler()
         intent = _make_intent(replicas=3)
         observed = _make_observed(
@@ -133,7 +237,7 @@ class TestDiff:
         )
         actions = reconciler._diff(intent, observed)
         creates = [a for a in actions if a.type == ActionType.CREATE]
-        assert len(creates) == 2  # shortfall of 2
+        assert len(creates) == 0  # candidates empty → no creates
 
     def test_stop_surplus(self):
         """When observed > desired, stop actions are generated."""
@@ -156,6 +260,22 @@ class TestDiff:
         observed = _make_observed(
             managed=[
                 _make_managed_instance("inst-1", model_source="repo://test:v1"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        replaces = [a for a in actions if a.type == ActionType.REPLACE]
+        assert len(replaces) == 1
+
+    def test_replace_on_backend_drift(self):
+        """When instance backend config differs, replace action is generated."""
+        reconciler = Reconciler()
+        intent = _make_intent(
+            replicas=1,
+            backend={"backend_type": "hf", "max_length": 1024},
+        )
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", max_length=512),
             ]
         )
         actions = reconciler._diff(intent, observed)
@@ -192,6 +312,26 @@ class TestDiff:
         stops = [a for a in actions if a.type == ActionType.STOP]
         assert len(stops) == 2
 
+    def test_disown_on_delete_orphan(self):
+        """Deleting intents with orphan=true get DISOWN actions, not STOP."""
+        reconciler = Reconciler()
+        intent = _make_intent(
+            replicas=2,
+            metadata={"orphan": "true"},
+            status=IntentStatus(phase=IntentPhase.DELETING),
+        )
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", host_id="h1"),
+                _make_managed_instance("inst-2", host_id="h2"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        disowns = [a for a in actions if a.type == ActionType.DISOWN]
+        stops = [a for a in actions if a.type == ActionType.STOP]
+        assert len(disowns) == 2
+        assert len(stops) == 0
+
     def test_stop_all_on_zero_replicas(self):
         """replicas=0 means stop all managed instances."""
         reconciler = Reconciler()
@@ -211,6 +351,7 @@ class TestDiff:
                 _make_managed_instance("inst-2", host_id="h2"),
             ],
             hosts=[_HostStub(id="h3")],
+            candidates=[(_HostStub(id="h3", name="h3"), _SnapshotStub("h3"))],
         )
         # Surplus of 1 → stop, failed → recreate, shortfall → create
         actions = reconciler._diff(intent, observed)
@@ -219,28 +360,31 @@ class TestDiff:
             priorities
         ), f"Expected sorted priorities, got {priorities}"
 
-    def test_no_create_when_hosts_occupied(self):
-        """Creates skip hosts already serving the alias."""
+    def test_migrate_from_displacement(self):
+        """When candidates are fewer than shortfall, MIGRATE actions are generated."""
         reconciler = Reconciler()
         intent = _make_intent(replicas=2)
         observed = _make_observed(
-            managed=[_make_managed_instance("inst-1", host_id="h1")],
-            alias_instances=[
-                _make_managed_instance("inst-1", host_id="h1"),
-                # Manual instance on h2 also serving the same alias
-                {
-                    "instance_id": "inst-manual",
-                    "config": {"alias": "test-model"},
-                    "_host_id": "h2",
-                },
+            managed=[],
+            hosts=[_HostStub(id="h1")],
+            candidates=[
+                (_HostStub(id="h1", name="h1"), _SnapshotStub("h1")),
             ],
-            hosts=[_HostStub(id="h2"), _HostStub(id="h3")],
+            displaceable_map={
+                "h2": [
+                    {
+                        "instance_id": "inst-ephemeral",
+                        "config": {"alias": "other"},
+                        "_priority": "ephemeral",
+                    }
+                ],
+            },
         )
         actions = reconciler._diff(intent, observed)
+        migrates = [a for a in actions if a.type == ActionType.MIGRATE]
         creates = [a for a in actions if a.type == ActionType.CREATE]
-        # Only h3 is eligible (h2 occupied by manual instance)
-        assert len(creates) == 1
-        assert creates[0].host_id == "h3"
+        assert len(creates) == 1  # 1 candidate used
+        assert len(migrates) == 1  # 1 displacement needed for remaining shortfall
 
 
 # ── Build instance config test ──────────────────────────────────
@@ -250,10 +394,7 @@ class TestBuildInstanceConfig:
     """Test _build_instance_config method."""
 
     def test_maps_fields_correctly(self):
-        """Config contains alias, model_source, priority, managed_by, intent_id.
-
-        Per deployment-intent.md §6, backend_type maps to the instance config.
-        """
+        """Config contains alias, model_source, priority, managed_by, intent_id."""
         reconciler = Reconciler()
         intent = _make_intent(
             alias="iris-osl:110m",
@@ -286,6 +427,41 @@ class TestBuildInstanceConfig:
         config = reconciler._build_instance_config(intent, host)
         assert config["config"]["backend_type"] == "llamacpp"
         assert config["config"]["dtype"] == "float16"
+
+
+# ── Backoff tests ──────────────────────────────────────────────
+
+
+class TestBackoff:
+    """Test exponential backoff logic."""
+
+    def test_backoff_clear(self):
+        reconciler = Reconciler()
+        reconciler._backoff["test-id"] = {"failures": 3}
+        reconciler._backoff_clear("test-id")
+        assert "test-id" not in reconciler._backoff
+
+    def test_backoff_active_after_failure(self):
+        reconciler = Reconciler()
+        reconciler._backoff_record_failure("test-id")
+        assert reconciler._backoff_active("test-id") is True  # 10s backoff
+
+    def test_backoff_not_active_for_unknown(self):
+        reconciler = Reconciler()
+        assert reconciler._backoff_active("unknown") is False
+
+    def test_skip_when_backoff_active(self):
+        """_reconcile_one returns early when backoff is active."""
+        reconciler = Reconciler()
+        intent = _make_intent()
+        reconciler._backoff_record_failure(intent.id)
+
+        with patch.object(reconciler, "_observe") as mock_observe:
+            # Should not call _observe because backoff is active
+            import asyncio
+
+            asyncio.run(reconciler._reconcile_one(intent))
+            mock_observe.assert_not_called()
 
 
 # ── Integration tests ──────────────────────────────────────────
@@ -326,7 +502,11 @@ class TestReconcileOne:
         intent = _make_intent(replicas=1)
         host = _HostStub(id="h1")
 
-        observed = _make_observed(managed=[], hosts=[host])
+        observed = _make_observed(
+            managed=[],
+            hosts=[host],
+            candidates=[(host, _SnapshotStub("h1"))],
+        )
 
         with (
             patch.object(reconciler, "_observe", new=AsyncMock(return_value=observed)),
@@ -348,7 +528,11 @@ class TestReconcileOne:
         intent = _make_intent(replicas=1)
         host = _HostStub(id="h1")
 
-        observed = _make_observed(managed=[], hosts=[host])
+        observed = _make_observed(
+            managed=[],
+            hosts=[host],
+            candidates=[(host, _SnapshotStub("h1"))],
+        )
 
         with (
             patch.object(reconciler, "_observe", new=AsyncMock(return_value=observed)),
@@ -367,3 +551,30 @@ class TestReconcileOne:
             assert last_error is not None
             assert last_error["code"] == "RuntimeError"
             assert "host unreachable" in last_error["message"]
+
+    @pytest.mark.anyio
+    async def test_backoff_recorded_on_failure(self):
+        """After a failure, backoff is set."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        host = _HostStub(id="h1")
+
+        observed = _make_observed(
+            managed=[],
+            hosts=[host],
+            candidates=[(host, _SnapshotStub("h1"))],
+        )
+
+        with (
+            patch.object(reconciler, "_observe", new=AsyncMock(return_value=observed)),
+            patch.object(
+                reconciler,
+                "_act",
+                new=AsyncMock(side_effect=RuntimeError("fail")),
+            ),
+            patch.object(reconciler, "_update_status", new=AsyncMock()),
+        ):
+            await reconciler._reconcile_one(intent)
+
+        assert reconciler._backoff_active(intent.id) is True
+        assert reconciler._backoff[intent.id]["failures"] == 1

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -394,7 +394,11 @@ class TestBuildInstanceConfig:
     """Test _build_instance_config method."""
 
     def test_maps_fields_correctly(self):
-        """Config contains alias, model_source, priority, managed_by, intent_id."""
+        """Top-level: managed_by, intent_id, priority. Config: alias, source, backend.
+
+        Per deployment-intent.md §6, managed_by/intent_id/priority are top-level
+        fields on the Instance model, not nested inside config.
+        """
         reconciler = Reconciler()
         intent = _make_intent(
             alias="iris-osl:110m",
@@ -407,15 +411,23 @@ class TestBuildInstanceConfig:
             },
         )
         host = _HostStub(id="h1")
-        config = reconciler._build_instance_config(intent, host)
+        payload = reconciler._build_instance_config(intent, host)
 
-        assert config["config"]["alias"] == "iris-osl:110m"
-        assert config["config"]["model_source"] == "repo://iris-osl:v3"
-        assert config["config"]["priority"] == "production"
-        assert config["config"]["managed_by"] == "intent"
-        assert config["config"]["intent_id"] == "intent-001"
-        assert config["config"]["max_length"] == 512
-        assert config["config"]["backend_type"] == "huggingface_classification"
+        # Top-level fields
+        assert payload["managed_by"] == "intent"
+        assert payload["intent_id"] == "intent-001"
+        assert payload["priority"] == "production"
+
+        # Config fields
+        assert payload["config"]["alias"] == "iris-osl:110m"
+        assert payload["config"]["model_source"] == "repo://iris-osl:v3"
+        assert payload["config"]["max_length"] == 512
+        assert payload["config"]["backend_type"] == "huggingface_classification"
+
+        # NOT inside config
+        assert "managed_by" not in payload["config"]
+        assert "intent_id" not in payload["config"]
+        assert "priority" not in payload["config"]
 
     def test_copies_backend_runtime_params(self):
         """Backend params are copied to config, backend_type included."""

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,369 @@
+"""Tests for reconciliation engine (S-041)."""
+
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.intent import (
+    IntentPhase,
+    IntentResponse,
+    IntentStatus,
+    PlacementConstraints,
+    ReconcileState,
+    ResourceRequirements,
+)
+from app.services.reconciliation import ActionType, Reconciler
+
+# ── Simple host stub ────────────────────────────────────────────
+
+
+@dataclass
+class _HostStub:
+    id: str
+    name: str = ""
+    status: str = "online"
+    url: str = "http://localhost:8080"
+    api_key: str = "test-key"
+    roles: list | None = None
+    gpu_type: str | None = None
+
+    def __post_init__(self):
+        if self.roles is None:
+            self.roles = ["inference"]
+
+
+# ── Helpers ────────────────────────────────────────────────────
+
+
+def _make_intent(**overrides) -> IntentResponse:
+    """Build a minimal IntentResponse for testing."""
+    defaults = {
+        "id": "intent-001",
+        "alias": "test-model",
+        "model_source": "repo://test:v1",
+        "replicas": 2,
+        "priority": "production",
+        "strategy": "rolling",
+        "backend": {"backend_type": "huggingface_classification", "max_length": 512},
+        "placement": PlacementConstraints(),
+        "resources": ResourceRequirements(),
+        "metadata": {},
+        "status": IntentStatus(
+            phase=IntentPhase.RECONCILING,
+            reconcile=ReconcileState.IN_PROGRESS,
+            desired_replicas=2,
+        ),
+    }
+    defaults.update(overrides)
+    return IntentResponse(**defaults)
+
+
+def _make_managed_instance(
+    instance_id: str,
+    host_id: str = "host-1",
+    host_name: str = "host1",
+    alias: str = "test-model",
+    model_source: str = "repo://test:v1",
+    status: str = "running",
+) -> dict:
+    """Build a managed instance dict (as stored in Redis)."""
+    return {
+        "instance_id": instance_id,
+        "id": instance_id,
+        "status": status,
+        "config": {
+            "alias": alias,
+            "model_source": model_source,
+            "managed_by": "intent",
+            "intent_id": "intent-001",
+            "backend_type": "huggingface_classification",
+        },
+        "_host_id": host_id,
+        "_host_name": host_name,
+    }
+
+
+def _make_observed(
+    managed: list | None = None,
+    alias_instances: list | None = None,
+    hosts: list | None = None,
+    gateway_aliases: set | None = None,
+) -> dict:
+    """Build an observed state dict for testing."""
+    if managed is None:
+        managed = []
+    if alias_instances is None:
+        alias_instances = list(managed)
+    return {
+        "managed_instances": managed,
+        "alias_instances": alias_instances,
+        "hosts": hosts or [],
+        "snapshots": {},
+        "gateway_aliases": gateway_aliases or set(),
+    }
+
+
+# ── Diff tests ─────────────────────────────────────────────────
+
+
+class TestDiff:
+    """Test the _diff method's action planning."""
+
+    def test_noop_when_desired_matches_observed(self):
+        """When replicas match, no actions needed."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=2)
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", host_id="h1"),
+                _make_managed_instance("inst-2", host_id="h2"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        assert actions == []
+
+    def test_create_on_shortfall(self):
+        """When observed < desired, create actions are generated."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=3)
+        observed = _make_observed(
+            managed=[_make_managed_instance("inst-1", host_id="h1")],
+            hosts=[_HostStub(id="h2"), _HostStub(id="h3")],
+        )
+        actions = reconciler._diff(intent, observed)
+        creates = [a for a in actions if a.type == ActionType.CREATE]
+        assert len(creates) == 2  # shortfall of 2
+
+    def test_stop_surplus(self):
+        """When observed > desired, stop actions are generated."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", host_id="h1"),
+                _make_managed_instance("inst-2", host_id="h2"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        stops = [a for a in actions if a.type == ActionType.STOP]
+        assert len(stops) == 1
+
+    def test_replace_on_model_source_drift(self):
+        """When instance model_source differs, replace action is generated."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1, model_source="repo://test:v2")
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", model_source="repo://test:v1"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        replaces = [a for a in actions if a.type == ActionType.REPLACE]
+        assert len(replaces) == 1
+
+    def test_recreate_on_failed_instance(self):
+        """Failed instances trigger recreate actions."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", status="failed"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        recreates = [a for a in actions if a.type == ActionType.RECREATE]
+        assert len(recreates) == 1
+
+    def test_stop_all_on_delete(self):
+        """Deleting intents get stop actions for all managed instances."""
+        reconciler = Reconciler()
+        intent = _make_intent(
+            replicas=2,
+            status=IntentStatus(phase=IntentPhase.DELETING),
+        )
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", host_id="h1"),
+                _make_managed_instance("inst-2", host_id="h2"),
+            ]
+        )
+        actions = reconciler._diff(intent, observed)
+        stops = [a for a in actions if a.type == ActionType.STOP]
+        assert len(stops) == 2
+
+    def test_stop_all_on_zero_replicas(self):
+        """replicas=0 means stop all managed instances."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=0)
+        observed = _make_observed(managed=[_make_managed_instance("inst-1")])
+        actions = reconciler._diff(intent, observed)
+        stops = [a for a in actions if a.type == ActionType.STOP]
+        assert len(stops) == 1
+
+    def test_actions_sorted_by_priority(self):
+        """Actions are sorted: stops first (p0), recreate (p15), create (p50)."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        observed = _make_observed(
+            managed=[
+                _make_managed_instance("inst-1", host_id="h1", status="failed"),
+                _make_managed_instance("inst-2", host_id="h2"),
+            ],
+            hosts=[_HostStub(id="h3")],
+        )
+        # Surplus of 1 → stop, failed → recreate, shortfall → create
+        actions = reconciler._diff(intent, observed)
+        priorities = [a.priority for a in actions]
+        assert priorities == sorted(
+            priorities
+        ), f"Expected sorted priorities, got {priorities}"
+
+    def test_no_create_when_hosts_occupied(self):
+        """Creates skip hosts already serving the alias."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=2)
+        observed = _make_observed(
+            managed=[_make_managed_instance("inst-1", host_id="h1")],
+            alias_instances=[
+                _make_managed_instance("inst-1", host_id="h1"),
+                # Manual instance on h2 also serving the same alias
+                {
+                    "instance_id": "inst-manual",
+                    "config": {"alias": "test-model"},
+                    "_host_id": "h2",
+                },
+            ],
+            hosts=[_HostStub(id="h2"), _HostStub(id="h3")],
+        )
+        actions = reconciler._diff(intent, observed)
+        creates = [a for a in actions if a.type == ActionType.CREATE]
+        # Only h3 is eligible (h2 occupied by manual instance)
+        assert len(creates) == 1
+        assert creates[0].host_id == "h3"
+
+
+# ── Build instance config test ──────────────────────────────────
+
+
+class TestBuildInstanceConfig:
+    """Test _build_instance_config method."""
+
+    def test_maps_fields_correctly(self):
+        """Config contains alias, model_source, priority, managed_by, intent_id.
+
+        Per deployment-intent.md §6, backend_type maps to the instance config.
+        """
+        reconciler = Reconciler()
+        intent = _make_intent(
+            alias="iris-osl:110m",
+            model_source="repo://iris-osl:v3",
+            priority="production",
+            backend={
+                "backend_type": "huggingface_classification",
+                "max_length": 512,
+                "labels": ["osl"],
+            },
+        )
+        host = _HostStub(id="h1")
+        config = reconciler._build_instance_config(intent, host)
+
+        assert config["config"]["alias"] == "iris-osl:110m"
+        assert config["config"]["model_source"] == "repo://iris-osl:v3"
+        assert config["config"]["priority"] == "production"
+        assert config["config"]["managed_by"] == "intent"
+        assert config["config"]["intent_id"] == "intent-001"
+        assert config["config"]["max_length"] == 512
+        assert config["config"]["backend_type"] == "huggingface_classification"
+
+    def test_copies_backend_runtime_params(self):
+        """Backend params are copied to config, backend_type included."""
+        reconciler = Reconciler()
+        intent = _make_intent(
+            backend={"backend_type": "llamacpp", "dtype": "float16"},
+        )
+        host = _HostStub(id="h1")
+        config = reconciler._build_instance_config(intent, host)
+        assert config["config"]["backend_type"] == "llamacpp"
+        assert config["config"]["dtype"] == "float16"
+
+
+# ── Integration tests ──────────────────────────────────────────
+
+
+class TestReconcileOne:
+    """Integration tests for the full observe→diff→act→status pipeline."""
+
+    @pytest.mark.anyio
+    async def test_noop_when_already_healthy(self):
+        """When desired state matches, status is updated but no actions taken."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=2)
+        managed = [
+            _make_managed_instance("inst-1", host_id="h1"),
+            _make_managed_instance("inst-2", host_id="h2"),
+        ]
+
+        with (
+            patch.object(
+                reconciler,
+                "_observe",
+                new=AsyncMock(
+                    return_value=_make_observed(
+                        managed=managed, gateway_aliases={"test-model"}
+                    )
+                ),
+            ),
+            patch.object(reconciler, "_update_status", new=AsyncMock()) as mock_status,
+        ):
+            await reconciler._reconcile_one(intent)
+            mock_status.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_create_action_executed(self):
+        """Shortfall triggers create action on eligible host."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        host = _HostStub(id="h1")
+
+        observed = _make_observed(managed=[], hosts=[host])
+
+        with (
+            patch.object(reconciler, "_observe", new=AsyncMock(return_value=observed)),
+            patch.object(
+                reconciler,
+                "_act",
+                new=AsyncMock(return_value={"instance_id": "new-inst"}),
+            ) as mock_act,
+            patch.object(reconciler, "_update_status", new=AsyncMock()) as mock_status,
+        ):
+            await reconciler._reconcile_one(intent)
+            mock_act.assert_called_once()
+            mock_status.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_error_reported_in_status(self):
+        """When action fails, last_error is populated."""
+        reconciler = Reconciler()
+        intent = _make_intent(replicas=1)
+        host = _HostStub(id="h1")
+
+        observed = _make_observed(managed=[], hosts=[host])
+
+        with (
+            patch.object(reconciler, "_observe", new=AsyncMock(return_value=observed)),
+            patch.object(
+                reconciler,
+                "_act",
+                new=AsyncMock(side_effect=RuntimeError("host unreachable")),
+            ),
+            patch.object(reconciler, "_update_status", new=AsyncMock()) as mock_status,
+        ):
+            await reconciler._reconcile_one(intent)
+
+            # Verify last_error was passed to _update_status
+            call_kwargs = mock_status.call_args
+            last_error = call_kwargs[1].get("last_error")
+            assert last_error is not None
+            assert last_error["code"] == "RuntimeError"
+            assert "host unreachable" in last_error["message"]


### PR DESCRIPTION
## Description

Implements a level-triggered reconciliation engine in solar-control that periodically processes active deployment intents, compares desired state with observed state (managed instances + gateway registry), and converges the cluster by creating, stopping, and migrating instances via Solar Host primitives.

The reconciler reuses the shared placement policy (`app/services/placement.py`), migration orchestrator (`app/services/migration.py`), model distribution (S-019), and resource aggregation (S-035). Per-intent Redis locks prevent concurrent reconciliation from multiple Solar Control replicas.

## Changes

- **New:** `app/services/reconciliation.py` — Reconciler class with observe→diff→act→status pipeline
- **New:** `tests/test_reconciliation.py` — 14 tests (9 unit diff tests, 2 config building tests, 3 integration tests)
- **Modified:** `app/database/intents.py` — added `update_status()` and `list_active_for_reconciliation()`
- **Modified:** `app/config.py` — added `reconcile_interval_s` setting (default 10s)
- **Modified:** `app/main.py` — start/stop reconciler in lifespan
- **Modified:** `app/routes/management/intents.py` — wake reconciler on intent create/delete
- **Modified:** `app/socketio_app/host_handlers.py` — wake reconciler on host connect/disconnect/health

Key behaviors:
- Level-triggered: periodic 10s tick + event-driven wake-ups (intent CRUD, host connect/disconnect/health)
- One action per intent per tick for gradual, safe convergence
- Stateless/restart-safe: recomputes `managed(I)` from observed state every pass
- Per-intent Redis lock prevents duplicate reconciliation from multiple replicas
- Emits `intent_update` Socket.IO events to `/webui` for live status updates
- Pre-filters training-only hosts from inference placement candidates
- Socket.IO intent events on status changes for live WebUI updates

## Related Issues

Closes #41