### PR TITLE
feat(reconciliation): implement rolling and immediate deployment strategies (S-042)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,5 +52,10 @@ class Settings(BaseSettings):
     # Reconciliation (S-041)
     reconcile_interval_s: float = 10.0
 
+    # Strategy health gate timeout (S-042)
+    # Maximum seconds to wait for a replacement instance to become healthy
+    # before the rolling strategy holds and reports failure.
+    reconcile_health_gate_timeout_s: float = 120.0
+
 
 settings = Settings()

--- a/app/models/intent.py
+++ b/app/models/intent.py
@@ -108,14 +108,27 @@ class Condition(BaseModel):
 
 
 class StrategyProgress(BaseModel):
-    """In-flight strategy progress (S-039 §11.4)."""
+    """In-flight strategy progress (S-039 §11.4, extended for S-042 state machine).
+
+    Persisted in intent status_json so strategy state survives reconciler
+    restarts.  The ``phase`` field drives the strategy state machine;
+    ``current_host_id`` / ``current_instance_id`` track which replacement
+    is in flight; ``pending_hosts`` / ``failed_hosts`` track remaining
+    and failed hosts across ticks.
+    """
 
     strategy: str
     target_model_source: str | None = None
+    phase: str | None = None
     step: str | None = None
     updated: int = 0
     in_progress: int = 0
     failed: int = 0
+    current_host_id: str | None = None
+    current_instance_id: str | None = None
+    pending_hosts: list[str] = Field(default_factory=list)
+    failed_hosts: list[str] = Field(default_factory=list)
+    started_at: str | None = None
     message: str | None = None
 
 

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -471,6 +471,11 @@ class Reconciler:
                         failed_hosts.append(action_dict["host_id"])
                     new_progress["failed_hosts"] = failed_hosts
 
+        # If strategy reached FAILED state, record backoff so retries
+        # are paced per §11.5 ("Reconciler retries with backoff").
+        if new_progress and new_progress.get("phase") == "failed":
+            self._backoff_record_failure(intent.id)
+
         # Update status with strategy progress
         await self._update_status(
             intent,

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -405,7 +405,9 @@ class Reconciler:
         if len(managed) > desired:
             logger.info(
                 "Scale-down (%d→%d) deferred for intent %s while strategy active",
-                len(managed), desired, intent.id,
+                len(managed),
+                desired,
+                intent.id,
             )
 
         action_dict, new_progress = continue_strategy(
@@ -425,9 +427,13 @@ class Reconciler:
             try:
                 action = Action(
                     type=(
-                        ActionType.CREATE if action_type == "create"
-                        else ActionType.STOP if action_type == "stop"
-                        else ActionType.NOOP
+                        ActionType.CREATE
+                        if action_type == "create"
+                        else (
+                            ActionType.STOP
+                            if action_type == "stop"
+                            else ActionType.NOOP
+                        )
                     ),
                     intent_id=intent.id,
                     alias=intent.alias,
@@ -441,13 +447,15 @@ class Reconciler:
                 # If create succeeded, capture instance_id for progress
                 if action_type == "create" and result and new_progress:
                     created = result.get("instance", result)
-                    new_progress["current_instance_id"] = (
-                        created.get("id") or created.get("instance_id")
-                    )
+                    new_progress["current_instance_id"] = created.get(
+                        "id"
+                    ) or created.get("instance_id")
             except Exception as e:
                 logger.error(
                     "Strategy action %s failed for intent %s: %s",
-                    action_type, intent.id, e,
+                    action_type,
+                    intent.id,
+                    e,
                 )
                 last_error = {
                     "code": type(e).__name__,
@@ -465,7 +473,8 @@ class Reconciler:
 
         # Update status with strategy progress
         await self._update_status(
-            intent, observed,
+            intent,
+            observed,
             last_error=last_error,
             strategy_progress=new_progress,
         )

--- a/app/services/reconciliation.py
+++ b/app/services/reconciliation.py
@@ -197,6 +197,10 @@ class Reconciler:
         """Reconcile a single intent: observe → diff → act → update status.
 
         Implements deployment-intent.md §8.1 reconciliation loop.
+
+        When a deployment strategy is in-flight (strategy_progress is set),
+        delegates to the strategy state machine instead of the normal
+        diff/act path (S-042 §11).
         """
         # Check backoff before acting
         if self._backoff_active(intent.id):
@@ -206,8 +210,66 @@ class Reconciler:
         # 1. Observe
         observed = await self._observe(intent)
 
+        # ── S-042: Check if a strategy is already in-flight ──────
+        strategy_progress = self._get_strategy_progress(intent)
+        if strategy_progress is not None:
+            await self._continue_strategy(intent, observed, strategy_progress)
+            return
+
+        # ── Delete / scale-to-zero takes priority over strategies ─
+        current_phase = _intent_phase(intent)
+        if current_phase == "deleting" or (
+            current_phase not in ("deleting", "deleted") and intent.replicas == 0
+        ):
+            # Normal delete/scale-to-zero flow via _diff
+            actions = self._diff(intent, observed)
+            if not actions:
+                await self._update_status(intent, observed)
+                return
+            actions.sort(key=lambda a: a.priority)
+            action = actions[0]
+            last_error = None
+            action_succeeded = False
+            try:
+                result = await self._act(intent, action)
+                action_succeeded = True
+                if action.type in (ActionType.CREATE, ActionType.MIGRATE) and result:
+                    await asyncio.sleep(0.5)
+                    observed = await self._observe(intent)
+            except Exception as e:
+                logger.error(
+                    "Action %s failed for intent %s: %s",
+                    action.type,
+                    intent.id,
+                    e,
+                )
+                last_error = {
+                    "code": type(e).__name__,
+                    "message": str(e),
+                    "host_id": action.host_id,
+                    "source_uri": intent.model_source,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            if action_succeeded and last_error is None:
+                self._backoff_clear(intent.id)
+            elif last_error is not None:
+                self._backoff_record_failure(intent.id)
+            await self._update_status(intent, observed, last_error=last_error)
+            return
+
         # 2. Diff
         actions = self._diff(intent, observed)
+
+        # ── S-042: Check if a strategy should be initiated ────────
+        strategy_progress_data = self._maybe_initiate_strategy(
+            intent, observed, actions
+        )
+        if strategy_progress_data is not None:
+            # Persist strategy_progress; next tick will execute it
+            await self._update_status(
+                intent, observed, strategy_progress=strategy_progress_data
+            )
+            return
 
         if not actions:
             # No actions needed — still update status to reflect current state
@@ -259,6 +321,154 @@ class Reconciler:
 
         # 4. Update status
         await self._update_status(intent, observed, last_error=last_error)
+
+    # ── S-042: Strategy helpers ──────────────────────────────────
+
+    def _get_strategy_progress(self, intent: Any) -> dict[str, Any] | None:
+        """Extract strategy_progress from intent status, if present."""
+        try:
+            sp = intent.status.strategy_progress
+            if sp is None:
+                return None
+            if hasattr(sp, "model_dump"):
+                return sp.model_dump()
+            if isinstance(sp, dict):
+                return sp
+            return None
+        except (AttributeError, TypeError):
+            return None
+
+    def _maybe_initiate_strategy(
+        self,
+        intent: Any,
+        observed: dict[str, Any],
+        actions: list[Action],
+    ) -> dict[str, Any] | None:
+        """Check if a deployment strategy should be initiated.
+
+        A strategy is needed when:
+        - There are REPLACE actions (model_source drift)
+        - The intent specifies a known strategy (rolling / immediate)
+
+        Returns strategy_progress dict if initiated, None otherwise.
+        """
+        from app.services.strategies import initiate_strategy
+
+        replaces = [a for a in actions if a.type == ActionType.REPLACE]
+        if not replaces:
+            return None
+
+        managed = observed["managed_instances"]
+        candidates = observed["candidates"]
+
+        progress = initiate_strategy(
+            intent=intent,
+            managed_instances=managed,
+            candidates=candidates,
+        )
+        return progress
+
+    async def _continue_strategy(
+        self,
+        intent: Any,
+        observed: dict[str, Any],
+        strategy_progress: dict[str, Any],
+    ) -> None:
+        """Continue an in-flight deployment strategy.
+
+        Drives the strategy state machine: computes the next action,
+        executes it, and updates status with new progress.
+        """
+        from app.config import settings
+        from app.services.strategies import continue_strategy
+
+        managed = observed["managed_instances"]
+        candidates = observed["candidates"]
+        gateway_aliases = observed["gateway_aliases"]
+
+        # Compute health gate elapsed time from strategy start
+        started_at_str = strategy_progress.get("started_at")
+        health_gate_started_at = 0.0
+        if started_at_str:
+            try:
+                started_dt = datetime.fromisoformat(started_at_str)
+                health_gate_started_at = (
+                    datetime.now(timezone.utc) - started_dt
+                ).total_seconds()
+            except (ValueError, TypeError):
+                pass
+
+        timeout = settings.reconcile_health_gate_timeout_s
+
+        # If scale-down requested during strategy, defer it
+        desired = intent.replicas
+        if len(managed) > desired:
+            logger.info(
+                "Scale-down (%d→%d) deferred for intent %s while strategy active",
+                len(managed), desired, intent.id,
+            )
+
+        action_dict, new_progress = continue_strategy(
+            progress_data=strategy_progress,
+            intent=intent,
+            managed_instances=managed,
+            candidates=candidates,
+            gateway_aliases=gateway_aliases,
+            health_gate_started_at=health_gate_started_at,
+            health_gate_timeout_s=timeout,
+        )
+
+        # Execute the action if one is returned
+        last_error = None
+        if action_dict and action_dict.get("type") not in ("wait", "noop"):
+            action_type = action_dict["type"]
+            try:
+                action = Action(
+                    type=(
+                        ActionType.CREATE if action_type == "create"
+                        else ActionType.STOP if action_type == "stop"
+                        else ActionType.NOOP
+                    ),
+                    intent_id=intent.id,
+                    alias=intent.alias,
+                    host_id=action_dict.get("host_id"),
+                    instance_id=action_dict.get("instance_id"),
+                    reason=action_dict.get("reason", ""),
+                    priority=20 if action_type == "create" else 0,
+                )
+                result = await self._act(intent, action)
+
+                # If create succeeded, capture instance_id for progress
+                if action_type == "create" and result and new_progress:
+                    created = result.get("instance", result)
+                    new_progress["current_instance_id"] = (
+                        created.get("id") or created.get("instance_id")
+                    )
+            except Exception as e:
+                logger.error(
+                    "Strategy action %s failed for intent %s: %s",
+                    action_type, intent.id, e,
+                )
+                last_error = {
+                    "code": type(e).__name__,
+                    "message": str(e),
+                    "host_id": action_dict.get("host_id"),
+                    "source_uri": intent.model_source,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+                if new_progress:
+                    new_progress["failed"] = new_progress.get("failed", 0) + 1
+                    failed_hosts = list(new_progress.get("failed_hosts", []))
+                    if action_dict.get("host_id"):
+                        failed_hosts.append(action_dict["host_id"])
+                    new_progress["failed_hosts"] = failed_hosts
+
+        # Update status with strategy progress
+        await self._update_status(
+            intent, observed,
+            last_error=last_error,
+            strategy_progress=new_progress,
+        )
 
     # ── Observe ────────────────────────────────────────────────
 
@@ -935,10 +1145,13 @@ class Reconciler:
         intent: Any,
         observed: dict[str, Any],
         last_error: dict[str, Any] | None = None,
+        strategy_progress: dict[str, Any] | None = None,
     ) -> None:
         """Compute and persist the intent status after reconciliation.
 
         Implements deployment-intent.md §10.2 status fields.
+        When *strategy_progress* is provided (S-042), it is persisted
+        into the status JSON so strategy state survives restarts.
         """
         from app.database.intents import intent_db
         from app.models.intent import (
@@ -1080,7 +1293,7 @@ class Reconciler:
             "shortfall": structural_shortfall,
             "replica_set": replica_set,
             "conditions": conditions,
-            "strategy_progress": None,
+            "strategy_progress": strategy_progress,
             "last_error": last_error_model.model_dump() if last_error_model else None,
         }
 

--- a/app/services/strategies.py
+++ b/app/services/strategies.py
@@ -181,6 +181,14 @@ class RollingStrategy:
         if needed <= 0:
             return None  # Already at desired state
 
+        # Only initiate strategy when there are drifted instances that
+        # need replacing.  Pure scale-up (same source, more replicas)
+        # and initial deployment (0→N) are handled by normal diff.
+        if updated == len(managed_instances) and needed > 0:
+            # All existing instances are already on target source —
+            # this is a pure scale-up, not a version change.
+            return None
+
         # Hosts of managed instances that are NOT yet on the target source
         drifted_host_ids = {
             inst.get("_host_id")
@@ -479,6 +487,11 @@ class ImmediateStrategy:
         if needed <= 0:
             return None  # Already at desired state
 
+        # Only initiate strategy when there are drifted instances that
+        # need replacing.  Pure scale-up is handled by normal diff.
+        if updated == len(managed_instances) and needed > 0:
+            return None
+
         # All managed instances with old source need stopping
         drifted = [
             inst for inst in managed_instances
@@ -498,7 +511,7 @@ class ImmediateStrategy:
 
         return {
             "strategy": "immediate",
-            "target_model_source": target_source,
+            "target_model_source": target_model_source,
             "phase": StrategyPhase.STOPPING_OLD,
             "step": f"0/{total_steps}",
             "updated": updated,

--- a/app/services/strategies.py
+++ b/app/services/strategies.py
@@ -18,7 +18,6 @@ Health gate (shared, per §11.1):
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -200,10 +199,7 @@ class RollingStrategy:
         # Replacement hosts: from candidates, exclude hosts already hosting
         # a managed instance (to enforce one-replica-per-host during
         # replacement — the old instance will be retired first).
-        candidate_hosts = [
-            h for h, _ in candidates
-            if h.id not in drifted_host_ids
-        ]
+        candidate_hosts = [h for h, _ in candidates if h.id not in drifted_host_ids]
 
         # If we have drifted instances, we can also replace in-place:
         # stop old, then create new on same host (candidate hosts list
@@ -299,8 +295,7 @@ class RollingStrategy:
                     "type": "create",
                     "host_id": current_host_id,
                     "reason": (
-                        f"Rolling replacement step "
-                        f"{progress_data.get('step', '?')}"
+                        f"Rolling replacement step " f"{progress_data.get('step', '?')}"
                     ),
                 },
                 progress_data,  # unchanged; _continue_strategy sets instance_id
@@ -344,8 +339,12 @@ class RollingStrategy:
                     # No old instance — this was a pure scale-up add on a
                     # new host.  Advance to next slot.
                     return _advance_to_next_rolling(
-                        progress_data, managed_instances, candidates,
-                        desired_replicas, alias, target_source,
+                        progress_data,
+                        managed_instances,
+                        candidates,
+                        desired_replicas,
+                        alias,
+                        target_source,
                     )
 
             # Check timeout
@@ -383,8 +382,12 @@ class RollingStrategy:
 
             # Old replica gone → advance to next slot
             return _advance_to_next_rolling(
-                progress_data, managed_instances, candidates,
-                desired_replicas, alias, target_source,
+                progress_data,
+                managed_instances,
+                candidates,
+                desired_replicas,
+                alias,
+                target_source,
             )
 
         # ── Unknown phase ────────────────────────────────────────
@@ -421,13 +424,8 @@ def _advance_to_next_rolling(
         if remaining <= 0:
             return None, None
         # Try to find additional candidates
-        current_host_ids = {
-            inst.get("_host_id") for inst in managed_instances
-        }
-        extra_candidates = [
-            h.id for h, _ in candidates
-            if h.id not in current_host_ids
-        ]
+        current_host_ids = {inst.get("_host_id") for inst in managed_instances}
+        extra_candidates = [h.id for h, _ in candidates if h.id not in current_host_ids]
         pending = extra_candidates[:remaining]
 
     if not pending:
@@ -494,17 +492,15 @@ class ImmediateStrategy:
 
         # All managed instances with old source need stopping
         drifted = [
-            inst for inst in managed_instances
+            inst
+            for inst in managed_instances
             if (inst.get("config", inst).get("model_source") != target_model_source)
         ]
 
         # Replacement host candidates
-        current_host_ids = {
-            inst.get("_host_id") for inst in managed_instances
-        }
+        current_host_ids = {inst.get("_host_id") for inst in managed_instances}
         replacement_hosts = [
-            h.id for h, _ in candidates
-            if h.id not in current_host_ids
+            h.id for h, _ in candidates if h.id not in current_host_ids
         ]
 
         total_steps = max(len(drifted), needed)
@@ -551,13 +547,13 @@ class ImmediateStrategy:
                     inst_id = inst.get("instance_id") or inst.get("id")
                     host_id = inst.get("_host_id")
                     remaining = sum(
-                        1 for m in managed_instances
+                        1
+                        for m in managed_instances
                         if (m.get("config", m).get("model_source") != target_source)
                     )
                     new_progress = dict(progress_data)
                     new_progress["message"] = (
-                        f"Stopping old replica on {host_id} "
-                        f"({remaining} remaining)"
+                        f"Stopping old replica on {host_id} " f"({remaining} remaining)"
                     )
                     return (
                         {
@@ -576,17 +572,15 @@ class ImmediateStrategy:
                 return None, None  # Nothing left to do
 
             # Refresh replacement hosts
-            current_host_ids = {
-                inst.get("_host_id") for inst in managed_instances
-            }
+            current_host_ids = {inst.get("_host_id") for inst in managed_instances}
             # Also include candidate hosts from the pending_hosts list
             # that were saved during init
             pending_from_init = list(progress_data.get("pending_hosts", []))
             # Plus new candidates not in current set
             new_candidates = [
-                h.id for h, _ in candidates
-                if h.id not in current_host_ids
-                and h.id not in pending_from_init
+                h.id
+                for h, _ in candidates
+                if h.id not in current_host_ids and h.id not in pending_from_init
             ]
             all_pending = pending_from_init + new_candidates
 
@@ -600,9 +594,7 @@ class ImmediateStrategy:
             new_progress["phase"] = StrategyPhase.CREATING_REPLACEMENTS
             new_progress["pending_hosts"] = all_pending[:needed]
             new_progress["in_progress"] = needed
-            new_progress["message"] = (
-                f"Creating {needed} replacement replica(s)"
-            )
+            new_progress["message"] = f"Creating {needed} replacement replica(s)"
             return {"type": "wait", "reason": "transitioning"}, new_progress
 
         # ── PHASE: creating_replacements ─────────────────────────

--- a/app/services/strategies.py
+++ b/app/services/strategies.py
@@ -1,0 +1,773 @@
+"""Deployment strategies for intent reconciliation (S-042).
+
+Implements rolling and immediate strategies as state machines driven by
+the reconciliation loop.  Each strategy persists its progress in intent
+status so state survives reconciler restarts.
+
+Strategy phases (rolling):
+  creating_replacement → waiting_healthy → retiring_old → (next host or done)
+
+Strategy phases (immediate):
+  stopping_old → creating_replacements → done
+
+Health gate (shared, per §11.1):
+  replacement is healthy when instance status == "running" AND the alias
+  is registered in the gateway registry.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ── Strategy phases ──────────────────────────────────────────────
+
+
+class StrategyPhase:
+    CREATING_REPLACEMENT = "creating_replacement"
+    WAITING_HEALTHY = "waiting_healthy"
+    RETIRING_OLD = "retiring_old"
+    DONE = "done"
+    FAILED = "failed"
+    # Immediate phases
+    STOPPING_OLD = "stopping_old"
+    CREATING_REPLACEMENTS = "creating_replacements"
+
+
+# ── Health gate (shared) ─────────────────────────────────────────
+
+
+async def check_instance_healthy(
+    *,
+    instance_data: dict[str, Any] | None,
+    host_id: str,
+    alias: str,
+    gateway_aliases: set[str],
+) -> bool:
+    """Check if a replacement instance is healthy per §11.1.
+
+    Returns True when ALL hold:
+    1. Instance status == "running"
+    2. Alias is registered in the gateway registry
+    """
+    if instance_data is None:
+        return False
+
+    status = instance_data.get("status") or instance_data.get("state", "")
+    if status != "running":
+        return False
+
+    if alias not in gateway_aliases:
+        return False
+
+    return True
+
+
+def check_instance_healthy_sync(
+    *,
+    instance_data: dict[str, Any] | None,
+    alias: str,
+    gateway_aliases: set[str],
+) -> bool:
+    """Synchronous variant of check_instance_healthy.
+
+    Used inside strategy continue_step() which runs in a sync context
+    after the reconciler has already collected all observed state.
+    """
+    if instance_data is None:
+        return False
+
+    status = instance_data.get("status") or instance_data.get("state", "")
+    if status != "running":
+        return False
+
+    if alias not in gateway_aliases:
+        return False
+
+    return True
+
+
+# ── Shared helpers ───────────────────────────────────────────────
+
+
+def _find_instance_on_host(
+    managed: list[dict[str, Any]],
+    host_id: str | None,
+    instance_id: str | None,
+) -> dict[str, Any] | None:
+    """Find an instance on a host by instance_id or host_id."""
+    for inst in managed:
+        hid = inst.get("_host_id")
+        iid = inst.get("instance_id") or inst.get("id")
+        if instance_id and iid == instance_id:
+            return inst
+        if host_id and hid == host_id and not instance_id:
+            # Return the first instance on this host that's on the
+            # *target* source (the replacement, not an old one still
+            # being retired).  Callers should prefer instance_id.
+            return inst
+    return None
+
+
+def _find_old_instance(
+    managed: list[dict[str, Any]],
+    host_id: str | None,
+    target_source: str,
+) -> dict[str, Any] | None:
+    """Find an instance on *host_id* whose model_source != target_source."""
+    for inst in managed:
+        hid = inst.get("_host_id")
+        if hid != host_id:
+            continue
+        cfg = inst.get("config", inst)
+        if cfg.get("model_source") != target_source:
+            return inst
+    return None
+
+
+def _count_updated(
+    managed: list[dict[str, Any]],
+    target_source: str,
+) -> int:
+    """Count managed instances already on the target model_source."""
+    count = 0
+    for inst in managed:
+        cfg = inst.get("config", inst)
+        if cfg.get("model_source") == target_source:
+            count += 1
+    return count
+
+
+# ── Rolling Strategy (§11.2) ────────────────────────────────────
+
+
+class RollingStrategy:
+    """Rolling update: one host at a time, create→wait-healthy→retire-old.
+
+    Implements deployment-intent.md §11.2.
+
+    State machine:
+      creating_replacement: emit create action → transition to waiting_healthy
+      waiting_healthy: check health gate → if healthy, transition to retiring_old
+      retiring_old: emit stop for old replica → advance to next host or done
+    """
+
+    @staticmethod
+    def init(
+        *,
+        intent_id: str,
+        alias: str,
+        target_model_source: str,
+        desired_replicas: int,
+        managed_instances: list[dict[str, Any]],
+        candidates: list[tuple[Any, Any]],
+    ) -> dict[str, Any] | None:
+        """Initialize a rolling strategy from current observed state.
+
+        Returns strategy_progress dict, or None if nothing to do (already
+        on target source at desired replicas).
+        """
+        now = datetime.now(timezone.utc).isoformat()
+
+        updated = _count_updated(managed_instances, target_model_source)
+
+        # How many replicas still need to be on the target source?
+        needed = desired_replicas - updated
+        if needed <= 0:
+            return None  # Already at desired state
+
+        # Hosts of managed instances that are NOT yet on the target source
+        drifted_host_ids = {
+            inst.get("_host_id")
+            for inst in managed_instances
+            if (inst.get("config", inst).get("model_source") != target_model_source)
+            and inst.get("_host_id") is not None
+        }
+
+        # Replacement hosts: from candidates, exclude hosts already hosting
+        # a managed instance (to enforce one-replica-per-host during
+        # replacement — the old instance will be retired first).
+        candidate_hosts = [
+            h for h, _ in candidates
+            if h.id not in drifted_host_ids
+        ]
+
+        # If we have drifted instances, we can also replace in-place:
+        # stop old, then create new on same host (candidate hosts list
+        # excludes drifted_host_ids, so we add drifted hosts back as
+        # potential targets for replacement after their old instance is
+        # retired).
+        # For in-place: first replacement uses a drifted host directly.
+        all_replacement_hosts: list[str] = []
+        if drifted_host_ids:
+            all_replacement_hosts.extend(sorted(drifted_host_ids))
+        all_replacement_hosts.extend(h.id for h in candidate_hosts)
+        # Deduplicate while preserving order
+        seen: set[str] = set()
+        unique_hosts: list[str] = []
+        for h in all_replacement_hosts:
+            if h not in seen:
+                seen.add(h)
+                unique_hosts.append(h)
+
+        # Need at most `needed` replacement hosts
+        replacement_hosts = unique_hosts[:needed]
+
+        if not replacement_hosts:
+            return None  # No hosts available to place replacements
+
+        first_host = replacement_hosts[0]
+        pending = replacement_hosts[1:] if len(replacement_hosts) > 1 else []
+
+        total_steps = needed
+
+        return {
+            "strategy": "rolling",
+            "target_model_source": target_model_source,
+            "phase": StrategyPhase.CREATING_REPLACEMENT,
+            "step": f"1/{total_steps}",
+            "updated": updated,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": first_host,
+            "current_instance_id": None,
+            "pending_hosts": pending,
+            "failed_hosts": [],
+            "started_at": now,
+            "message": f"Creating replacement on {first_host}",
+        }
+
+    @staticmethod
+    def continue_step(
+        *,
+        progress_data: dict[str, Any],
+        intent_id: str,
+        alias: str,
+        desired_replicas: int,
+        managed_instances: list[dict[str, Any]],
+        candidates: list[tuple[Any, Any]],
+        gateway_aliases: set[str],
+        health_gate_started_at: float,
+        health_gate_timeout_s: float,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Continue a rolling strategy from its current phase.
+
+        Returns (action, new_progress) where:
+        - action: dict with type/host_id/instance_id/reason, or None if done
+        - new_progress: updated progress dict, or None if strategy complete
+        """
+        phase = progress_data.get("phase", "")
+        current_host_id = progress_data.get("current_host_id")
+        current_instance_id = progress_data.get("current_instance_id")
+        target_source = progress_data.get("target_model_source", "")
+
+        # ── PHASE: creating_replacement ──────────────────────────
+        if phase == StrategyPhase.CREATING_REPLACEMENT:
+            if not current_host_id:
+                return _strategy_held(
+                    progress_data,
+                    "No replacement host available",
+                )
+
+            # If we already have a current_instance_id (from a prior
+            # tick that executed the create), transition to waiting.
+            if current_instance_id:
+                new_progress = dict(progress_data)
+                new_progress["phase"] = StrategyPhase.WAITING_HEALTHY
+                new_progress["message"] = (
+                    f"Waiting for replacement on {current_host_id} "
+                    f"to become healthy"
+                )
+                return {"type": "wait", "reason": "awaiting health"}, new_progress
+
+            # Emit create action for the replacement
+            return (
+                {
+                    "type": "create",
+                    "host_id": current_host_id,
+                    "reason": (
+                        f"Rolling replacement step "
+                        f"{progress_data.get('step', '?')}"
+                    ),
+                },
+                progress_data,  # unchanged; _continue_strategy sets instance_id
+            )
+
+        # ── PHASE: waiting_healthy ───────────────────────────────
+        if phase == StrategyPhase.WAITING_HEALTHY:
+            # Find the replacement instance on the current host
+            replacement = _find_instance_on_host(
+                managed_instances, current_host_id, current_instance_id
+            )
+
+            is_healthy = check_instance_healthy_sync(
+                instance_data=replacement,
+                alias=alias,
+                gateway_aliases=gateway_aliases,
+            )
+
+            if is_healthy:
+                # Find old instance to retire on this host
+                old_instance = _find_old_instance(
+                    managed_instances, current_host_id, target_source
+                )
+                if old_instance:
+                    old_id = old_instance.get("instance_id") or old_instance.get("id")
+                    new_progress = dict(progress_data)
+                    new_progress["phase"] = StrategyPhase.RETIRING_OLD
+                    new_progress["message"] = (
+                        f"Retiring old replica on {current_host_id}"
+                    )
+                    return (
+                        {
+                            "type": "stop",
+                            "host_id": current_host_id,
+                            "instance_id": old_id,
+                            "reason": "Rolling: retiring old replica",
+                        },
+                        new_progress,
+                    )
+                else:
+                    # No old instance — this was a pure scale-up add on a
+                    # new host.  Advance to next slot.
+                    return _advance_to_next_rolling(
+                        progress_data, managed_instances, candidates,
+                        desired_replicas, alias, target_source,
+                    )
+
+            # Check timeout
+            elapsed = health_gate_started_at
+            if elapsed > health_gate_timeout_s:
+                return _strategy_held(
+                    progress_data,
+                    (
+                        f"Health gate timeout for replacement on "
+                        f"{current_host_id} after {elapsed:.0f}s"
+                    ),
+                )
+
+            # Still waiting — no action
+            new_progress = dict(progress_data)
+            new_progress["message"] = (
+                f"Waiting for replacement on {current_host_id} "
+                f"({elapsed:.0f}s / {health_gate_timeout_s:.0f}s)"
+            )
+            return {"type": "wait", "reason": "health gate"}, new_progress
+
+        # ── PHASE: retiring_old ──────────────────────────────────
+        if phase == StrategyPhase.RETIRING_OLD:
+            # Check if old instance has been stopped (gone from managed)
+            old_still_exists = _find_old_instance(
+                managed_instances, current_host_id, target_source
+            )
+            if old_still_exists:
+                # Keep waiting for the stop to take effect
+                new_progress = dict(progress_data)
+                new_progress["message"] = (
+                    f"Waiting for old replica on {current_host_id} to stop"
+                )
+                return {"type": "wait", "reason": "awaiting stop"}, new_progress
+
+            # Old replica gone → advance to next slot
+            return _advance_to_next_rolling(
+                progress_data, managed_instances, candidates,
+                desired_replicas, alias, target_source,
+            )
+
+        # ── Unknown phase ────────────────────────────────────────
+        logger.warning("Unknown rolling strategy phase: %s", phase)
+        return None, None
+
+
+def _advance_to_next_rolling(
+    progress_data: dict[str, Any],
+    managed_instances: list[dict[str, Any]],
+    candidates: list[tuple[Any, Any]],
+    desired_replicas: int,
+    alias: str,
+    target_source: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Advance to the next replacement host, or complete the strategy."""
+    updated = _count_updated(managed_instances, target_source)
+
+    # Determine total steps from the step string
+    step_str = progress_data.get("step", "0/1")
+    try:
+        total_steps = int(step_str.split("/")[-1])
+    except (ValueError, IndexError):
+        total_steps = 1
+
+    if updated >= desired_replicas:
+        # All replicas on target source
+        return None, None  # strategy done
+
+    pending = list(progress_data.get("pending_hosts", []))
+    if not pending:
+        # No more hosts to use — check if we still need more
+        remaining = desired_replicas - updated
+        if remaining <= 0:
+            return None, None
+        # Try to find additional candidates
+        current_host_ids = {
+            inst.get("_host_id") for inst in managed_instances
+        }
+        extra_candidates = [
+            h.id for h, _ in candidates
+            if h.id not in current_host_ids
+        ]
+        pending = extra_candidates[:remaining]
+
+    if not pending:
+        # No hosts available but still need replicas → strategy can't complete
+        return None, None
+
+    next_host = pending[0]
+    step_num = updated + 1  # next step after the one that just completed
+    new_progress = dict(progress_data)
+    new_progress["phase"] = StrategyPhase.CREATING_REPLACEMENT
+    new_progress["step"] = f"{step_num}/{total_steps}"
+    new_progress["updated"] = updated
+    new_progress["in_progress"] = 1
+    new_progress["current_host_id"] = next_host
+    new_progress["current_instance_id"] = None
+    new_progress["pending_hosts"] = pending[1:]
+    new_progress["message"] = f"Creating replacement on {next_host}"
+
+    return (
+        {
+            "type": "create",
+            "host_id": next_host,
+            "reason": f"Rolling replacement step {step_num}/{total_steps}",
+        },
+        new_progress,
+    )
+
+
+# ── Immediate Strategy (§11.3) ──────────────────────────────────
+
+
+class ImmediateStrategy:
+    """Immediate update: stop all old replicas, then create all replacements.
+
+    Implements deployment-intent.md §11.3.
+
+    State machine:
+      stopping_old: emit stop for each old replica → transition to creating
+      creating_replacements: emit create for each replacement → done
+    """
+
+    @staticmethod
+    def init(
+        *,
+        intent_id: str,
+        alias: str,
+        target_model_source: str,
+        desired_replicas: int,
+        managed_instances: list[dict[str, Any]],
+        candidates: list[tuple[Any, Any]],
+    ) -> dict[str, Any] | None:
+        """Initialize an immediate strategy from current observed state."""
+        now = datetime.now(timezone.utc).isoformat()
+
+        updated = _count_updated(managed_instances, target_model_source)
+        needed = desired_replicas - updated
+        if needed <= 0:
+            return None  # Already at desired state
+
+        # All managed instances with old source need stopping
+        drifted = [
+            inst for inst in managed_instances
+            if (inst.get("config", inst).get("model_source") != target_model_source)
+        ]
+
+        # Replacement host candidates
+        current_host_ids = {
+            inst.get("_host_id") for inst in managed_instances
+        }
+        replacement_hosts = [
+            h.id for h, _ in candidates
+            if h.id not in current_host_ids
+        ]
+
+        total_steps = max(len(drifted), needed)
+
+        return {
+            "strategy": "immediate",
+            "target_model_source": target_source,
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": f"0/{total_steps}",
+            "updated": updated,
+            "in_progress": len(drifted),
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": replacement_hosts[:needed],
+            "failed_hosts": [],
+            "started_at": now,
+            "message": f"Stopping {len(drifted)} old replica(s)",
+        }
+
+    @staticmethod
+    def continue_step(
+        *,
+        progress_data: dict[str, Any],
+        intent_id: str,
+        alias: str,
+        desired_replicas: int,
+        managed_instances: list[dict[str, Any]],
+        candidates: list[tuple[Any, Any]],
+        gateway_aliases: set[str],
+        health_gate_started_at: float,
+        health_gate_timeout_s: float,
+    ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+        """Continue an immediate strategy from its current phase."""
+        phase = progress_data.get("phase", "")
+        target_source = progress_data.get("target_model_source", "")
+
+        # ── PHASE: stopping_old ──────────────────────────────────
+        if phase == StrategyPhase.STOPPING_OLD:
+            # Find first old instance still running
+            for inst in managed_instances:
+                cfg = inst.get("config", inst)
+                if cfg.get("model_source") != target_source:
+                    inst_id = inst.get("instance_id") or inst.get("id")
+                    host_id = inst.get("_host_id")
+                    remaining = sum(
+                        1 for m in managed_instances
+                        if (m.get("config", m).get("model_source") != target_source)
+                    )
+                    new_progress = dict(progress_data)
+                    new_progress["message"] = (
+                        f"Stopping old replica on {host_id} "
+                        f"({remaining} remaining)"
+                    )
+                    return (
+                        {
+                            "type": "stop",
+                            "host_id": host_id,
+                            "instance_id": inst_id,
+                            "reason": "Immediate: stopping old replica",
+                        },
+                        new_progress,
+                    )
+
+            # All old instances stopped → transition to creating
+            updated = _count_updated(managed_instances, target_source)
+            needed = desired_replicas - updated
+            if needed <= 0:
+                return None, None  # Nothing left to do
+
+            # Refresh replacement hosts
+            current_host_ids = {
+                inst.get("_host_id") for inst in managed_instances
+            }
+            # Also include candidate hosts from the pending_hosts list
+            # that were saved during init
+            pending_from_init = list(progress_data.get("pending_hosts", []))
+            # Plus new candidates not in current set
+            new_candidates = [
+                h.id for h, _ in candidates
+                if h.id not in current_host_ids
+                and h.id not in pending_from_init
+            ]
+            all_pending = pending_from_init + new_candidates
+
+            if not all_pending and needed > 0:
+                return _strategy_held(
+                    progress_data,
+                    f"No hosts available for {needed} replacement replicas",
+                )
+
+            new_progress = dict(progress_data)
+            new_progress["phase"] = StrategyPhase.CREATING_REPLACEMENTS
+            new_progress["pending_hosts"] = all_pending[:needed]
+            new_progress["in_progress"] = needed
+            new_progress["message"] = (
+                f"Creating {needed} replacement replica(s)"
+            )
+            return {"type": "wait", "reason": "transitioning"}, new_progress
+
+        # ── PHASE: creating_replacements ─────────────────────────
+        if phase == StrategyPhase.CREATING_REPLACEMENTS:
+            pending = list(progress_data.get("pending_hosts", []))
+            if not pending:
+                # All replacements dispatched — strategy done
+                return None, None
+
+            host_id = pending[0]
+            remaining = len(pending)
+            new_progress = dict(progress_data)
+            new_progress["pending_hosts"] = pending[1:]
+            new_progress["message"] = (
+                f"Creating replacement on {host_id} ({remaining} remaining)"
+            )
+            new_progress["in_progress"] = remaining
+            return (
+                {
+                    "type": "create",
+                    "host_id": host_id,
+                    "reason": "Immediate: creating replacement",
+                },
+                new_progress,
+            )
+
+        # ── Unknown phase ────────────────────────────────────────
+        logger.warning("Unknown immediate strategy phase: %s", phase)
+        return None, None
+
+
+# ── Failure helpers ──────────────────────────────────────────────
+
+
+def _strategy_held(
+    progress_data: dict[str, Any],
+    message: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Strategy is held — do not proceed, keep existing state.
+
+    For rolling: old replicas keep running, intent becomes degraded
+    but service remains available with a mix of old/new replicas.
+    For immediate: replacements that came up stay running; shortfall
+    is reported.
+    """
+    new_progress = dict(progress_data)
+    new_progress["phase"] = StrategyPhase.FAILED
+    new_progress["failed"] = new_progress.get("failed", 0) + 1
+    new_progress["message"] = message
+    new_progress["in_progress"] = 0
+    return {"type": "wait", "reason": "strategy held"}, new_progress
+
+
+def _strategy_failed(
+    progress_data: dict[str, Any],
+    message: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Strategy has permanently failed — clear and report."""
+    new_progress = dict(progress_data)
+    new_progress["phase"] = StrategyPhase.FAILED
+    new_progress["message"] = message
+    return None, new_progress
+
+
+# ── Initiation helper ────────────────────────────────────────────
+
+
+def should_initiate_strategy(
+    *,
+    intent: Any,
+    managed_instances: list[dict[str, Any]],
+) -> bool:
+    """Check if a strategy should be initiated for this intent.
+
+    Returns True when:
+    - Any managed instance has a different model_source from the intent
+    - AND the intent specifies a supported strategy ('rolling'/'immediate')
+    """
+    strategy = getattr(intent, "strategy", None)
+    if strategy not in ("rolling", "immediate"):
+        return False
+
+    target_source = getattr(intent, "model_source", None)
+    if not target_source:
+        return False
+
+    for inst in managed_instances:
+        cfg = inst.get("config", inst)
+        if cfg.get("model_source") != target_source:
+            return True
+
+    # Also trigger if observed < desired (scale-up) — handled by normal
+    # diff, but if there's also source drift we want the strategy.
+    return False
+
+
+def initiate_strategy(
+    *,
+    intent: Any,
+    managed_instances: list[dict[str, Any]],
+    candidates: list[tuple[Any, Any]],
+) -> dict[str, Any] | None:
+    """Create initial strategy_progress for the intent's strategy.
+
+    Returns strategy_progress dict or None if no strategy needed.
+    """
+    strategy_name = getattr(intent, "strategy", None)
+    alias = getattr(intent, "alias", "")
+    target_source = getattr(intent, "model_source", "")
+    desired = getattr(intent, "replicas", 0)
+    intent_id = getattr(intent, "id", "")
+
+    if strategy_name == "rolling":
+        return RollingStrategy.init(
+            intent_id=intent_id,
+            alias=alias,
+            target_model_source=target_source,
+            desired_replicas=desired,
+            managed_instances=managed_instances,
+            candidates=candidates,
+        )
+    elif strategy_name == "immediate":
+        return ImmediateStrategy.init(
+            intent_id=intent_id,
+            alias=alias,
+            target_model_source=target_source,
+            desired_replicas=desired,
+            managed_instances=managed_instances,
+            candidates=candidates,
+        )
+
+    return None
+
+
+def continue_strategy(
+    *,
+    progress_data: dict[str, Any],
+    intent: Any,
+    managed_instances: list[dict[str, Any]],
+    candidates: list[tuple[Any, Any]],
+    gateway_aliases: set[str],
+    health_gate_started_at: float,
+    health_gate_timeout_s: float,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Continue an in-flight strategy from its current phase.
+
+    Returns (action_dict, new_progress) — same convention as
+    RollingStrategy.continue_step / ImmediateStrategy.continue_step.
+    """
+    strategy_name = progress_data.get("strategy", "")
+    alias = getattr(intent, "alias", "")
+    desired = getattr(intent, "replicas", 0)
+    intent_id = getattr(intent, "id", "")
+
+    if strategy_name == "rolling":
+        return RollingStrategy.continue_step(
+            progress_data=progress_data,
+            intent_id=intent_id,
+            alias=alias,
+            desired_replicas=desired,
+            managed_instances=managed_instances,
+            candidates=candidates,
+            gateway_aliases=gateway_aliases,
+            health_gate_started_at=health_gate_started_at,
+            health_gate_timeout_s=health_gate_timeout_s,
+        )
+    elif strategy_name == "immediate":
+        return ImmediateStrategy.continue_step(
+            progress_data=progress_data,
+            intent_id=intent_id,
+            alias=alias,
+            desired_replicas=desired,
+            managed_instances=managed_instances,
+            candidates=candidates,
+            gateway_aliases=gateway_aliases,
+            health_gate_started_at=health_gate_started_at,
+            health_gate_timeout_s=health_gate_timeout_s,
+        )
+
+    logger.warning("Unknown strategy: %s", strategy_name)
+    return None, None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,697 @@
+"""Tests for deployment strategies (S-042).
+
+Covers §11.6 scenarios: scale up, model version change (rolling/immediate),
+failed health check (rolling hold), failed health check (immediate degraded),
+shortfall, in-place replacement, and dispatch functions.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.services.strategies import (
+    ImmediateStrategy,
+    RollingStrategy,
+    StrategyPhase,
+    check_instance_healthy_sync,
+    continue_strategy,
+    initiate_strategy,
+    should_initiate_strategy,
+)
+
+
+# ── Test stubs ────────────────────────────────────────────────────
+
+
+@dataclass
+class _HostStub:
+    id: str
+    name: str = ""
+    status: str = "online"
+    url: str = "http://localhost:8080"
+    api_key: str = "test-key"
+    roles: list | None = None
+    gpu_type: str | None = None
+
+    def __post_init__(self):
+        if self.roles is None:
+            self.roles = ["inference"]
+
+
+def _make_instance(
+    instance_id: str,
+    host_id: str = "host-1",
+    host_name: str = "host1",
+    alias: str = "test-model",
+    model_source: str = "repo://test:v1",
+    status: str = "running",
+    **extra_config,
+) -> dict:
+    """Build a managed instance dict matching the Redis/host-store format."""
+    config: dict = {
+        "alias": alias,
+        "model_source": model_source,
+        "managed_by": "intent",
+        "intent_id": "intent-001",
+    }
+    config.update(extra_config)
+    return {
+        "instance_id": instance_id,
+        "id": instance_id,
+        "status": status,
+        "config": config,
+        "_host_id": host_id,
+        "_host_name": host_name,
+    }
+
+
+def _make_intent_stub(**overrides):
+    """Build a minimal intent stub for dispatch tests."""
+    defaults = {
+        "id": "intent-001",
+        "alias": "test-model",
+        "model_source": "repo://test:v2",
+        "replicas": 2,
+        "strategy": "rolling",
+        "priority": "production",
+    }
+    defaults.update(overrides)
+
+    class IntentStub:
+        pass
+
+    obj = IntentStub()
+    for k, v in defaults.items():
+        setattr(obj, k, v)
+    return obj
+
+
+# ── Health gate tests ──────────────────────────────────────────────
+
+
+class TestHealthGate:
+    """Test the shared health gate function (§11.1)."""
+
+    def test_healthy_when_running_and_registered(self):
+        assert check_instance_healthy_sync(
+            instance_data={"status": "running", "config": {"alias": "test"}},
+            alias="test",
+            gateway_aliases={"test"},
+        ) is True
+
+    def test_not_healthy_when_not_running(self):
+        assert check_instance_healthy_sync(
+            instance_data={"status": "starting", "config": {"alias": "test"}},
+            alias="test",
+            gateway_aliases={"test"},
+        ) is False
+
+    def test_not_healthy_when_not_in_gateway(self):
+        assert check_instance_healthy_sync(
+            instance_data={"status": "running", "config": {"alias": "test"}},
+            alias="test",
+            gateway_aliases=set(),
+        ) is False
+
+    def test_not_healthy_when_instance_is_none(self):
+        assert check_instance_healthy_sync(
+            instance_data=None,
+            alias="test",
+            gateway_aliases={"test"},
+        ) is False
+
+    def test_not_healthy_when_status_is_failed(self):
+        assert check_instance_healthy_sync(
+            instance_data={"status": "failed", "config": {"alias": "test"}},
+            alias="test",
+            gateway_aliases={"test"},
+        ) is False
+
+    def test_uses_state_fallback_when_status_missing(self):
+        """check_instance_healthy_sync falls back to 'state' if 'status'
+        key is missing."""
+        assert check_instance_healthy_sync(
+            instance_data={"state": "running", "config": {"alias": "test"}},
+            alias="test",
+            gateway_aliases={"test"},
+        ) is True
+
+
+# ── Rolling strategy tests (§11.2) ─────────────────────────────────
+
+
+class TestRollingInit:
+    """Test RollingStrategy.init() for various scenarios."""
+
+    def test_init_returns_none_when_already_on_target(self):
+        """No strategy needed when all replicas already on target source."""
+        managed = [
+            _make_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_instance("i2", host_id="h2", model_source="repo://test:v2"),
+        ]
+        candidates = [(_HostStub(id="h3"), None)]
+        result = RollingStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=2, managed_instances=managed, candidates=candidates,
+        )
+        assert result is None
+
+    def test_init_for_model_version_change(self):
+        """Rolling update from v1 to v2 generates creating_replacement phase."""
+        managed = [
+            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
+            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        candidates = [
+            (_HostStub(id="h3", name="h3"), None),
+            (_HostStub(id="h4", name="h4"), None),
+        ]
+        progress = RollingStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=2, managed_instances=managed, candidates=candidates,
+        )
+        assert progress is not None
+        assert progress["strategy"] == "rolling"
+        assert progress["target_model_source"] == "repo://test:v2"
+        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        assert progress["updated"] == 0
+        assert progress["in_progress"] == 1
+        assert progress["failed"] == 0
+        assert progress["step"] == "1/2"
+        assert progress["current_host_id"] is not None
+        assert "started_at" in progress
+
+    def test_init_scale_up_same_source(self):
+        """Scale up with same source: all instances match target, returns None."""
+        managed = [
+            _make_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        candidates = [(_HostStub(id="h2"), None)]
+        result = RollingStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v1",
+            desired_replicas=2, managed_instances=managed, candidates=candidates,
+        )
+        # Pure scale-up (no drift): strategy not needed
+        assert result is None
+
+    def test_init_in_place_replacement(self):
+        """When no new hosts available, drifted hosts become replacement targets."""
+        managed = [
+            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        # No external candidates — must replace on the drifted host itself
+        candidates: list = []
+        progress = RollingStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=1, managed_instances=managed, candidates=candidates,
+        )
+        assert progress is not None
+        assert progress["current_host_id"] == "h1"  # in-place
+
+    def test_init_shortfall_fewer_candidates_than_needed(self):
+        """Initial deployment (0→N) is not a strategy — it goes through normal diff.
+        
+        Strategy is only for version changes (existing drifted instances).
+        Initial deployment with fewer candidates is handled by the reconciler's
+        normal CREATE actions with shortfall reporting.
+        """
+        managed: list = []
+        candidates = [(_HostStub(id="h1", name="h1"), None)]
+        progress = RollingStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=3, managed_instances=managed, candidates=candidates,
+        )
+        # Initial deployment goes through normal diff, not strategy
+        assert progress is None
+
+
+class TestRollingContinue:
+    """Test RollingStrategy.continue_step() through all phases."""
+
+    def _base_continue_args(self, **overrides):
+        """Return default args for continue_step()."""
+        defaults = {
+            "progress_data": {
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.CREATING_REPLACEMENT,
+                "step": "1/2",
+                "updated": 0,
+                "in_progress": 1,
+                "failed": 0,
+                "current_host_id": "h3",
+                "current_instance_id": None,
+                "pending_hosts": ["h4"],
+                "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z",
+                "message": "Creating replacement on h3",
+            },
+            "intent_id": "int-1",
+            "alias": "test-model",
+            "desired_replicas": 2,
+            "managed_instances": [],
+            "candidates": [],
+            "gateway_aliases": set(),
+            "health_gate_started_at": 0.0,
+            "health_gate_timeout_s": 120.0,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_creating_emits_create_action(self):
+        """Phase creating_replacement with no instance_id emits create."""
+        args = self._base_continue_args(
+            progress_data={
+                **self._base_continue_args()["progress_data"],
+                "current_instance_id": None,
+            },
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "create"
+        assert action["host_id"] == "h3"
+        # Progress unchanged — caller sets instance_id after create
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+    def test_creating_with_instance_id_transitions_to_waiting(self):
+        """When instance_id is already set, transition to waiting_healthy."""
+        args = self._base_continue_args(
+            progress_data={
+                **self._base_continue_args()["progress_data"],
+                "current_instance_id": "new-inst-1",
+            },
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "wait"
+        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
+
+    def test_waiting_healthy_emits_stop_when_healthy(self):
+        """When replacement becomes healthy, emit stop for old replica."""
+        managed = [
+            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="running"),
+        ]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.WAITING_HEALTHY,
+                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
+                "current_host_id": "h3", "current_instance_id": "new-1",
+                "pending_hosts": ["h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            gateway_aliases={"test-model"},
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "stop"
+        assert action["instance_id"] == "old-1"
+        assert new_progress["phase"] == StrategyPhase.RETIRING_OLD
+
+    def test_waiting_healthy_waits_when_not_healthy(self):
+        """When replacement not yet healthy, emit wait."""
+        managed = [
+            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="starting"),
+        ]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.WAITING_HEALTHY,
+                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
+                "current_host_id": "h3", "current_instance_id": "new-1",
+                "pending_hosts": ["h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            gateway_aliases={"test-model"},
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "wait"
+        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
+
+    def test_waiting_healthy_timeout_holds(self):
+        """When health gate timeout exceeded, strategy holds (failed phase)."""
+        managed = [
+            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="starting"),
+        ]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.WAITING_HEALTHY,
+                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
+                "current_host_id": "h3", "current_instance_id": "new-1",
+                "pending_hosts": ["h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            gateway_aliases={"test-model"},
+            health_gate_started_at=999.0,  # way past timeout
+            health_gate_timeout_s=120.0,
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert new_progress["phase"] == StrategyPhase.FAILED
+        # Old replica NOT retired — kept running (rolling hold)
+        assert action["type"] == "wait"
+
+    def test_retiring_old_waits_until_stopped(self):
+        """While old instance still exists, keep waiting."""
+        managed = [
+            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
+        ]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.RETIRING_OLD,
+                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
+                "current_host_id": "h3", "current_instance_id": "new-1",
+                "pending_hosts": ["h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            gateway_aliases={"test-model"},
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action["type"] == "wait"
+        assert new_progress["phase"] == StrategyPhase.RETIRING_OLD
+
+    def test_retiring_old_advances_to_next_when_gone(self):
+        """When old instance is gone, proceed to next host."""
+        managed = [
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
+        ]
+        candidates = [(_HostStub(id="h4", name="h4"), None)]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.RETIRING_OLD,
+                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
+                "current_host_id": "h3", "current_instance_id": "new-1",
+                "pending_hosts": ["h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            candidates=candidates,
+            gateway_aliases={"test-model"},
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "create"  # next host
+        assert action["host_id"] == "h4"
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+    def test_completes_when_all_updated(self):
+        """Strategy returns (None, None) when all replicas on target source."""
+        managed = [
+            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
+            _make_instance("new-2", host_id="h4", model_source="repo://test:v2"),
+        ]
+        args = self._base_continue_args(
+            progress_data={
+                "strategy": "rolling",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.RETIRING_OLD,
+                "step": "2/2", "updated": 1, "in_progress": 0, "failed": 0,
+                "current_host_id": "h4", "current_instance_id": "new-2",
+                "pending_hosts": [], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "",
+            },
+            managed_instances=managed,
+            gateway_aliases={"test-model"},
+        )
+        action, new_progress = RollingStrategy.continue_step(**args)
+        assert action is None
+        assert new_progress is None  # strategy complete
+
+
+# ── Immediate strategy tests (§11.3) ──────────────────────────────
+
+
+class TestImmediateInit:
+    """Test ImmediateStrategy.init()."""
+
+    def test_init_returns_none_when_already_on_target(self):
+        managed = [
+            _make_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+        result = ImmediateStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=1, managed_instances=managed, candidates=[],
+        )
+        assert result is None
+
+    def test_init_with_drifted_instances(self):
+        managed = [
+            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
+            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        candidates = [
+            (_HostStub(id="h3"), None),
+            (_HostStub(id="h4"), None),
+        ]
+        progress = ImmediateStrategy.init(
+            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
+            desired_replicas=2, managed_instances=managed, candidates=candidates,
+        )
+        assert progress is not None
+        assert progress["strategy"] == "immediate"
+        assert progress["phase"] == StrategyPhase.STOPPING_OLD
+        assert progress["in_progress"] == 2  # 2 old to stop
+
+
+class TestImmediateContinue:
+    """Test ImmediateStrategy.continue_step()."""
+
+    def _base_args(self, **overrides):
+        defaults = {
+            "progress_data": {
+                "strategy": "immediate",
+                "target_model_source": "repo://test:v2",
+                "phase": StrategyPhase.STOPPING_OLD,
+                "step": "0/2", "updated": 0, "in_progress": 2, "failed": 0,
+                "current_host_id": None, "current_instance_id": None,
+                "pending_hosts": ["h3", "h4"], "failed_hosts": [],
+                "started_at": "2026-01-01T00:00:00Z", "message": "Stopping old",
+            },
+            "intent_id": "int-1", "alias": "test-model",
+            "desired_replicas": 2, "managed_instances": [],
+            "candidates": [], "gateway_aliases": set(),
+            "health_gate_started_at": 0.0, "health_gate_timeout_s": 120.0,
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_stopping_old_emits_stop(self):
+        managed = [
+            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
+            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        args = self._base_args(managed_instances=managed)
+        action, new_progress = ImmediateStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "stop"
+        assert action["host_id"] == "h1"
+        assert new_progress["phase"] == StrategyPhase.STOPPING_OLD
+
+    def test_stopping_transitions_to_creating_when_all_stopped(self):
+        """When no old instances remain, transition to creating_replacements."""
+        managed: list = []  # all old stopped
+        candidates = [
+            (_HostStub(id="h3"), None),
+            (_HostStub(id="h4"), None),
+        ]
+        args = self._base_args(
+            managed_instances=managed,
+            candidates=candidates,
+        )
+        action, new_progress = ImmediateStrategy.continue_step(**args)
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENTS
+
+    def test_creating_emits_create_actions(self):
+        """create_replacements phase emits create for each pending host."""
+        candidates = [(_HostStub(id="h3"), None)]
+        args = self._base_args(
+            progress_data={
+                **self._base_args()["progress_data"],
+                "phase": StrategyPhase.CREATING_REPLACEMENTS,
+                "pending_hosts": ["h3"],
+                "in_progress": 1,
+            },
+            candidates=candidates,
+        )
+        action, new_progress = ImmediateStrategy.continue_step(**args)
+        assert action is not None
+        assert action["type"] == "create"
+        assert action["host_id"] == "h3"
+
+    def test_completes_when_all_replacement_hosts_used(self):
+        """When pending_hosts is empty, strategy completes."""
+        args = self._base_args(
+            progress_data={
+                **self._base_args()["progress_data"],
+                "phase": StrategyPhase.CREATING_REPLACEMENTS,
+                "pending_hosts": [],
+                "in_progress": 0,
+            },
+        )
+        action, new_progress = ImmediateStrategy.continue_step(**args)
+        assert action is None
+        assert new_progress is None
+
+    def test_degraded_when_no_hosts_for_replacements(self):
+        """When stopping_old completes but no hosts for replacements, fails."""
+        managed: list = []
+        args = self._base_args(
+            managed_instances=managed,
+            progress_data={
+                **self._base_args()["progress_data"],
+                "pending_hosts": [],  # none available
+            },
+        )
+        action, new_progress = ImmediateStrategy.continue_step(**args)
+        # Should transition with what it has — empty pending list is OK
+        assert new_progress is not None
+
+
+# ── Dispatch function tests ───────────────────────────────────────
+
+
+class TestShouldInitiateStrategy:
+    """Test should_initiate_strategy()."""
+
+    def test_true_when_drift_and_valid_strategy(self):
+        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v2")
+        managed = [_make_instance("old-1", model_source="repo://test:v1")]
+        assert should_initiate_strategy(intent=intent, managed_instances=managed) is True
+
+    def test_false_when_no_drift(self):
+        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v1")
+        managed = [_make_instance("i1", model_source="repo://test:v1")]
+        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
+
+    def test_false_when_unknown_strategy(self):
+        intent = _make_intent_stub(strategy="unknown", model_source="repo://test:v2")
+        managed = [_make_instance("old-1", model_source="repo://test:v1")]
+        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
+
+    def test_false_when_strategy_is_none(self):
+        intent = _make_intent_stub(strategy=None, model_source="repo://test:v2")
+        managed = [_make_instance("old-1", model_source="repo://test:v1")]
+        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
+
+
+class TestInitiateStrategy:
+    """Test initiate_strategy() dispatch."""
+
+    def test_rolling_strategy_dispatched(self):
+        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v2")
+        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
+        candidates = [(_HostStub(id="h2"), None)]
+        progress = initiate_strategy(
+            intent=intent, managed_instances=managed, candidates=candidates,
+        )
+        assert progress is not None
+        assert progress["strategy"] == "rolling"
+        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+    def test_immediate_strategy_dispatched(self):
+        intent = _make_intent_stub(strategy="immediate", model_source="repo://test:v2")
+        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
+        candidates = [(_HostStub(id="h2"), None)]
+        progress = initiate_strategy(
+            intent=intent, managed_instances=managed, candidates=candidates,
+        )
+        assert progress is not None
+        assert progress["strategy"] == "immediate"
+        assert progress["phase"] == StrategyPhase.STOPPING_OLD
+
+    def test_unknown_strategy_returns_none(self):
+        intent = _make_intent_stub(strategy="canary", model_source="repo://test:v2")
+        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
+        progress = initiate_strategy(
+            intent=intent, managed_instances=managed, candidates=[],
+        )
+        assert progress is None
+
+
+class TestContinueStrategyDispatch:
+    """Test continue_strategy() dispatch function."""
+
+    def test_rolling_dispatched_correctly(self):
+        intent = _make_intent_stub(strategy="rolling")
+        progress_data = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENT,
+            "step": "1/1", "updated": 0, "in_progress": 1, "failed": 0,
+            "current_host_id": "h1", "current_instance_id": None,
+            "pending_hosts": [], "failed_hosts": [],
+            "started_at": "2026-01-01T00:00:00Z", "message": "",
+        }
+        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
+        action, new_progress = continue_strategy(
+            progress_data=progress_data,
+            intent=intent,
+            managed_instances=managed,
+            candidates=[],
+            gateway_aliases={"test-model"},
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=120.0,
+        )
+        assert action is not None
+        assert action["type"] == "create"
+
+    def test_immediate_dispatched_correctly(self):
+        intent = _make_intent_stub(strategy="immediate")
+        progress_data = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/1", "updated": 0, "in_progress": 1, "failed": 0,
+            "current_host_id": None, "current_instance_id": None,
+            "pending_hosts": ["h2"], "failed_hosts": [],
+            "started_at": "2026-01-01T00:00:00Z", "message": "",
+        }
+        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
+        action, new_progress = continue_strategy(
+            progress_data=progress_data,
+            intent=intent,
+            managed_instances=managed,
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=120.0,
+        )
+        assert action is not None
+        assert action["type"] == "stop"
+
+    def test_unknown_strategy_returns_none(self):
+        intent = _make_intent_stub(strategy="unknown")
+        progress_data = {
+            "strategy": "unknown",
+            "phase": "whatever",
+            "step": "1/1", "updated": 0, "in_progress": 0, "failed": 0,
+            "pending_hosts": [], "failed_hosts": [],
+            "started_at": "2026-01-01T00:00:00Z", "message": "",
+        }
+        action, new_progress = continue_strategy(
+            progress_data=progress_data,
+            intent=intent,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=120.0,
+        )
+        assert action is None
+        assert new_progress is None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,26 +1,33 @@
-"""Tests for deployment strategies (S-042).
+"""Comprehensive tests for S-042 deployment strategies module.
 
-Covers §11.6 scenarios: scale up, model version change (rolling/immediate),
-failed health check (rolling hold), failed health check (immediate degraded),
-shortfall, in-place replacement, and dispatch functions.
+Tests cover:
+  - check_instance_healthy_sync() health gate
+  - RollingStrategy.init() and RollingStrategy.continue_step()
+  - ImmediateStrategy.init() and ImmediateStrategy.continue_step()
+  - initiate_strategy() and continue_strategy() dispatch
+  - Failure modes: timeout, shortfall, in-place replacement
 """
 
 from dataclasses import dataclass
 
-import pytest
 
 from app.services.strategies import (
     ImmediateStrategy,
     RollingStrategy,
     StrategyPhase,
+    _advance_to_next_rolling,
+    _count_updated,
+    _find_instance_on_host,
+    _find_old_instance,
+    _strategy_failed,
+    _strategy_held,
     check_instance_healthy_sync,
     continue_strategy,
     initiate_strategy,
     should_initiate_strategy,
 )
 
-
-# ── Test stubs ────────────────────────────────────────────────────
+# ── Test stubs ──────────────────────────────────────────────────
 
 
 @dataclass
@@ -38,21 +45,34 @@ class _HostStub:
             self.roles = ["inference"]
 
 
-def _make_instance(
-    instance_id: str,
-    host_id: str = "host-1",
-    host_name: str = "host1",
-    alias: str = "test-model",
-    model_source: str = "repo://test:v1",
-    status: str = "running",
+@dataclass
+class _IntentStub:
+    """Minimal intent stub for dispatch tests."""
+
+    id: str = "intent-001"
+    alias: str = "test-model"
+    model_source: str = "repo://test:v2"
+    replicas: int = 3
+    strategy: str = "rolling"
+
+
+def _make_managed_instance(
+    instance_id,
+    host_id="host-1",
+    host_name="host1",
+    alias="test-model",
+    model_source="repo://test:v1",
+    status="running",
     **extra_config,
-) -> dict:
-    """Build a managed instance dict matching the Redis/host-store format."""
-    config: dict = {
+):
+    """Build a managed instance dict matching the Redis-backed format."""
+    config = {
         "alias": alias,
         "model_source": model_source,
         "managed_by": "intent",
         "intent_id": "intent-001",
+        "backend_type": "huggingface_classification",
+        "max_length": 512,
     }
     config.update(extra_config)
     return {
@@ -65,633 +85,1676 @@ def _make_instance(
     }
 
 
-def _make_intent_stub(**overrides):
-    """Build a minimal intent stub for dispatch tests."""
-    defaults = {
-        "id": "intent-001",
-        "alias": "test-model",
-        "model_source": "repo://test:v2",
-        "replicas": 2,
-        "strategy": "rolling",
-        "priority": "production",
-    }
-    defaults.update(overrides)
-
-    class IntentStub:
-        pass
-
-    obj = IntentStub()
-    for k, v in defaults.items():
-        setattr(obj, k, v)
-    return obj
+# ── Helpers ─────────────────────────────────────────────────────
 
 
-# ── Health gate tests ──────────────────────────────────────────────
+def _make_candidates(*host_ids):
+    """Build a list of (HostStub, None) tuples for candidate hosts."""
+    return [(_HostStub(id=h), None) for h in host_ids]
 
 
-class TestHealthGate:
-    """Test the shared health gate function (§11.1)."""
+# ═════════════════════════════════════════════════════════════════
+#  health gate tests
+# ═════════════════════════════════════════════════════════════════
 
-    def test_healthy_when_running_and_registered(self):
-        assert check_instance_healthy_sync(
-            instance_data={"status": "running", "config": {"alias": "test"}},
-            alias="test",
-            gateway_aliases={"test"},
-        ) is True
 
-    def test_not_healthy_when_not_running(self):
-        assert check_instance_healthy_sync(
-            instance_data={"status": "starting", "config": {"alias": "test"}},
-            alias="test",
-            gateway_aliases={"test"},
-        ) is False
+class TestCheckInstanceHealthySync:
+    """Tests for check_instance_healthy_sync() — §11.1 health gate."""
 
-    def test_not_healthy_when_not_in_gateway(self):
-        assert check_instance_healthy_sync(
-            instance_data={"status": "running", "config": {"alias": "test"}},
-            alias="test",
-            gateway_aliases=set(),
-        ) is False
-
-    def test_not_healthy_when_instance_is_none(self):
-        assert check_instance_healthy_sync(
+    def test_none_instance_data_returns_false(self):
+        result = check_instance_healthy_sync(
             instance_data=None,
-            alias="test",
-            gateway_aliases={"test"},
-        ) is False
-
-    def test_not_healthy_when_status_is_failed(self):
-        assert check_instance_healthy_sync(
-            instance_data={"status": "failed", "config": {"alias": "test"}},
-            alias="test",
-            gateway_aliases={"test"},
-        ) is False
-
-    def test_uses_state_fallback_when_status_missing(self):
-        """check_instance_healthy_sync falls back to 'state' if 'status'
-        key is missing."""
-        assert check_instance_healthy_sync(
-            instance_data={"state": "running", "config": {"alias": "test"}},
-            alias="test",
-            gateway_aliases={"test"},
-        ) is True
-
-
-# ── Rolling strategy tests (§11.2) ─────────────────────────────────
-
-
-class TestRollingInit:
-    """Test RollingStrategy.init() for various scenarios."""
-
-    def test_init_returns_none_when_already_on_target(self):
-        """No strategy needed when all replicas already on target source."""
-        managed = [
-            _make_instance("i1", host_id="h1", model_source="repo://test:v2"),
-            _make_instance("i2", host_id="h2", model_source="repo://test:v2"),
-        ]
-        candidates = [(_HostStub(id="h3"), None)]
-        result = RollingStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=2, managed_instances=managed, candidates=candidates,
-        )
-        assert result is None
-
-    def test_init_for_model_version_change(self):
-        """Rolling update from v1 to v2 generates creating_replacement phase."""
-        managed = [
-            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
-            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
-        ]
-        candidates = [
-            (_HostStub(id="h3", name="h3"), None),
-            (_HostStub(id="h4", name="h4"), None),
-        ]
-        progress = RollingStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=2, managed_instances=managed, candidates=candidates,
-        )
-        assert progress is not None
-        assert progress["strategy"] == "rolling"
-        assert progress["target_model_source"] == "repo://test:v2"
-        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
-        assert progress["updated"] == 0
-        assert progress["in_progress"] == 1
-        assert progress["failed"] == 0
-        assert progress["step"] == "1/2"
-        assert progress["current_host_id"] is not None
-        assert "started_at" in progress
-
-    def test_init_scale_up_same_source(self):
-        """Scale up with same source: all instances match target, returns None."""
-        managed = [
-            _make_instance("i1", host_id="h1", model_source="repo://test:v1"),
-        ]
-        candidates = [(_HostStub(id="h2"), None)]
-        result = RollingStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v1",
-            desired_replicas=2, managed_instances=managed, candidates=candidates,
-        )
-        # Pure scale-up (no drift): strategy not needed
-        assert result is None
-
-    def test_init_in_place_replacement(self):
-        """When no new hosts available, drifted hosts become replacement targets."""
-        managed = [
-            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
-        ]
-        # No external candidates — must replace on the drifted host itself
-        candidates: list = []
-        progress = RollingStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=1, managed_instances=managed, candidates=candidates,
-        )
-        assert progress is not None
-        assert progress["current_host_id"] == "h1"  # in-place
-
-    def test_init_shortfall_fewer_candidates_than_needed(self):
-        """Initial deployment (0→N) is not a strategy — it goes through normal diff.
-        
-        Strategy is only for version changes (existing drifted instances).
-        Initial deployment with fewer candidates is handled by the reconciler's
-        normal CREATE actions with shortfall reporting.
-        """
-        managed: list = []
-        candidates = [(_HostStub(id="h1", name="h1"), None)]
-        progress = RollingStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=3, managed_instances=managed, candidates=candidates,
-        )
-        # Initial deployment goes through normal diff, not strategy
-        assert progress is None
-
-
-class TestRollingContinue:
-    """Test RollingStrategy.continue_step() through all phases."""
-
-    def _base_continue_args(self, **overrides):
-        """Return default args for continue_step()."""
-        defaults = {
-            "progress_data": {
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.CREATING_REPLACEMENT,
-                "step": "1/2",
-                "updated": 0,
-                "in_progress": 1,
-                "failed": 0,
-                "current_host_id": "h3",
-                "current_instance_id": None,
-                "pending_hosts": ["h4"],
-                "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z",
-                "message": "Creating replacement on h3",
-            },
-            "intent_id": "int-1",
-            "alias": "test-model",
-            "desired_replicas": 2,
-            "managed_instances": [],
-            "candidates": [],
-            "gateway_aliases": set(),
-            "health_gate_started_at": 0.0,
-            "health_gate_timeout_s": 120.0,
-        }
-        defaults.update(overrides)
-        return defaults
-
-    def test_creating_emits_create_action(self):
-        """Phase creating_replacement with no instance_id emits create."""
-        args = self._base_continue_args(
-            progress_data={
-                **self._base_continue_args()["progress_data"],
-                "current_instance_id": None,
-            },
-        )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "create"
-        assert action["host_id"] == "h3"
-        # Progress unchanged — caller sets instance_id after create
-        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
-
-    def test_creating_with_instance_id_transitions_to_waiting(self):
-        """When instance_id is already set, transition to waiting_healthy."""
-        args = self._base_continue_args(
-            progress_data={
-                **self._base_continue_args()["progress_data"],
-                "current_instance_id": "new-inst-1",
-            },
-        )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "wait"
-        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
-
-    def test_waiting_healthy_emits_stop_when_healthy(self):
-        """When replacement becomes healthy, emit stop for old replica."""
-        managed = [
-            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="running"),
-        ]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.WAITING_HEALTHY,
-                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
-                "current_host_id": "h3", "current_instance_id": "new-1",
-                "pending_hosts": ["h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
+            alias="test-model",
             gateway_aliases={"test-model"},
         )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "stop"
-        assert action["instance_id"] == "old-1"
-        assert new_progress["phase"] == StrategyPhase.RETIRING_OLD
+        assert result is False
 
-    def test_waiting_healthy_waits_when_not_healthy(self):
-        """When replacement not yet healthy, emit wait."""
-        managed = [
-            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="starting"),
-        ]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.WAITING_HEALTHY,
-                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
-                "current_host_id": "h3", "current_instance_id": "new-1",
-                "pending_hosts": ["h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
+    def test_status_not_running_returns_false(self):
+        inst = _make_managed_instance("inst-1", status="starting")
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
             gateway_aliases={"test-model"},
         )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "wait"
-        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
+        assert result is False
 
-    def test_waiting_healthy_timeout_holds(self):
-        """When health gate timeout exceeded, strategy holds (failed phase)."""
-        managed = [
-            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2", status="starting"),
-        ]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.WAITING_HEALTHY,
-                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
-                "current_host_id": "h3", "current_instance_id": "new-1",
-                "pending_hosts": ["h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
-            gateway_aliases={"test-model"},
-            health_gate_started_at=999.0,  # way past timeout
-            health_gate_timeout_s=120.0,
+    def test_alias_not_in_gateway_returns_false(self):
+        inst = _make_managed_instance("inst-1", status="running")
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
+            gateway_aliases=set(),
         )
-        action, new_progress = RollingStrategy.continue_step(**args)
+        assert result is False
+
+    def test_running_and_in_gateway_returns_true(self):
+        inst = _make_managed_instance("inst-1", status="running")
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
+            gateway_aliases={"test-model", "other-model"},
+        )
+        assert result is True
+
+    def test_state_field_as_fallback(self):
+        """When 'status' is absent, 'state' field is used as fallback."""
+        inst = _make_managed_instance("inst-1", status="running")
+        del inst["status"]
+        inst["state"] = "running"
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
+            gateway_aliases={"test-model"},
+        )
+        assert result is True
+
+    def test_state_field_non_running_returns_false(self):
+        inst = _make_managed_instance("inst-1", status="running")
+        del inst["status"]
+        inst["state"] = "error"
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
+            gateway_aliases={"test-model"},
+        )
+        assert result is False
+
+    def test_both_status_and_state_absent_returns_false(self):
+        inst = _make_managed_instance("inst-1", status="running")
+        del inst["status"]
+        # No 'state' key either — .get("state", "") returns ""
+        result = check_instance_healthy_sync(
+            instance_data=inst,
+            alias="test-model",
+            gateway_aliases={"test-model"},
+        )
+        assert result is False
+
+
+# ═════════════════════════════════════════════════════════════════
+#  internal helpers
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestInternalHelpers:
+    """Tests for internal helper functions."""
+
+    def test_count_updated_all_on_target(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v2"),
+        ]
+        assert _count_updated(instances, "repo://test:v2") == 2
+
+    def test_count_updated_mixed(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        assert _count_updated(instances, "repo://test:v2") == 1
+
+    def test_count_updated_empty(self):
+        assert _count_updated([], "repo://test:v2") == 0
+
+    def test_find_instance_on_host_by_instance_id(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1"),
+            _make_managed_instance("i2", host_id="h2"),
+        ]
+        found = _find_instance_on_host(instances, host_id=None, instance_id="i2")
+        assert found is not None
+        assert found["instance_id"] == "i2"
+
+    def test_find_instance_on_host_by_host_id_no_instance_id(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1"),
+            _make_managed_instance("i2", host_id="h2"),
+        ]
+        found = _find_instance_on_host(instances, host_id="h2", instance_id=None)
+        assert found is not None
+        assert found["_host_id"] == "h2"
+
+    def test_find_instance_on_host_not_found(self):
+        instances = [_make_managed_instance("i1", host_id="h1")]
+        found = _find_instance_on_host(instances, host_id="h99", instance_id=None)
+        assert found is None
+
+    def test_find_old_instance_finds_mismatched_source(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        found = _find_old_instance(instances, "h1", "repo://test:v2")
+        assert found is not None
+        assert found["instance_id"] == "i1"
+
+    def test_find_old_instance_skips_matching_source(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+        found = _find_old_instance(instances, "h1", "repo://test:v2")
+        assert found is None
+
+    def test_find_old_instance_wrong_host(self):
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        found = _find_old_instance(instances, "h2", "repo://test:v2")
+        assert found is None
+
+    def test_strategy_held_sets_failed_phase(self):
+        progress = {"phase": "waiting_healthy", "failed": 0, "in_progress": 1}
+        action, new_progress = _strategy_held(progress, "timeout exceeded")
+        assert action == {"type": "wait", "reason": "strategy held"}
         assert new_progress["phase"] == StrategyPhase.FAILED
-        # Old replica NOT retired — kept running (rolling hold)
-        assert action["type"] == "wait"
+        assert new_progress["failed"] == 1
+        assert new_progress["in_progress"] == 0
+        assert "timeout exceeded" in new_progress["message"]
 
-    def test_retiring_old_waits_until_stopped(self):
-        """While old instance still exists, keep waiting."""
-        managed = [
-            _make_instance("old-1", host_id="h3", model_source="repo://test:v1"),
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
-        ]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.RETIRING_OLD,
-                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
-                "current_host_id": "h3", "current_instance_id": "new-1",
-                "pending_hosts": ["h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
-            gateway_aliases={"test-model"},
-        )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action["type"] == "wait"
-        assert new_progress["phase"] == StrategyPhase.RETIRING_OLD
-
-    def test_retiring_old_advances_to_next_when_gone(self):
-        """When old instance is gone, proceed to next host."""
-        managed = [
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
-        ]
-        candidates = [(_HostStub(id="h4", name="h4"), None)]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.RETIRING_OLD,
-                "step": "1/2", "updated": 0, "in_progress": 1, "failed": 0,
-                "current_host_id": "h3", "current_instance_id": "new-1",
-                "pending_hosts": ["h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
-            candidates=candidates,
-            gateway_aliases={"test-model"},
-        )
-        action, new_progress = RollingStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "create"  # next host
-        assert action["host_id"] == "h4"
-        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
-
-    def test_completes_when_all_updated(self):
-        """Strategy returns (None, None) when all replicas on target source."""
-        managed = [
-            _make_instance("new-1", host_id="h3", model_source="repo://test:v2"),
-            _make_instance("new-2", host_id="h4", model_source="repo://test:v2"),
-        ]
-        args = self._base_continue_args(
-            progress_data={
-                "strategy": "rolling",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.RETIRING_OLD,
-                "step": "2/2", "updated": 1, "in_progress": 0, "failed": 0,
-                "current_host_id": "h4", "current_instance_id": "new-2",
-                "pending_hosts": [], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "",
-            },
-            managed_instances=managed,
-            gateway_aliases={"test-model"},
-        )
-        action, new_progress = RollingStrategy.continue_step(**args)
+    def test_strategy_failed_sets_failed_phase_no_action(self):
+        progress = {"phase": "creating_replacement"}
+        action, new_progress = _strategy_failed(progress, "permanent failure")
         assert action is None
-        assert new_progress is None  # strategy complete
+        assert new_progress["phase"] == StrategyPhase.FAILED
+        assert "permanent failure" in new_progress["message"]
 
 
-# ── Immediate strategy tests (§11.3) ──────────────────────────────
+# ═════════════════════════════════════════════════════════════════
+#  scale-up: same source, more replicas (§11.6 scenario 1)
+# ═════════════════════════════════════════════════════════════════
 
 
-class TestImmediateInit:
-    """Test ImmediateStrategy.init()."""
+class TestScaleUp:
+    """Scale-up scenarios (§11.6 scenario 1)."""
 
-    def test_init_returns_none_when_already_on_target(self):
-        managed = [
-            _make_instance("i1", host_id="h1", model_source="repo://test:v2"),
+    def test_already_at_desired_state_returns_none(self):
+        """All instances on target source at desired count → no strategy needed."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v2"),
         ]
-        result = ImmediateStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=1, managed_instances=managed, candidates=[],
-        )
-        assert result is None
+        candidates = _make_candidates("h3")
 
-    def test_init_with_drifted_instances(self):
-        managed = [
-            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
-            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
-        ]
-        candidates = [
-            (_HostStub(id="h3"), None),
-            (_HostStub(id="h4"), None),
-        ]
-        progress = ImmediateStrategy.init(
-            intent_id="int-1", alias="test", target_model_source="repo://test:v2",
-            desired_replicas=2, managed_instances=managed, candidates=candidates,
-        )
-        assert progress is not None
-        assert progress["strategy"] == "immediate"
-        assert progress["phase"] == StrategyPhase.STOPPING_OLD
-        assert progress["in_progress"] == 2  # 2 old to stop
-
-
-class TestImmediateContinue:
-    """Test ImmediateStrategy.continue_step()."""
-
-    def _base_args(self, **overrides):
-        defaults = {
-            "progress_data": {
-                "strategy": "immediate",
-                "target_model_source": "repo://test:v2",
-                "phase": StrategyPhase.STOPPING_OLD,
-                "step": "0/2", "updated": 0, "in_progress": 2, "failed": 0,
-                "current_host_id": None, "current_instance_id": None,
-                "pending_hosts": ["h3", "h4"], "failed_hosts": [],
-                "started_at": "2026-01-01T00:00:00Z", "message": "Stopping old",
-            },
-            "intent_id": "int-1", "alias": "test-model",
-            "desired_replicas": 2, "managed_instances": [],
-            "candidates": [], "gateway_aliases": set(),
-            "health_gate_started_at": 0.0, "health_gate_timeout_s": 120.0,
-        }
-        defaults.update(overrides)
-        return defaults
-
-    def test_stopping_old_emits_stop(self):
-        managed = [
-            _make_instance("old-1", host_id="h1", model_source="repo://test:v1"),
-            _make_instance("old-2", host_id="h2", model_source="repo://test:v1"),
-        ]
-        args = self._base_args(managed_instances=managed)
-        action, new_progress = ImmediateStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "stop"
-        assert action["host_id"] == "h1"
-        assert new_progress["phase"] == StrategyPhase.STOPPING_OLD
-
-    def test_stopping_transitions_to_creating_when_all_stopped(self):
-        """When no old instances remain, transition to creating_replacements."""
-        managed: list = []  # all old stopped
-        candidates = [
-            (_HostStub(id="h3"), None),
-            (_HostStub(id="h4"), None),
-        ]
-        args = self._base_args(
-            managed_instances=managed,
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
             candidates=candidates,
         )
-        action, new_progress = ImmediateStrategy.continue_step(**args)
-        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENTS
+        assert result is None, "Should return None when already at desired state"
 
-    def test_creating_emits_create_actions(self):
-        """create_replacements phase emits create for each pending host."""
-        candidates = [(_HostStub(id="h3"), None)]
-        args = self._base_args(
-            progress_data={
-                **self._base_args()["progress_data"],
-                "phase": StrategyPhase.CREATING_REPLACEMENTS,
-                "pending_hosts": ["h3"],
-                "in_progress": 1,
-            },
+    def test_scale_up_same_source_returns_none(self):
+        """Pure scale-up (same source, more replicas) returns None —
+        handled by normal reconciliation diff, not by strategy module."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v2"),
+        ]
+        candidates = _make_candidates("h3", "h4")
+
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=3,  # scale up from 2 to 3
+            managed_instances=instances,
             candidates=candidates,
         )
-        action, new_progress = ImmediateStrategy.continue_step(**args)
-        assert action is not None
-        assert action["type"] == "create"
-        assert action["host_id"] == "h3"
+        assert (
+            result is None
+        ), "Pure scale-up should return None — handled by normal diff"
 
-    def test_completes_when_all_replacement_hosts_used(self):
-        """When pending_hosts is empty, strategy completes."""
-        args = self._base_args(
-            progress_data={
-                **self._base_args()["progress_data"],
-                "phase": StrategyPhase.CREATING_REPLACEMENTS,
-                "pending_hosts": [],
-                "in_progress": 0,
-            },
+    def test_initial_deployment_from_zero_returns_none(self):
+        """Initial deployment (0→N) with no existing instances returns None —
+        handled by normal reconciliation diff, not by strategy module."""
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=3,
+            managed_instances=[],
+            candidates=_make_candidates("h1", "h2", "h3"),
         )
-        action, new_progress = ImmediateStrategy.continue_step(**args)
-        assert action is None
-        assert new_progress is None
+        assert (
+            result is None
+        ), "Initial deployment should return None — handled by normal diff"
 
-    def test_degraded_when_no_hosts_for_replacements(self):
-        """When stopping_old completes but no hosts for replacements, fails."""
-        managed: list = []
-        args = self._base_args(
-            managed_instances=managed,
-            progress_data={
-                **self._base_args()["progress_data"],
-                "pending_hosts": [],  # none available
-            },
+
+# ═════════════════════════════════════════════════════════════════
+#  model version change — rolling (§11.6 scenario 3)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestRollingModelVersionChange:
+    """Rolling update: create → wait-healthy → retire-old → advance (§11.6 scenario 3)."""
+
+    # ── init ────────────────────────────────────────────────────
+
+    def test_init_creates_progress_with_creating_replacement_phase(self):
+        """init() creates proper progress with creating_replacement phase."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h3", "h4")
+
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=candidates,
         )
-        action, new_progress = ImmediateStrategy.continue_step(**args)
-        # Should transition with what it has — empty pending list is OK
-        assert new_progress is not None
 
+        assert result is not None
+        assert result["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        assert result["strategy"] == "rolling"
+        assert result["target_model_source"] == "repo://test:v2"
+        assert result["step"] == "1/2"
+        assert result["updated"] == 0
+        assert result["in_progress"] == 1
+        assert result["failed"] == 0
+        assert result["current_host_id"] is not None
+        assert result["current_instance_id"] is None
+        assert result["pending_hosts"] is not None
+        assert len(result["pending_hosts"]) >= 0
+        assert result["started_at"] is not None
+        assert "Creating replacement" in result["message"]
 
-# ── Dispatch function tests ───────────────────────────────────────
+    # ── Phase: creating_replacement → waiting_healthy ──────────
 
-
-class TestShouldInitiateStrategy:
-    """Test should_initiate_strategy()."""
-
-    def test_true_when_drift_and_valid_strategy(self):
-        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v2")
-        managed = [_make_instance("old-1", model_source="repo://test:v1")]
-        assert should_initiate_strategy(intent=intent, managed_instances=managed) is True
-
-    def test_false_when_no_drift(self):
-        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v1")
-        managed = [_make_instance("i1", model_source="repo://test:v1")]
-        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
-
-    def test_false_when_unknown_strategy(self):
-        intent = _make_intent_stub(strategy="unknown", model_source="repo://test:v2")
-        managed = [_make_instance("old-1", model_source="repo://test:v1")]
-        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
-
-    def test_false_when_strategy_is_none(self):
-        intent = _make_intent_stub(strategy=None, model_source="repo://test:v2")
-        managed = [_make_instance("old-1", model_source="repo://test:v1")]
-        assert should_initiate_strategy(intent=intent, managed_instances=managed) is False
-
-
-class TestInitiateStrategy:
-    """Test initiate_strategy() dispatch."""
-
-    def test_rolling_strategy_dispatched(self):
-        intent = _make_intent_stub(strategy="rolling", model_source="repo://test:v2")
-        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
-        candidates = [(_HostStub(id="h2"), None)]
-        progress = initiate_strategy(
-            intent=intent, managed_instances=managed, candidates=candidates,
-        )
-        assert progress is not None
-        assert progress["strategy"] == "rolling"
-        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
-
-    def test_immediate_strategy_dispatched(self):
-        intent = _make_intent_stub(strategy="immediate", model_source="repo://test:v2")
-        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
-        candidates = [(_HostStub(id="h2"), None)]
-        progress = initiate_strategy(
-            intent=intent, managed_instances=managed, candidates=candidates,
-        )
-        assert progress is not None
-        assert progress["strategy"] == "immediate"
-        assert progress["phase"] == StrategyPhase.STOPPING_OLD
-
-    def test_unknown_strategy_returns_none(self):
-        intent = _make_intent_stub(strategy="canary", model_source="repo://test:v2")
-        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
-        progress = initiate_strategy(
-            intent=intent, managed_instances=managed, candidates=[],
-        )
-        assert progress is None
-
-
-class TestContinueStrategyDispatch:
-    """Test continue_strategy() dispatch function."""
-
-    def test_rolling_dispatched_correctly(self):
-        intent = _make_intent_stub(strategy="rolling")
-        progress_data = {
+    def test_creating_replacement_without_instance_id_emits_create(self):
+        """When current_instance_id is None, emits a create action."""
+        progress = {
             "strategy": "rolling",
             "target_model_source": "repo://test:v2",
             "phase": StrategyPhase.CREATING_REPLACEMENT,
-            "step": "1/1", "updated": 0, "in_progress": 1, "failed": 0,
-            "current_host_id": "h1", "current_instance_id": None,
-            "pending_hosts": [], "failed_hosts": [],
-            "started_at": "2026-01-01T00:00:00Z", "message": "",
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": None,
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating replacement on h1",
         }
-        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
-        action, new_progress = continue_strategy(
-            progress_data=progress_data,
-            intent=intent,
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is not None
+        assert action["type"] == "create"
+        assert action["host_id"] == "h1"
+        assert "Rolling replacement step" in action["reason"]
+        # Progress unchanged — reconciler sets current_instance_id
+        assert new_progress == progress
+
+    def test_creating_replacement_with_instance_id_transitions_to_waiting(self):
+        """When current_instance_id is set, transitions to waiting_healthy phase."""
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENT,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating replacement on h1",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action == {"type": "wait", "reason": "awaiting health"}
+        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
+        assert "Waiting for replacement" in new_progress["message"]
+
+    # ── Phase: waiting_healthy → retiring_old ──────────────────
+
+    def test_waiting_healthy_when_healthy_transitions_to_retiring_old(self):
+        """Healthy replacement triggers transition to retiring_old with stop action."""
+        # Old instance on h1, replacement on h1
+        old_inst = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1", status="running"
+        )
+        replacement = _make_managed_instance(
+            "inst-new-1", host_id="h1", model_source="repo://test:v2", status="running"
+        )
+        managed = [old_inst, replacement]
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.WAITING_HEALTHY,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Waiting for replacement",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
             managed_instances=managed,
             candidates=[],
             gateway_aliases={"test-model"},
-            health_gate_started_at=0.0,
-            health_gate_timeout_s=120.0,
+            health_gate_started_at=10.0,
+            health_gate_timeout_s=300.0,
         )
+
+        assert action is not None
+        assert action["type"] == "stop"
+        assert action["host_id"] == "h1"
+        assert action["instance_id"] == "i1"
+        assert "retiring old replica" in action["reason"]
+        assert new_progress["phase"] == StrategyPhase.RETIRING_OLD
+        assert "Retiring old replica" in new_progress["message"]
+
+    def test_waiting_healthy_no_old_instance_advances(self):
+        """When no old instance exists (fresh host), advances to next slot."""
+        replacement = _make_managed_instance(
+            "inst-new-1", host_id="h3", model_source="repo://test:v2", status="running"
+        )
+        managed = [replacement]
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.WAITING_HEALTHY,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h3",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h4"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Waiting for replacement",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=managed,
+            candidates=[_HostStub(id="h4"), _HostStub(id="h5")],
+            gateway_aliases={"test-model"},
+            health_gate_started_at=10.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        # Should advance — emit create for next host
         assert action is not None
         assert action["type"] == "create"
+        assert action["host_id"] == "h4"
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
 
-    def test_immediate_dispatched_correctly(self):
-        intent = _make_intent_stub(strategy="immediate")
-        progress_data = {
-            "strategy": "immediate",
+    # ── Phase: retiring_old ────────────────────────────────────
+
+    def test_retiring_old_waits_while_old_still_exists(self):
+        """While the old instance still exists in managed, emit wait."""
+        old_inst = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1", status="stopping"
+        )
+        managed = [old_inst]
+
+        progress = {
+            "strategy": "rolling",
             "target_model_source": "repo://test:v2",
-            "phase": StrategyPhase.STOPPING_OLD,
-            "step": "0/1", "updated": 0, "in_progress": 1, "failed": 0,
-            "current_host_id": None, "current_instance_id": None,
-            "pending_hosts": ["h2"], "failed_hosts": [],
-            "started_at": "2026-01-01T00:00:00Z", "message": "",
+            "phase": StrategyPhase.RETIRING_OLD,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Retiring old replica",
         }
-        managed = [_make_instance("old-1", host_id="h1", model_source="repo://test:v1")]
-        action, new_progress = continue_strategy(
-            progress_data=progress_data,
-            intent=intent,
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
             managed_instances=managed,
             candidates=[],
             gateway_aliases=set(),
             health_gate_started_at=0.0,
-            health_gate_timeout_s=120.0,
+            health_gate_timeout_s=300.0,
         )
-        assert action is not None
-        assert action["type"] == "stop"
 
-    def test_unknown_strategy_returns_none(self):
-        intent = _make_intent_stub(strategy="unknown")
-        progress_data = {
-            "strategy": "unknown",
-            "phase": "whatever",
-            "step": "1/1", "updated": 0, "in_progress": 0, "failed": 0,
-            "pending_hosts": [], "failed_hosts": [],
-            "started_at": "2026-01-01T00:00:00Z", "message": "",
+        assert action == {"type": "wait", "reason": "awaiting stop"}
+        assert "Waiting for old replica" in new_progress["message"]
+
+    def test_retiring_old_advances_when_old_gone(self):
+        """When old instance is gone, advances to next host or completes."""
+        replacement = _make_managed_instance(
+            "inst-new-1", host_id="h1", model_source="repo://test:v2", status="running"
+        )
+        managed = [replacement]  # old instance "i1" removed
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.RETIRING_OLD,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Retiring old replica",
         }
-        action, new_progress = continue_strategy(
-            progress_data=progress_data,
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=managed,
+            candidates=_make_candidates("h2"),
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        # Should advance to next host
+        assert action is not None
+        assert action["type"] == "create"
+        assert action["host_id"] == "h2"
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+    # ── Full lifecycle: completion ─────────────────────────────
+
+    def test_strategy_completes_when_all_replicas_updated(self):
+        """Strategy returns (None, None) when all replicas are on target source."""
+        # All instances on target source, count matches desired
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v2"),
+        ]
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.RETIRING_OLD,
+            "step": "2/2",
+            "updated": 1,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h2",
+            "current_instance_id": "inst-new-2",
+            "pending_hosts": [],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Retiring old replica",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        # Strategy complete — both None
+        assert action is None
+        assert new_progress is None
+
+    # ── End-to-end rolling lifecycle test ──────────────────────
+
+    def test_full_rolling_lifecycle(self):
+        """Exercise the complete rolling state machine across all phases."""
+        # Start: 2 instances on v1, target v2
+        old_i1 = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1"
+        )
+        old_i2 = _make_managed_instance(
+            "i2", host_id="h2", model_source="repo://test:v1"
+        )
+
+        # Init
+        progress = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=_make_candidates("h3", "h4"),
+        )
+        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        assert progress["current_host_id"] is not None
+
+        # Step 1: creating_replacement — emit create
+        action, _ = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=_make_candidates("h3", "h4"),
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action["type"] == "create"
+
+        # Simulate reconciler setting instance_id
+        progress = dict(progress)
+        progress["current_instance_id"] = "new-1"
+
+        # Step 2: creating_replacement with instance_id → wait
+        action, progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=_make_candidates("h3", "h4"),
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action == {"type": "wait", "reason": "awaiting health"}
+        assert progress["phase"] == StrategyPhase.WAITING_HEALTHY
+
+        # Step 3: waiting_healthy — instance is healthy
+        new_inst = _make_managed_instance(
+            "new-1",
+            host_id=progress["current_host_id"],
+            model_source="repo://test:v2",
+            status="running",
+        )
+        action, progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2, new_inst],
+            candidates=_make_candidates("h3", "h4"),
+            gateway_aliases={"test-model"},
+            health_gate_started_at=10.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action["type"] == "stop"  # retiring old
+        assert progress["phase"] == StrategyPhase.RETIRING_OLD
+
+        # Step 4: retiring_old — old instance gone
+        action, progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i2, new_inst],  # old_i1 removed
+            candidates=_make_candidates("h3", "h4"),
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action["type"] == "create"  # advance to next host
+        assert progress["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+
+# ═════════════════════════════════════════════════════════════════
+#  model version change — immediate (§11.6 scenario 4)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestImmediateModelVersionChange:
+    """Immediate update: stop-all → create-all (§11.6 scenario 4)."""
+
+    # ── init ────────────────────────────────────────────────────
+
+    def test_init_creates_stopping_old_phase(self):
+        """init() with source drift creates stopping_old phase."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h3", "h4")
+
+        result = ImmediateStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["phase"] == StrategyPhase.STOPPING_OLD
+        assert result["strategy"] == "immediate"
+        assert result["target_model_source"] == "repo://test:v2"
+        assert result["in_progress"] == 2  # 2 drifted instances
+        assert result["updated"] == 0
+        assert result["failed"] == 0
+        assert result["pending_hosts"] == ["h3", "h4"]
+        assert "Stopping 2 old replica" in result["message"]
+
+    def test_init_returns_none_when_already_at_target(self):
+        """No drift → init returns None (no strategy needed)."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v2"),
+        ]
+
+        result = ImmediateStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=[],
+        )
+
+        assert result is None
+
+    # ── Phase: stopping_old ────────────────────────────────────
+
+    def test_continue_step_stopping_old_emits_stop(self):
+        """stopping_old emits stop for first old instance found."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+        ]
+
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/2",
+            "updated": 0,
+            "in_progress": 2,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": ["h3", "h4"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Stopping 2 old replica(s)",
+        }
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action["type"] == "stop"
+        assert action["host_id"] == "h1"
+        assert action["instance_id"] == "i1"
+        assert "Immediate: stopping old replica" in action["reason"]
+
+    def test_continue_step_stops_all_old_then_transitions(self):
+        """After all old instances are stopped, transitions to creating_replacements."""
+        # No old instances left — all stopped
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/2",
+            "updated": 0,
+            "in_progress": 2,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": ["h3", "h4"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Stopping 2 old replica(s)",
+        }
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],  # all old instances removed
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action == {"type": "wait", "reason": "transitioning"}
+        assert new_progress["phase"] == StrategyPhase.CREATING_REPLACEMENTS
+        assert "Creating 2 replacement" in new_progress["message"]
+
+    def test_stopping_old_with_no_replacements_needed_returns_none(self):
+        """When all old are stopped AND updated >= desired, returns (None, None)."""
+        # All instances are already on target — should not happen in normal
+        # flow but guard is in place
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/2",
+            "updated": 2,
+            "in_progress": 0,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": [],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Stopping old replicas",
+        }
+
+        # Managed instances already on target
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=1,
+            managed_instances=instances,
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is None
+        assert new_progress is None
+
+    # ── Phase: creating_replacements ────────────────────────────
+
+    def test_creating_replacements_emits_create(self):
+        """creating_replacements emits create for each pending host."""
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENTS,
+            "step": "0/2",
+            "updated": 0,
+            "in_progress": 2,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": ["h3", "h4"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating 2 replacement(s)",
+        }
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action["type"] == "create"
+        assert action["host_id"] == "h3"
+        assert "Immediate: creating replacement" in action["reason"]
+        assert new_progress["pending_hosts"] == ["h4"]
+
+    def test_creating_replacements_completes_when_no_pending(self):
+        """When no hosts left to create, returns (None, None)."""
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENTS,
+            "step": "0/2",
+            "updated": 0,
+            "in_progress": 0,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": [],  # all dispatched
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating replacements",
+        }
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is None
+        assert new_progress is None
+
+
+# ═════════════════════════════════════════════════════════════════
+#  failed health check — rolling holds (§11.6 scenario 5)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestFailedHealthCheckRolling:
+    """Timeout on health gate causes strategy to hold (§11.6 scenario 5)."""
+
+    def test_waiting_healthy_timeout_sets_phase_failed(self):
+        """When health gate timeout exceeded, phase → failed, keeps old replicas."""
+        old_inst = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1"
+        )
+        replacement = _make_managed_instance(
+            "inst-new-1",
+            host_id="h1",
+            model_source="repo://test:v2",
+            status="starting",  # not running yet
+        )
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.WAITING_HEALTHY,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Waiting for replacement",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_inst, replacement],  # old still there
+            candidates=[],
+            gateway_aliases={"test-model"},
+            health_gate_started_at=500.0,  # > 300s timeout
+            health_gate_timeout_s=300.0,
+        )
+
+        assert new_progress["phase"] == StrategyPhase.FAILED
+        assert new_progress["failed"] == 1
+        assert new_progress["in_progress"] == 0
+        assert "Health gate timeout" in new_progress["message"]
+
+    def test_waiting_healthy_still_waiting_within_timeout(self):
+        """Within timeout, emits wait — does not fail."""
+        old_inst = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1"
+        )
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.WAITING_HEALTHY,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Waiting for replacement",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_inst],  # replacement not in managed yet
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=50.0,  # within 300s
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action == {"type": "wait", "reason": "health gate"}
+        assert new_progress["phase"] == StrategyPhase.WAITING_HEALTHY
+        assert "Waiting for replacement" in new_progress["message"]
+
+
+# ═════════════════════════════════════════════════════════════════
+#  failed health check — immediate degraded (§11.6 scenario 6)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestFailedHealthCheckImmediate:
+    """Immediate strategy — some replacements succeed, some fail (§11.6 scenario 6)."""
+
+    def test_immediate_held_when_no_hosts_available(self):
+        """When transition to creating_replacements finds no hosts, strategy held."""
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/3",
+            "updated": 0,
+            "in_progress": 3,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": [],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Stopping old replicas",
+        }
+
+        # No old instances, no candidates → no hosts for replacement
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=3,
+            managed_instances=[],  # all old stopped
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert new_progress["phase"] == StrategyPhase.FAILED
+        assert "No hosts available" in new_progress["message"]
+
+    def test_partial_success_some_replacements_dispatch(self):
+        """With 3 desired replicas but only 2 hosts, 2 replacements dispatched."""
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENTS,
+            "step": "0/3",
+            "updated": 0,
+            "in_progress": 3,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": ["h3", "h4"],  # only 2 hosts for 3 needed
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating replacements",
+        }
+
+        # Dispatch first
+        action1, progress1 = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=3,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action1["type"] == "create"
+        assert action1["host_id"] == "h3"
+
+        # Dispatch second
+        action2, progress2 = ImmediateStrategy.continue_step(
+            progress_data=progress1,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=3,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action2["type"] == "create"
+        assert action2["host_id"] == "h4"
+
+        # Third call — no more pending, strategy complete
+        action3, progress3 = ImmediateStrategy.continue_step(
+            progress_data=progress2,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=3,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action3 is None
+        assert progress3 is None
+
+
+# ═════════════════════════════════════════════════════════════════
+#  shortfall — fewer hosts than replicas (§11.6 scenario 7)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestShortfall:
+    """Shortfall: fewer candidate hosts than needed replicas (§11.6 scenario 7)."""
+
+    def test_rolling_init_with_shortfall_still_creates_progress(self):
+        """When candidates < needed, init still creates progress with available hosts."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+            _make_managed_instance("i3", host_id="h3", model_source="repo://test:v1"),
+        ]
+        # Only 1 new candidate host, but we need 3 replacements
+        candidates = _make_candidates("h4")
+
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=3,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        # First replacement uses a drifted host (h1), then candidate (h4)
+        # drifted_host_ids = {h1, h2, h3}, candidate_hosts = [h4]
+        # all_replacement = [h1, h2, h3, h4] → unique → [h1, h2, h3, h4]
+        # replacement_hosts[:3] = [h1, h2, h3]
+        assert result["current_host_id"] is not None
+        assert len(result["pending_hosts"]) == 2  # h2, h3
+
+    def test_immediate_init_with_shortfall_still_creates_progress(self):
+        """Immediate init with few candidate hosts still creates progress."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+            _make_managed_instance("i3", host_id="h3", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h4")  # only 1 candidate for 3 needed
+
+        result = ImmediateStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=3,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["phase"] == StrategyPhase.STOPPING_OLD
+        assert result["in_progress"] == 3  # 3 drifted
+        # Only 1 pending host (h4), but 3 needed — shortfall
+        assert len(result["pending_hosts"]) == 1  # [h4]
+
+
+# ═════════════════════════════════════════════════════════════════
+#  in-place replacement (§11.6 scenario 8)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestInPlaceReplacement:
+    """Rolling in-place: replace old instance on same host (§11.6 scenario 8)."""
+
+    def test_in_place_init_uses_drifted_hosts_as_targets(self):
+        """When no new candidate hosts, drifted hosts become replacement targets."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+        ]
+        candidates = []  # no new hosts
+
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        # Drifted hosts used as replacement targets
+        assert result["current_host_id"] in ("h1", "h2")
+        assert result["pending_hosts"] is not None
+
+    def test_in_place_full_lifecycle(self):
+        """Complete in-place replacement: stop old on h1, create new on h1."""
+        old_i1 = _make_managed_instance(
+            "i1", host_id="h1", model_source="repo://test:v1"
+        )
+        old_i2 = _make_managed_instance(
+            "i2", host_id="h2", model_source="repo://test:v1"
+        )
+
+        progress = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=[],  # in-place
+        )
+
+        first_host = progress["current_host_id"]
+        assert first_host in ("h1", "h2")
+
+        # Emit create
+        action, _ = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action["type"] == "create"
+        assert action["host_id"] == first_host
+
+        # Simulate instance created → transition to waiting_healthy
+        progress = dict(progress)
+        progress["current_instance_id"] = "new-on-same-host"
+        action, progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[old_i1, old_i2],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert progress["phase"] == StrategyPhase.WAITING_HEALTHY
+
+        # Healthy → retire old on same host
+        new_inst = _make_managed_instance(
+            "new-on-same-host",
+            host_id=first_host,
+            model_source="repo://test:v2",
+            status="running",
+        )
+        all_managed = [old_i1, old_i2, new_inst]
+        action, progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=all_managed,
+            candidates=[],
+            gateway_aliases={"test-model"},
+            health_gate_started_at=10.0,
+            health_gate_timeout_s=300.0,
+        )
+        assert action["type"] == "stop"
+        assert action["host_id"] == first_host
+
+    def test_in_place_no_drifted_hosts_no_candidates_returns_none(self):
+        """When all instances are on target source, init returns None regardless."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=1,
+            managed_instances=instances,
+            candidates=[],
+        )
+
+        assert result is None
+
+
+# ═════════════════════════════════════════════════════════════════
+#  initiate_strategy / continue_strategy dispatch (§11.6 scenario 9)
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestDispatchFunctions:
+    """initiate_strategy() and continue_strategy() dispatch tests (§11.6 scenario 9)."""
+
+    def test_initiate_rolling_delegates_to_rolling_strategy(self):
+        """strategy='rolling' returns RollingStrategy.init result."""
+        intent = _IntentStub(
+            strategy="rolling", model_source="repo://test:v2", replicas=2
+        )
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h2")
+
+        result = initiate_strategy(
+            intent=intent,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["strategy"] == "rolling"
+        assert result["phase"] == StrategyPhase.CREATING_REPLACEMENT
+
+    def test_initiate_immediate_delegates_to_immediate_strategy(self):
+        """strategy='immediate' returns ImmediateStrategy.init result."""
+        intent = _IntentStub(
+            strategy="immediate", model_source="repo://test:v2", replicas=2
+        )
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h2")
+
+        result = initiate_strategy(
+            intent=intent,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+
+        assert result is not None
+        assert result["strategy"] == "immediate"
+        assert result["phase"] == StrategyPhase.STOPPING_OLD
+
+    def test_initiate_unknown_strategy_returns_none(self):
+        """Unknown strategy name → returns None."""
+        intent = _IntentStub(strategy="blue-green", model_source="repo://test:v2")
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+
+        result = initiate_strategy(
+            intent=intent,
+            managed_instances=instances,
+            candidates=[],
+        )
+
+        assert result is None
+
+    def test_initiate_no_strategy_returns_none(self):
+        """No strategy set → returns None."""
+        intent = _IntentStub(strategy=None, model_source="repo://test:v2")
+
+        result = initiate_strategy(
+            intent=intent,
+            managed_instances=[],
+            candidates=[],
+        )
+
+        assert result is None
+
+    def test_continue_rolling_dispatches(self):
+        """continue_strategy with 'rolling' delegates to RollingStrategy.continue_step."""
+        intent = _IntentStub(
+            strategy="rolling", model_source="repo://test:v2", replicas=2
+        )
+
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENT,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": None,
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Creating replacement on h1",
+        }
+
+        action, _ = continue_strategy(
+            progress_data=progress,
             intent=intent,
             managed_instances=[],
             candidates=[],
             gateway_aliases=set(),
             health_gate_started_at=0.0,
-            health_gate_timeout_s=120.0,
+            health_gate_timeout_s=300.0,
         )
+
+        assert action is not None
+        assert action["type"] == "create"
+
+    def test_continue_immediate_dispatches(self):
+        """continue_strategy with 'immediate' delegates to ImmediateStrategy.continue_step."""
+        intent = _IntentStub(
+            strategy="immediate", model_source="repo://test:v2", replicas=2
+        )
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.STOPPING_OLD,
+            "step": "0/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": ["h2"],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Stopping old replicas",
+        }
+
+        action, _ = continue_strategy(
+            progress_data=progress,
+            intent=intent,
+            managed_instances=instances,
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is not None
+        assert action["type"] == "stop"
+
+    def test_continue_unknown_strategy_returns_none_none(self):
+        """Unknown strategy in progress_data → returns (None, None)."""
+        intent = _IntentStub(strategy="blue-green")
+
+        progress = {
+            "strategy": "blue-green",
+            "phase": "unknown",
+        }
+
+        action, new_progress = continue_strategy(
+            progress_data=progress,
+            intent=intent,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is None
+        assert new_progress is None
+
+
+# ═════════════════════════════════════════════════════════════════
+#  should_initiate_strategy
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestShouldInitiateStrategy:
+    """Tests for should_initiate_strategy() dispatch guard."""
+
+    def test_returns_true_when_drift_detected(self):
+        """When managed instances have different model_source, returns True."""
+        intent = _IntentStub(strategy="rolling", model_source="repo://test:v2")
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+
+        assert (
+            should_initiate_strategy(intent=intent, managed_instances=instances) is True
+        )
+
+    def test_returns_false_when_no_drift(self):
+        """All instances on target source → returns False."""
+        intent = _IntentStub(strategy="rolling", model_source="repo://test:v2")
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+
+        assert (
+            should_initiate_strategy(intent=intent, managed_instances=instances)
+            is False
+        )
+
+    def test_returns_false_for_unsupported_strategy(self):
+        """strategy='none' or other → returns False even with drift."""
+        intent = _IntentStub(strategy="none", model_source="repo://test:v2")
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+
+        assert (
+            should_initiate_strategy(intent=intent, managed_instances=instances)
+            is False
+        )
+
+    def test_returns_false_when_no_target_source(self):
+        """No model_source on intent → returns False."""
+        intent = _IntentStub(strategy="rolling", model_source="")
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+        ]
+
+        assert (
+            should_initiate_strategy(intent=intent, managed_instances=instances)
+            is False
+        )
+
+    def test_returns_false_for_empty_managed(self):
+        """When managed_instances is empty, returns False (drift check passes
+        since loop has nothing to iterate, but no scale-up trigger either)."""
+        intent = _IntentStub(strategy="rolling", model_source="repo://test:v2")
+
+        assert should_initiate_strategy(intent=intent, managed_instances=[]) is False
+
+
+# ═════════════════════════════════════════════════════════════════
+#  edge cases & additional coverage
+# ═════════════════════════════════════════════════════════════════
+
+
+class TestEdgeCases:
+    """Edge case tests for strategy robustness."""
+
+    def test_rolling_advance_pending_empty_with_extra_candidates(self):
+        """When pending_hosts empty but candidates available, _advance_to_next_rolling
+        finds new candidates from the candidates list."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+        # Only 1 instance on target, need 1 more
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.RETIRING_OLD,
+            "step": "1/2",
+            "updated": 1,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": [],  # depleted
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Retiring old",
+        }
+        candidates = _make_candidates("h3", "h4")
+
+        action, new_progress = _advance_to_next_rolling(
+            progress_data=progress,
+            managed_instances=instances,
+            candidates=candidates,
+            desired_replicas=2,
+            alias="test-model",
+            target_source="repo://test:v2",
+        )
+
+        # Should find h3 as an extra candidate
+        assert action is not None
+        assert action["type"] == "create"
+        assert action["host_id"] == "h3"
+
+    def test_rolling_advance_pending_empty_no_candidates(self):
+        """When no pending hosts and no extra candidates, advance returns None,None."""
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v2"),
+        ]
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.RETIRING_OLD,
+            "step": "1/2",
+            "updated": 1,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": "h1",
+            "current_instance_id": "inst-new-1",
+            "pending_hosts": [],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "Retiring old",
+        }
+
+        action, new_progress = _advance_to_next_rolling(
+            progress_data=progress,
+            managed_instances=instances,
+            candidates=[],
+            desired_replicas=2,
+            alias="test-model",
+            target_source="repo://test:v2",
+        )
+
+        assert action is None
+        assert new_progress is None
+
+    def test_creating_replacement_no_host_id(self):
+        """When current_host_id is None/empty in creating_replacement, strategy held."""
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": StrategyPhase.CREATING_REPLACEMENT,
+            "step": "1/2",
+            "updated": 0,
+            "in_progress": 1,
+            "failed": 0,
+            "current_host_id": None,
+            "current_instance_id": None,
+            "pending_hosts": [],
+            "failed_hosts": [],
+            "started_at": "2024-01-01T00:00:00",
+            "message": "",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert new_progress["phase"] == StrategyPhase.FAILED
+
+    def test_unknown_phase_returns_none_none(self):
+        """Unknown phase in continue_step returns (None, None)."""
+        progress = {
+            "strategy": "rolling",
+            "target_model_source": "repo://test:v2",
+            "phase": "bogus_phase",
+        }
+
+        action, new_progress = RollingStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
+        assert action is None
+        assert new_progress is None
+
+    def test_immediate_unknown_phase_returns_none_none(self):
+        """Unknown phase in ImmediateStrategy.continue_step returns (None, None)."""
+        progress = {
+            "strategy": "immediate",
+            "target_model_source": "repo://test:v2",
+            "phase": "bogus_phase",
+        }
+
+        action, new_progress = ImmediateStrategy.continue_step(
+            progress_data=progress,
+            intent_id="intent-001",
+            alias="test-model",
+            desired_replicas=2,
+            managed_instances=[],
+            candidates=[],
+            gateway_aliases=set(),
+            health_gate_started_at=0.0,
+            health_gate_timeout_s=300.0,
+        )
+
         assert action is None
         assert new_progress is None

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1758,3 +1758,32 @@ class TestEdgeCases:
 
         assert action is None
         assert new_progress is None
+
+    def test_scale_down_during_strategy_continues_normally(self):
+        """When managed > desired (scale-down during strategy), the strategy
+        module operates correctly — excess handling is the reconciler's
+        responsibility (§11.6 scenario 2)."""
+        # 3 managed instances on v1, desired=2 on v2
+        instances = [
+            _make_managed_instance("i1", host_id="h1", model_source="repo://test:v1"),
+            _make_managed_instance("i2", host_id="h2", model_source="repo://test:v1"),
+            _make_managed_instance("i3", host_id="h3", model_source="repo://test:v1"),
+        ]
+        candidates = _make_candidates("h4", "h5")
+
+        # Rolling init: despite scale-down (3→2), strategy initiates for
+        # model version change (all 3 need replacing).
+        result = RollingStrategy.init(
+            intent_id="intent-001",
+            alias="test-model",
+            target_model_source="repo://test:v2",
+            desired_replicas=2,
+            managed_instances=instances,
+            candidates=candidates,
+        )
+        assert result is not None
+        assert result["phase"] == StrategyPhase.CREATING_REPLACEMENT
+        assert result["updated"] == 0  # none on target
+        # Strategy processes the first replacement on available host
+        assert result["current_host_id"] is not None
+        assert result["step"] == "1/2"  # needed=2 despite 3 managed


### PR DESCRIPTION
## Description

Adds `rolling` and `immediate` deployment strategies to Solar Control's reconciliation engine, replacing the naive "stop-old-then-create-new-on-next-tick" REPLACE behavior with strategy-aware orchestration. Strategies are driven as state machines across reconciliation ticks, with progress persisted in intent status so state survives reconciler restarts.

- **Rolling** (§11.2): one host at a time — create replacement → wait healthy (health gate) → retire old → next. Creates before stopping; holds on failure (keeps old replicas running).
- **Immediate** (§11.3): stop all old replicas, then create replacements per placement policy. Fast but with downtime.

Strategies only trigger on model-source drift; pure scale-up and initial deployment remain handled by the normal reconciler diff.

## Changes

- `app/config.py` — added `reconcile_health_gate_timeout_s` (120s default)
- `app/models/intent.py` — extended `StrategyProgress` with state machine fields (`phase`, `current_host_id`, `pending_hosts`, `failed_hosts`, `started_at`)
- `app/services/strategies.py` — **new**: `RollingStrategy`, `ImmediateStrategy`, health gate (`check_instance_healthy_sync`), `initiate_strategy`/`continue_strategy` dispatch
- `app/services/reconciliation.py` — integrated strategy delegation: `_get_strategy_progress()`, `_maybe_initiate_strategy()`, `_continue_strategy()`; `_update_status()` accepts and persists `strategy_progress`; delete/scale-to-zero take priority over active strategies
- `tests/test_strategies.py` — **new**: 63 tests covering all §11.6 scenarios (health gate, rolling lifecycle, immediate lifecycle, timeout hold, in-place replacement, dispatch, edge cases)

## Related Issues

Closes #42