### PR TITLE
feat: add active job step workloads to host status model and aggregation

### DIFF
--- a/app/database/jobs.py
+++ b/app/database/jobs.py
@@ -1,13 +1,17 @@
 """PostgreSQL-backed job CRUD operations using SQLAlchemy ORM."""
 
 from typing import Any
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select, delete, update
 
 from app.models.job import Job, JobStatus
 from .connection import get_session_factory
 from .tables import JobRow
+
+# How long to retain terminal (completed/failed/cancelled) jobs in the
+# active-job aggregation view after they finish.
+_TERMINAL_RETENTION_MINUTES = 15
 
 
 class JobDB:
@@ -26,6 +30,8 @@ class JobDB:
             error_message=row.error_message,
             correlation_id=row.correlation_id,
             submission_id=row.submission_id,
+            current_step_name=row.current_step_name,
+            current_step_index=row.current_step_index,
             created_at=row.created_at,
             updated_at=row.updated_at,
             completed_at=row.completed_at,
@@ -41,6 +47,8 @@ class JobDB:
             "error_message": job.error_message,
             "correlation_id": job.correlation_id,
             "submission_id": job.submission_id,
+            "current_step_name": job.current_step_name,
+            "current_step_index": job.current_step_index,
             "created_at": job.created_at,
             "updated_at": job.updated_at,
             "completed_at": job.completed_at,
@@ -127,6 +135,65 @@ class JobDB:
             )
             await session.commit()
             return result.rowcount > 0
+
+    async def update_job_step(
+        self,
+        job_id: str,
+        *,
+        step_name: str | None = None,
+        step_index: int | None = None,
+    ) -> bool:
+        """Update the current pipeline step for a job."""
+        values: dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+        if step_name is not None:
+            values["current_step_name"] = step_name
+        if step_index is not None:
+            values["current_step_index"] = step_index
+
+        async with self._session() as session:
+            result = await session.execute(
+                update(JobRow).where(JobRow.id == job_id).values(**values)
+            )
+            await session.commit()
+            return result.rowcount > 0
+
+    async def get_active_by_host(
+        self,
+        host_id: str,
+        *,
+        terminal_retention_minutes: int = _TERMINAL_RETENTION_MINUTES,
+    ) -> list[Job]:
+        """Get active and recently-terminal jobs for a given host.
+
+        Returns jobs that are:
+        - Non-terminal (pending, running), OR
+        - Terminal (completed, failed, cancelled) within the retention window.
+
+        Ordered by creation time descending (most recent first).
+        """
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            minutes=terminal_retention_minutes
+        )
+        terminal_statuses = [
+            JobStatus.COMPLETED.value,
+            JobStatus.FAILED.value,
+            JobStatus.CANCELLED.value,
+        ]
+
+        async with self._session() as session:
+            result = await session.execute(
+                select(JobRow)
+                .where(JobRow.host_id == host_id)
+                .where(
+                    (JobRow.status.notin_(terminal_statuses))
+                    | (
+                        (JobRow.status.in_(terminal_statuses))
+                        & (JobRow.completed_at >= cutoff)
+                    )
+                )
+                .order_by(JobRow.created_at.desc())
+            )
+            return [self._row_to_job(row) for row in result.scalars()]
 
     async def remove_job(self, job_id: str) -> bool:
         """Delete a job record."""

--- a/app/database/jobs.py
+++ b/app/database/jobs.py
@@ -13,6 +13,11 @@ from .tables import JobRow
 # active-job aggregation view after they finish.
 _TERMINAL_RETENTION_MINUTES = 15
 
+# Cap on jobs returned per host. Jobs stuck in pending/running (e.g. the host
+# died mid-run) are never aged out, so without a cap the host_status payload
+# could grow without bound.
+_ACTIVE_JOB_LIMIT = 50
+
 
 class JobDB:
     """Database-backed job management."""
@@ -162,6 +167,7 @@ class JobDB:
         host_id: str,
         *,
         terminal_retention_minutes: int = _TERMINAL_RETENTION_MINUTES,
+        limit: int = _ACTIVE_JOB_LIMIT,
     ) -> list[Job]:
         """Get active and recently-terminal jobs for a given host.
 
@@ -169,7 +175,10 @@ class JobDB:
         - Non-terminal (pending, running), OR
         - Terminal (completed, failed, cancelled) within the retention window.
 
-        Ordered by creation time descending (most recent first).
+        Active jobs are ordered first, then by creation time descending, so a
+        long-running job is never pushed past ``limit`` by newer terminal or
+        stuck rows. The result feeds every host_status broadcast, so it must
+        stay bounded.
         """
         cutoff = datetime.now(timezone.utc) - timedelta(
             minutes=terminal_retention_minutes
@@ -191,7 +200,11 @@ class JobDB:
                         & (JobRow.completed_at >= cutoff)
                     )
                 )
-                .order_by(JobRow.created_at.desc())
+                .order_by(
+                    JobRow.status.in_(terminal_statuses),
+                    JobRow.created_at.desc(),
+                )
+                .limit(limit)
             )
             return [self._row_to_job(row) for row in result.scalars()]
 

--- a/app/database/migrations/versions/0005_add_job_step_tracking.py
+++ b/app/database/migrations/versions/0005_add_job_step_tracking.py
@@ -1,0 +1,42 @@
+"""Add current_step_name and current_step_index to jobs table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-07-26 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "current_step_name",
+            sa.Text(),
+            nullable=True,
+            comment="Name of the currently executing pipeline step (e.g. 'train')",
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "current_step_index",
+            sa.Integer(),
+            nullable=True,
+            comment="Zero-based index of the currently executing pipeline step",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "current_step_index")
+    op.drop_column("jobs", "current_step_name")

--- a/app/database/tables.py
+++ b/app/database/tables.py
@@ -157,6 +157,16 @@ class JobRow(Base):
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     correlation_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     submission_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    current_step_name: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Name of the currently executing pipeline step (e.g. 'train')",
+    )
+    current_step_index: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Zero-based index of the currently executing pipeline step",
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/gateway.py
+++ b/app/gateway.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 from app.config import settings
 from app.database.hosts import host_db
 from app.models import HostStatus, RegistryEntry
-from app.models.socketio import HostStatusPayload
 from app.redis_state import registry_store, health_store, routing_store, host_store
 
 logger = logging.getLogger(__name__)
@@ -249,12 +248,13 @@ class OpenAIGateway:
 
     async def _notify_host_online(self, host) -> None:
         """Emit host_status to WebUI when HTTP polling discovers a host is online."""
+        from app.services.host_status import build_host_status_payload
         from app.socketio_app.server import sio
 
         try:
             refreshed = await host_db.get_host(host.id)
             h = refreshed or host
-            payload = HostStatusPayload.from_host(h, connected=False)
+            payload = await build_host_status_payload(h, connected=False)
             await sio.emit("host_status", payload.model_dump(), namespace="/webui")
         except Exception as e:
             logger.debug("Failed to notify WebUI of host online: %s", e)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from .gateway import (
     RegistryEntry as RegistryEntry,
 )
 from .host import (
+    ActiveJobSummary as ActiveJobSummary,
     AggregatedResourceResponse as AggregatedResourceResponse,
     Host as Host,
     HostCreate as HostCreate,

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Any
 
 
 class HostStatus(str, Enum):
@@ -59,6 +60,57 @@ class HostResponse(BaseModel):
     message: str
 
 
+class ActiveJobSummary(BaseModel):
+    """Summary of an active or recently-terminal job on a host.
+
+    Provides operators and scheduling logic with a lightweight view of
+    what job workloads a host is running, without exposing the full
+    ``Job`` payload.
+    """
+
+    job_id: str
+    submission_id: str | None = Field(
+        default=None,
+        description="SuperNova submission ID for cross-system correlation",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Human-readable job name from the pipeline definition",
+    )
+    status: str = Field(
+        ...,
+        description="Current job status (pending/running/completed/failed/cancelled)",
+    )
+    current_step_name: str | None = Field(
+        default=None,
+        description="Name of the currently executing pipeline step (e.g. 'train')",
+    )
+    current_step_index: int | None = Field(
+        default=None,
+        description="Zero-based index of the currently executing pipeline step",
+    )
+    pipeline: list[str] = Field(
+        default_factory=list,
+        description="Ordered list of all pipeline step names",
+    )
+    resource_hints: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Resource hints extracted from the job payload (VRAM, RAM, etc.)",
+    )
+    started_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp when the job was created or started",
+    )
+    completed_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp when the job reached a terminal state",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error message if the job failed or was cancelled",
+    )
+
+
 class HostResourceSnapshot(BaseModel):
     """Per-host resource snapshot in the aggregated cluster view (S-035).
 
@@ -110,6 +162,12 @@ class HostResourceSnapshot(BaseModel):
     # Running workloads (from Redis instance cache)
     instance_count: int = 0
     running_instance_count: int = 0
+
+    # Active job workloads (from jobs table — training pipelines etc.)
+    active_jobs: list[ActiveJobSummary] = Field(
+        default_factory=list,
+        description="Active and recently-terminal job workloads on this host",
+    )
 
     # Reservation summary (totals only — no per-reservation list)
     reservation_count: int = 0

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -83,11 +83,29 @@ class ActiveJobSummary(BaseModel):
     )
     current_step_name: str | None = Field(
         default=None,
-        description="Name of the currently executing pipeline step (e.g. 'train')",
+        description=(
+            "Name of the currently executing pipeline step (e.g. 'train'). "
+            "Only set while the job is pending or running"
+        ),
     )
     current_step_index: int | None = Field(
         default=None,
-        description="Zero-based index of the currently executing pipeline step",
+        description=(
+            "Zero-based index of the currently executing pipeline step. "
+            "Only set while the job is pending or running"
+        ),
+    )
+    last_step_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of the last pipeline step the job entered. Remains set "
+            "after the job reaches a terminal state, so consumers can see "
+            "which step a failed job stopped on"
+        ),
+    )
+    last_step_index: int | None = Field(
+        default=None,
+        description="Zero-based index of the last pipeline step the job entered",
     )
     pipeline: list[str] = Field(
         default_factory=list,
@@ -95,7 +113,10 @@ class ActiveJobSummary(BaseModel):
     )
     resource_hints: dict[str, Any] = Field(
         default_factory=dict,
-        description="Resource hints extracted from the job payload (VRAM, RAM, etc.)",
+        description=(
+            "Resource requirements extracted from the translated job "
+            "definition (peak GPU count, minimum free disk, training config)"
+        ),
     )
     started_at: str | None = Field(
         default=None,

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -57,6 +57,14 @@ class Job(BaseModel):
         default=None,
         description="Optional SuperNova submission ID, forwarded to the host",
     )
+    current_step_name: str | None = Field(
+        default=None,
+        description="Name of the currently executing pipeline step (e.g. 'train')",
+    )
+    current_step_index: int | None = Field(
+        default=None,
+        description="Zero-based index of the currently executing pipeline step",
+    )
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None

--- a/app/models/socketio.py
+++ b/app/models/socketio.py
@@ -112,8 +112,16 @@ class HostStatusPayload(BaseModel):
         host: Host,
         *,
         connected: bool,
-        active_jobs: list[ActiveJobSummary] | None = None,
+        active_jobs: list[ActiveJobSummary],
     ) -> "HostStatusPayload":
+        """Build a host_status payload.
+
+        ``active_jobs`` is required rather than defaulted: WebUI clients replace
+        their whole host entry on ``host_status``, so an accidentally-omitted
+        list would erase live job state. Prefer
+        ``app.services.host_status.build_host_status_payload``, which populates
+        it for you.
+        """
         return cls(
             host_id=host.id,
             name=host.name,
@@ -129,7 +137,7 @@ class HostStatusPayload(BaseModel):
             memory_available_gb=host.memory_available_gb,
             version=host.version,
             connected=connected,
-            active_jobs=active_jobs or [],
+            active_jobs=active_jobs,
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
 

--- a/app/models/socketio.py
+++ b/app/models/socketio.py
@@ -3,7 +3,7 @@ from typing import Any
 from datetime import datetime, timezone
 from enum import Enum
 
-from .host import Host, MemoryInfo
+from .host import ActiveJobSummary, Host, MemoryInfo
 
 
 class WSMessageType(str, Enum):
@@ -100,10 +100,20 @@ class HostStatusPayload(BaseModel):
     memory_available_gb: float | None = None
     version: str | None = None
     connected: bool = False
+    active_jobs: list[ActiveJobSummary] = Field(
+        default_factory=list,
+        description="Active and recently-terminal job workloads on this host",
+    )
     timestamp: str = ""
 
     @classmethod
-    def from_host(cls, host: Host, *, connected: bool) -> "HostStatusPayload":
+    def from_host(
+        cls,
+        host: Host,
+        *,
+        connected: bool,
+        active_jobs: list[ActiveJobSummary] | None = None,
+    ) -> "HostStatusPayload":
         return cls(
             host_id=host.id,
             name=host.name,
@@ -119,6 +129,7 @@ class HostStatusPayload(BaseModel):
             memory_available_gb=host.memory_available_gb,
             version=host.version,
             connected=connected,
+            active_jobs=active_jobs or [],
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
 

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -6,12 +6,16 @@ GET /api/resources — cluster-wide view of host capacity, workloads, and reserv
 import asyncio
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 import aiohttp
 from fastapi import APIRouter, HTTPException, Query
 
 from app.database.hosts import host_db
+from app.database.jobs import job_db
 from app.models import Host, HostResourceSnapshot, AggregatedResourceResponse
+from app.models.host import ActiveJobSummary
+from app.models.job import Job
 from app.redis_state import host_store
 
 logger = logging.getLogger(__name__)
@@ -19,6 +23,39 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/resources", tags=["resources"])
 
 _RESOURCE_TIMEOUT = 5  # seconds to wait for a host's /resources response
+
+
+def _job_to_active_summary(job: Job) -> ActiveJobSummary:
+    """Convert a ``Job`` record to an ``ActiveJobSummary`` for resource views."""
+    payload = job.payload or {}
+    pipeline: list[str] = list(payload.get("pipeline", []))
+    name: str | None = payload.get("name")
+
+    resource_hints: dict[str, Any] = {}
+    training_config = payload.get("training_config") or {}
+    if training_config:
+        resource_hints["training_config"] = {
+            k: training_config[k]
+            for k in ("batch_size", "max_steps", "learning_rate")
+            if k in training_config
+        }
+    resources = payload.get("resources") or {}
+    if resources:
+        resource_hints["resources"] = resources
+
+    return ActiveJobSummary(
+        job_id=job.id,
+        submission_id=job.submission_id,
+        name=name,
+        status=job.status.value,
+        current_step_name=job.current_step_name,
+        current_step_index=job.current_step_index,
+        pipeline=pipeline,
+        resource_hints=resource_hints,
+        started_at=job.created_at.isoformat() if job.created_at else None,
+        completed_at=job.completed_at.isoformat() if job.completed_at else None,
+        error_message=job.error_message,
+    )
 
 
 async def _fetch_host_resource_snapshot(
@@ -55,6 +92,17 @@ async def _fetch_host_resource_snapshot(
     except Exception:
         logger.warning(
             "Failed to fetch instances from Redis for host %s",
+            host.id,
+            exc_info=True,
+        )
+
+    # Aggregate active job workloads from the jobs table
+    try:
+        jobs = await job_db.get_active_by_host(host.id)
+        base.active_jobs = [_job_to_active_summary(j) for j in jobs]
+    except Exception:
+        logger.warning(
+            "Failed to fetch active jobs for host %s",
             host.id,
             exc_info=True,
         )

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -28,7 +28,9 @@ _RESOURCE_TIMEOUT = 5  # seconds to wait for a host's /resources response
 def _job_to_active_summary(job: Job) -> ActiveJobSummary:
     """Convert a ``Job`` record to an ``ActiveJobSummary`` for resource views."""
     payload = job.payload or {}
-    pipeline: list[str] = list(payload.get("pipeline", []))
+    # The translated payload stores steps as a list of dicts with a "name" key.
+    steps: list[dict] = payload.get("steps", [])
+    pipeline: list[str] = [s["name"] for s in steps if isinstance(s, dict)]
     name: str | None = payload.get("name")
 
     resource_hints: dict[str, Any] = {}

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -6,58 +6,20 @@ GET /api/resources — cluster-wide view of host capacity, workloads, and reserv
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any
 
 import aiohttp
 from fastapi import APIRouter, HTTPException, Query
 
 from app.database.hosts import host_db
-from app.database.jobs import job_db
 from app.models import Host, HostResourceSnapshot, AggregatedResourceResponse
-from app.models.host import ActiveJobSummary
-from app.models.job import Job
 from app.redis_state import host_store
+from app.services.host_status import get_host_active_jobs
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/resources", tags=["resources"])
 
 _RESOURCE_TIMEOUT = 5  # seconds to wait for a host's /resources response
-
-
-def _job_to_active_summary(job: Job) -> ActiveJobSummary:
-    """Convert a ``Job`` record to an ``ActiveJobSummary`` for resource views."""
-    payload = job.payload or {}
-    # The translated payload stores steps as a list of dicts with a "name" key.
-    steps: list[dict] = payload.get("steps", [])
-    pipeline: list[str] = [s["name"] for s in steps if isinstance(s, dict)]
-    name: str | None = payload.get("name")
-
-    resource_hints: dict[str, Any] = {}
-    training_config = payload.get("training_config") or {}
-    if training_config:
-        resource_hints["training_config"] = {
-            k: training_config[k]
-            for k in ("batch_size", "max_steps", "learning_rate")
-            if k in training_config
-        }
-    resources = payload.get("resources") or {}
-    if resources:
-        resource_hints["resources"] = resources
-
-    return ActiveJobSummary(
-        job_id=job.id,
-        submission_id=job.submission_id,
-        name=name,
-        status=job.status.value,
-        current_step_name=job.current_step_name,
-        current_step_index=job.current_step_index,
-        pipeline=pipeline,
-        resource_hints=resource_hints,
-        started_at=job.created_at.isoformat() if job.created_at else None,
-        completed_at=job.completed_at.isoformat() if job.completed_at else None,
-        error_message=job.error_message,
-    )
 
 
 async def _fetch_host_resource_snapshot(
@@ -99,15 +61,7 @@ async def _fetch_host_resource_snapshot(
         )
 
     # Aggregate active job workloads from the jobs table
-    try:
-        jobs = await job_db.get_active_by_host(host.id)
-        base.active_jobs = [_job_to_active_summary(j) for j in jobs]
-    except Exception:
-        logger.warning(
-            "Failed to fetch active jobs for host %s",
-            host.id,
-            exc_info=True,
-        )
+    base.active_jobs = await get_host_active_jobs(host.id)
 
     # Proxy live resource data from the host
     try:

--- a/app/services/host_status.py
+++ b/app/services/host_status.py
@@ -1,0 +1,128 @@
+"""Shared host status aggregation (S-033).
+
+Builds the ``active_jobs`` view that Solar Control publishes alongside
+inference instance state, plus the ``host_status`` payload itself.
+
+Every producer of host status must go through :func:`build_host_status_payload`.
+WebUI clients replace their whole host entry when a ``host_status`` arrives, so
+any emit path that omits ``active_jobs`` erases live job state on the client.
+"""
+
+import logging
+from typing import Any
+
+from app.database.jobs import job_db
+from app.models.host import ActiveJobSummary, Host
+from app.models.job import Job, JobStatus
+from app.models.socketio import HostStatusPayload
+
+logger = logging.getLogger(__name__)
+
+# Statuses for which a persisted step is still actually executing.
+_ACTIVE_STATUSES = (JobStatus.PENDING, JobStatus.RUNNING)
+
+# training_config keys worth surfacing; the full config can be large.
+_TRAINING_CONFIG_HINT_KEYS = ("batch_size", "max_steps", "learning_rate")
+
+
+def _step_gpu_count(gpu: Any) -> int:
+    """Best-effort GPU count for a translated step's ``gpu`` block.
+
+    The block originates from the SuperNova intent and is passed through
+    ``_translate_payload`` unvalidated, so it may be a ``{"count": n}`` mapping,
+    a bare number, or a list of device IDs.
+    """
+    if not gpu:
+        return 0
+    if isinstance(gpu, dict):
+        count = gpu.get("count", 1)
+        return int(count) if isinstance(count, (int, float)) else 1
+    if isinstance(gpu, (int, float)):
+        return int(gpu)
+    if isinstance(gpu, (list, tuple)):
+        return len(gpu)
+    return 1
+
+
+def _build_resource_hints(
+    payload: dict[str, Any], steps: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Extract resource requirements from a translated ``JobDefinition``."""
+    hints: dict[str, Any] = {}
+
+    peak_gpu = max((_step_gpu_count(s.get("gpu")) for s in steps), default=0)
+    if peak_gpu:
+        hints["peak_gpu_count"] = peak_gpu
+
+    if payload.get("min_free_disk_gb") is not None:
+        hints["min_free_disk_gb"] = payload["min_free_disk_gb"]
+
+    training_config = payload.get("training_config") or {}
+    if isinstance(training_config, dict):
+        subset = {
+            k: training_config[k]
+            for k in _TRAINING_CONFIG_HINT_KEYS
+            if k in training_config
+        }
+        if subset:
+            hints["training_config"] = subset
+
+    return hints
+
+
+def build_active_job_summary(job: Job) -> ActiveJobSummary:
+    """Convert a ``Job`` record to an ``ActiveJobSummary`` for host status views.
+
+    ``job.payload`` holds the translated host ``JobDefinition``, whose ``steps``
+    is an ordered list of dicts each carrying a ``name``.
+    """
+    payload = job.payload or {}
+    steps = [s for s in payload.get("steps", []) if isinstance(s, dict)]
+    pipeline = [str(s["name"]) for s in steps if s.get("name")]
+
+    name = payload.get("name")
+    # A terminal job keeps its last step recorded, but nothing is executing.
+    is_active = job.status in _ACTIVE_STATUSES
+
+    return ActiveJobSummary(
+        job_id=job.id,
+        submission_id=job.submission_id,
+        name=str(name) if name is not None else None,
+        status=job.status.value,
+        current_step_name=job.current_step_name if is_active else None,
+        current_step_index=job.current_step_index if is_active else None,
+        last_step_name=job.current_step_name,
+        last_step_index=job.current_step_index,
+        pipeline=pipeline,
+        resource_hints=_build_resource_hints(payload, steps),
+        started_at=job.created_at.isoformat() if job.created_at else None,
+        completed_at=job.completed_at.isoformat() if job.completed_at else None,
+        error_message=job.error_message,
+    )
+
+
+async def get_host_active_jobs(host_id: str) -> list[ActiveJobSummary]:
+    """Aggregate active and recently-terminal jobs for *host_id*.
+
+    Never raises: host status is emitted from the Socket.IO ``connect`` handler,
+    where an exception would refuse the host's connection outright.
+    """
+    try:
+        jobs = await job_db.get_active_by_host(host_id)
+        return [build_active_job_summary(j) for j in jobs]
+    except Exception:
+        logger.warning(
+            "Failed to aggregate active jobs for host %s", host_id, exc_info=True
+        )
+        return []
+
+
+async def build_host_status_payload(
+    host: Host, *, connected: bool
+) -> HostStatusPayload:
+    """Build the ``host_status`` payload for *host*, including active jobs."""
+    return HostStatusPayload.from_host(
+        host,
+        connected=connected,
+        active_jobs=await get_host_active_jobs(host.id),
+    )

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -20,12 +20,10 @@ from .server import sio
 from app.database.hosts import host_db
 from app.database.jobs import job_db
 from app.models import Host, HostStatus
-from app.models.host import ActiveJobSummary
-from app.models.job import Job, JobStatus
+from app.models.job import JobStatus
 from app.models.socketio import (
     HostHealthPayload,
     HostPendingPayload,
-    HostStatusPayload,
     InstancesUpdatePayload,
     InstanceStatePayload,
     JobLifecyclePayload,
@@ -34,6 +32,7 @@ from app.models.socketio import (
     WSRegistration,
 )
 from app.redis_state import host_store
+from app.services.host_status import build_host_status_payload
 
 logger = logging.getLogger(__name__)
 
@@ -65,62 +64,9 @@ def _api_key_preview(api_key: str) -> str:
     return api_key[:8] + "..." if len(api_key) > 8 else api_key
 
 
-def _job_to_active_summary(job: Job) -> ActiveJobSummary:
-    """Convert a ``Job`` record to an ``ActiveJobSummary`` for host status views.
-
-    Extracts the job name and pipeline steps from the translated host
-    ``JobDefinition`` stored in ``job.payload``, and surfaces resource
-    hints where available.
-    """
-    payload = job.payload or {}
-    # The translated payload stores steps as a list of dicts with a "name" key.
-    steps: list[dict] = payload.get("steps", [])
-    pipeline: list[str] = [s["name"] for s in steps if isinstance(s, dict)]
-    name: str | None = payload.get("name")
-
-    # Extract lightweight resource hints from the payload.
-    resource_hints: dict[str, Any] = {}
-    training_config = payload.get("training_config") or {}
-    if training_config:
-        resource_hints["training_config"] = {
-            k: training_config[k]
-            for k in ("batch_size", "max_steps", "learning_rate")
-            if k in training_config
-        }
-    resources = payload.get("resources") or {}
-    if resources:
-        resource_hints["resources"] = resources
-
-    return ActiveJobSummary(
-        job_id=job.id,
-        submission_id=job.submission_id,
-        name=name,
-        status=job.status.value,
-        current_step_name=job.current_step_name,
-        current_step_index=job.current_step_index,
-        pipeline=pipeline,
-        resource_hints=resource_hints,
-        started_at=job.created_at.isoformat() if job.created_at else None,
-        completed_at=job.completed_at.isoformat() if job.completed_at else None,
-        error_message=job.error_message,
-    )
-
-
-async def _get_host_active_jobs(host_id: str) -> list[ActiveJobSummary]:
-    """Aggregate active and recently-terminal jobs for *host_id*.
-
-    Queries the jobs table and maps each ``Job`` to an ``ActiveJobSummary``.
-    """
-    jobs = await job_db.get_active_by_host(host_id)
-    return [_job_to_active_summary(j) for j in jobs]
-
-
 async def _emit_host_status(host: Host, *, connected: bool) -> None:
     """Emit a host_status event to WebUI using the typed payload model."""
-    active_jobs = await _get_host_active_jobs(host.id)
-    payload = HostStatusPayload.from_host(
-        host, connected=connected, active_jobs=active_jobs
-    )
+    payload = await build_host_status_payload(host, connected=connected)
     await sio.emit("host_status", payload.model_dump(), namespace="/webui")
 
 
@@ -684,6 +630,9 @@ async def _handle_job_lifecycle(
         timestamp=data.get("timestamp", datetime.now(timezone.utc).isoformat()),
     )
 
+    # Tracks whether this event changed anything the active_jobs view exposes.
+    job_state_changed = False
+
     # Persist job-level status transitions (step_* events don't change it).
     new_status = _LIFECYCLE_STATUS.get(event_name)
     if new_status and job_id:
@@ -693,6 +642,7 @@ async def _handle_job_lifecycle(
             new_status,
             error_message=error_message if new_status == JobStatus.FAILED else None,
         )
+        job_state_changed = True
         if new_status in (
             JobStatus.COMPLETED,
             JobStatus.FAILED,
@@ -710,14 +660,17 @@ async def _handle_job_lifecycle(
                 step_name=str(step_name) if step_name is not None else None,
                 step_index=int(step_index) if step_index is not None else None,
             )
+            job_state_changed = True
 
     from .webui_handlers import broadcast_job_lifecycle as _b
 
     await _b(payload.model_dump())
 
-    # Broadcast updated host status so WebUI consumers see the new
-    # active_jobs summary immediately.
-    if host and job_id:
+    # Broadcast updated host status so WebUI consumers see the new active_jobs
+    # summary immediately. Skipped when nothing was persisted: step_completed
+    # and step_failed would rebroadcast an identical payload, and step_failed
+    # is always followed by job_failed, which does broadcast.
+    if host and job_state_changed:
         await _emit_host_status(host, connected=True)
 
 

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -68,11 +68,14 @@ def _api_key_preview(api_key: str) -> str:
 def _job_to_active_summary(job: Job) -> ActiveJobSummary:
     """Convert a ``Job`` record to an ``ActiveJobSummary`` for host status views.
 
-    Extracts the job name and pipeline from the payload, and surfaces
-    resource hints where available.
+    Extracts the job name and pipeline steps from the translated host
+    ``JobDefinition`` stored in ``job.payload``, and surfaces resource
+    hints where available.
     """
     payload = job.payload or {}
-    pipeline: list[str] = list(payload.get("pipeline", []))
+    # The translated payload stores steps as a list of dicts with a "name" key.
+    steps: list[dict] = payload.get("steps", [])
+    pipeline: list[str] = [s["name"] for s in steps if isinstance(s, dict)]
     name: str | None = payload.get("name")
 
     # Extract lightweight resource hints from the payload.

--- a/app/socketio_app/host_handlers.py
+++ b/app/socketio_app/host_handlers.py
@@ -20,7 +20,8 @@ from .server import sio
 from app.database.hosts import host_db
 from app.database.jobs import job_db
 from app.models import Host, HostStatus
-from app.models.job import JobStatus
+from app.models.host import ActiveJobSummary
+from app.models.job import Job, JobStatus
 from app.models.socketio import (
     HostHealthPayload,
     HostPendingPayload,
@@ -64,9 +65,59 @@ def _api_key_preview(api_key: str) -> str:
     return api_key[:8] + "..." if len(api_key) > 8 else api_key
 
 
+def _job_to_active_summary(job: Job) -> ActiveJobSummary:
+    """Convert a ``Job`` record to an ``ActiveJobSummary`` for host status views.
+
+    Extracts the job name and pipeline from the payload, and surfaces
+    resource hints where available.
+    """
+    payload = job.payload or {}
+    pipeline: list[str] = list(payload.get("pipeline", []))
+    name: str | None = payload.get("name")
+
+    # Extract lightweight resource hints from the payload.
+    resource_hints: dict[str, Any] = {}
+    training_config = payload.get("training_config") or {}
+    if training_config:
+        resource_hints["training_config"] = {
+            k: training_config[k]
+            for k in ("batch_size", "max_steps", "learning_rate")
+            if k in training_config
+        }
+    resources = payload.get("resources") or {}
+    if resources:
+        resource_hints["resources"] = resources
+
+    return ActiveJobSummary(
+        job_id=job.id,
+        submission_id=job.submission_id,
+        name=name,
+        status=job.status.value,
+        current_step_name=job.current_step_name,
+        current_step_index=job.current_step_index,
+        pipeline=pipeline,
+        resource_hints=resource_hints,
+        started_at=job.created_at.isoformat() if job.created_at else None,
+        completed_at=job.completed_at.isoformat() if job.completed_at else None,
+        error_message=job.error_message,
+    )
+
+
+async def _get_host_active_jobs(host_id: str) -> list[ActiveJobSummary]:
+    """Aggregate active and recently-terminal jobs for *host_id*.
+
+    Queries the jobs table and maps each ``Job`` to an ``ActiveJobSummary``.
+    """
+    jobs = await job_db.get_active_by_host(host_id)
+    return [_job_to_active_summary(j) for j in jobs]
+
+
 async def _emit_host_status(host: Host, *, connected: bool) -> None:
     """Emit a host_status event to WebUI using the typed payload model."""
-    payload = HostStatusPayload.from_host(host, connected=connected)
+    active_jobs = await _get_host_active_jobs(host.id)
+    payload = HostStatusPayload.from_host(
+        host, connected=connected, active_jobs=active_jobs
+    )
     await sio.emit("host_status", payload.model_dump(), namespace="/webui")
 
 
@@ -646,9 +697,25 @@ async def _handle_job_lifecycle(
         ):
             _correlation_cache.pop(job_id, None)
 
+    # Persist current pipeline step on step_started events.
+    if event_name == "step_started" and job_id:
+        step_name = data.get("step_name")
+        step_index = data.get("step_index")
+        if step_name is not None or step_index is not None:
+            await job_db.update_job_step(
+                job_id,
+                step_name=str(step_name) if step_name is not None else None,
+                step_index=int(step_index) if step_index is not None else None,
+            )
+
     from .webui_handlers import broadcast_job_lifecycle as _b
 
     await _b(payload.model_dump())
+
+    # Broadcast updated host status so WebUI consumers see the new
+    # active_jobs summary immediately.
+    if host and job_id:
+        await _emit_host_status(host, connected=True)
 
 
 def _make_lifecycle_handler(event_name: str):

--- a/app/socketio_app/webui_handlers.py
+++ b/app/socketio_app/webui_handlers.py
@@ -14,7 +14,8 @@ from typing import Any
 from .server import sio
 from app.config import settings
 from app.database.hosts import host_db
-from app.models.socketio import HostStatusPayload, InstancesUpdatePayload
+from app.models.socketio import InstancesUpdatePayload
+from app.services.host_status import build_host_status_payload
 from app.socketio_app.host_handlers import (
     is_host_connected,
     get_pending_hosts,
@@ -54,7 +55,7 @@ async def webui_connect(
     hosts = await host_db.get_all_hosts()
     initial: list[dict[str, Any]] = []
     for h in hosts:
-        payload = HostStatusPayload.from_host(
+        payload = await build_host_status_payload(
             h, connected=await is_host_connected(h.id)
         )
         initial.append(payload.model_dump())

--- a/tests/test_host_status.py
+++ b/tests/test_host_status.py
@@ -1,0 +1,296 @@
+"""Tests for shared host status aggregation (S-033).
+
+Covers the ``active_jobs`` summary built from a translated host
+``JobDefinition``, and the three emit paths that must all carry it: the
+Socket.IO ``host_status`` broadcast, the WebUI ``initial_status`` snapshot, and
+the gateway's HTTP-polling host-online notification.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.database.jobs import job_db
+from app.jobs.router import _translate_payload
+from app.models import Host, HostStatus
+from app.models.job import Job, JobStatus
+from app.services.host_status import (
+    build_active_job_summary,
+    build_host_status_payload,
+    get_host_active_jobs,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def training_host():
+    return Host(
+        id="host-1",
+        name="Training Box",
+        url="http://training-box:8000",
+        api_key="host-key-1",
+        status=HostStatus.ONLINE,
+        roles=["training"],
+        disk_available_gb=500.0,
+    )
+
+
+@pytest.fixture
+def job_definition():
+    """A real translated ``JobDefinition``, as stored in ``Job.payload``.
+
+    Built through ``_translate_payload`` rather than hand-written so the tests
+    break if the host contract's ``steps`` shape ever changes.
+    """
+    return _translate_payload(
+        {
+            "name": "iris-osl-retrain",
+            "pipeline": ["download_model", "train", "upload_model"],
+            "min_free_disk_gb": 200.0,
+            "training_config": {
+                "batch_size": 8,
+                "max_steps": 1000,
+                "weight_decay": 0.01,
+            },
+            "steps": {
+                "download_model": {"image": "repo/download-model:v1"},
+                "train": {"image": "repo/train:v1", "run_name": "run-1"},
+                "upload_model": {"image": "repo/upload-model:v1"},
+            },
+        },
+        job_id="job-1",
+    )
+
+
+def _job(job_definition, **overrides) -> Job:
+    defaults = dict(
+        id="job-1",
+        host_id="host-1",
+        status=JobStatus.RUNNING,
+        payload=job_definition,
+        current_step_name="train",
+        current_step_index=1,
+    )
+    defaults.update(overrides)
+    return Job(**defaults)
+
+
+# ── build_active_job_summary ──────────────────────────────────
+
+
+def test_summary_reads_pipeline_from_translated_definition(job_definition):
+    """``steps`` is an ordered list of dicts on the host side, not a mapping."""
+    summary = build_active_job_summary(
+        _job(job_definition, submission_id="submission-9")
+    )
+
+    assert summary.pipeline == ["download_model", "train", "upload_model"]
+    assert summary.name == "iris-osl-retrain"
+    assert summary.job_id == "job-1"
+    assert summary.submission_id == "submission-9"
+    assert summary.status == "running"
+
+
+def test_summary_exposes_current_step_while_running(job_definition):
+    summary = build_active_job_summary(_job(job_definition))
+
+    assert summary.current_step_name == "train"
+    assert summary.current_step_index == 1
+    assert summary.last_step_name == "train"
+    assert summary.last_step_index == 1
+
+
+def test_summary_step_index_zero_is_preserved(job_definition):
+    """Index 0 is falsy — it must not be dropped."""
+    summary = build_active_job_summary(
+        _job(job_definition, current_step_name="download_model", current_step_index=0)
+    )
+
+    assert summary.current_step_index == 0
+    assert summary.last_step_index == 0
+
+
+@pytest.mark.parametrize(
+    "status", [JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED]
+)
+def test_summary_clears_current_step_when_terminal(job_definition, status):
+    """A finished job is not executing anything, but we keep the step it reached."""
+    completed_at = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
+    summary = build_active_job_summary(
+        _job(
+            job_definition,
+            status=status,
+            completed_at=completed_at,
+            error_message="Out of memory",
+        )
+    )
+
+    assert summary.current_step_name is None
+    assert summary.current_step_index is None
+    assert summary.last_step_name == "train"
+    assert summary.last_step_index == 1
+    assert summary.completed_at == completed_at.isoformat()
+    assert summary.error_message == "Out of memory"
+
+
+def test_summary_resource_hints(job_definition):
+    """Hints carry real resource requirements, not just hyperparameters."""
+    hints = build_active_job_summary(_job(job_definition)).resource_hints
+
+    # The train step defaults to one GPU in _translate_payload.
+    assert hints["peak_gpu_count"] == 1
+    assert hints["min_free_disk_gb"] == 200.0
+    assert hints["training_config"] == {"batch_size": 8, "max_steps": 1000}
+
+
+def test_summary_resource_hints_empty_when_nothing_to_report():
+    job = _job({"name": "tiny", "steps": [{"name": "noop"}]})
+
+    assert build_active_job_summary(job).resource_hints == {}
+
+
+@pytest.mark.parametrize(
+    "gpu,expected",
+    [
+        ({"count": 4}, 4),
+        ({}, None),
+        (2, 2),
+        ([0, 1, 2], 3),
+        (None, None),
+    ],
+)
+def test_summary_peak_gpu_count_tolerates_gpu_shapes(gpu, expected):
+    """The gpu block comes straight from the intent, so it may be any shape."""
+    payload = {"steps": [{"name": "a"}, {"name": "b", "gpu": gpu}]}
+
+    hints = build_active_job_summary(_job(payload)).resource_hints
+
+    assert hints.get("peak_gpu_count") == expected
+
+
+def test_summary_tolerates_malformed_steps():
+    payload = {"steps": [{"name": "ok"}, {"image": "no-name"}, "garbage", None]}
+
+    assert build_active_job_summary(_job(payload)).pipeline == ["ok"]
+
+
+def test_summary_tolerates_empty_payload():
+    summary = build_active_job_summary(_job({}, current_step_name=None))
+
+    assert summary.pipeline == []
+    assert summary.name is None
+    assert summary.resource_hints == {}
+
+
+# ── get_host_active_jobs ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_host_active_jobs_maps_rows(job_definition):
+    with patch.object(
+        job_db, "get_active_by_host", AsyncMock(return_value=[_job(job_definition)])
+    ):
+        summaries = await get_host_active_jobs("host-1")
+
+    assert [s.job_id for s in summaries] == ["job-1"]
+
+
+@pytest.mark.anyio
+async def test_get_host_active_jobs_swallows_db_errors():
+    """Host status is emitted from the connect handler — it must never raise."""
+    with patch.object(
+        job_db, "get_active_by_host", AsyncMock(side_effect=RuntimeError("db down"))
+    ):
+        assert await get_host_active_jobs("host-1") == []
+
+
+@pytest.mark.anyio
+async def test_build_host_status_payload_includes_active_jobs(
+    training_host, job_definition
+):
+    with patch.object(
+        job_db, "get_active_by_host", AsyncMock(return_value=[_job(job_definition)])
+    ):
+        payload = await build_host_status_payload(training_host, connected=True)
+
+    assert payload.host_id == "host-1"
+    assert payload.connected is True
+    assert [j.job_id for j in payload.active_jobs] == ["job-1"]
+
+
+# ── Emit paths ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_emit_host_status_survives_db_failure(training_host):
+    """A database outage must not stop hosts from connecting."""
+    from app.socketio_app import host_handlers
+
+    with (
+        patch.object(
+            job_db, "get_active_by_host", AsyncMock(side_effect=RuntimeError("db down"))
+        ),
+        patch.object(host_handlers.sio, "emit", AsyncMock()) as mock_emit,
+    ):
+        await host_handlers._emit_host_status(training_host, connected=True)
+
+    assert mock_emit.await_args.args[1]["active_jobs"] == []
+
+
+@pytest.mark.anyio
+async def test_webui_initial_status_includes_active_jobs(training_host, job_definition):
+    """The first snapshot a WebUI client receives must carry active jobs."""
+    from app.socketio_app import webui_handlers
+
+    with (
+        patch.object(
+            webui_handlers, "settings", SimpleNamespace(management_api_key="mgmt-key")
+        ),
+        patch.object(
+            webui_handlers.host_db,
+            "get_all_hosts",
+            AsyncMock(return_value=[training_host]),
+        ),
+        patch.object(webui_handlers, "is_host_connected", AsyncMock(return_value=True)),
+        patch.object(
+            webui_handlers, "get_connected_host_ids", AsyncMock(return_value=[])
+        ),
+        patch.object(webui_handlers, "get_pending_hosts", AsyncMock(return_value=[])),
+        patch.object(
+            job_db, "get_active_by_host", AsyncMock(return_value=[_job(job_definition)])
+        ),
+        patch.object(webui_handlers.sio, "emit", AsyncMock()) as mock_emit,
+    ):
+        await webui_handlers.webui_connect(
+            "sid-1", {"headers": []}, {"api_key": "mgmt-key"}
+        )
+
+    initial = next(
+        c.args[1] for c in mock_emit.call_args_list if c.args[0] == "initial_status"
+    )
+    assert [j["job_id"] for j in initial[0]["active_jobs"]] == ["job-1"]
+
+
+@pytest.mark.anyio
+async def test_gateway_host_online_notification_includes_active_jobs(
+    training_host, job_definition
+):
+    """HTTP polling must not broadcast an empty list over live job state."""
+    from app.gateway import gateway
+    from app.socketio_app import server
+
+    with (
+        patch("app.gateway.host_db.get_host", AsyncMock(return_value=training_host)),
+        patch.object(
+            job_db, "get_active_by_host", AsyncMock(return_value=[_job(job_definition)])
+        ),
+        patch.object(server.sio, "emit", AsyncMock()) as mock_emit,
+    ):
+        await gateway._notify_host_online(training_host)
+
+    event, payload = mock_emit.await_args.args
+    assert event == "host_status"
+    assert [j["job_id"] for j in payload["active_jobs"]] == ["job-1"]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,11 +5,14 @@ Covers host selection, translation of the SuperNova intent into the Solar Host
 the S-025/S-026 event forwarding handlers.
 """
 
-from unittest.mock import AsyncMock, patch
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.dialects import postgresql
 
-from app.database.jobs import JobDB
+from app.database.jobs import _ACTIVE_JOB_LIMIT, JobDB
 from app.jobs.host_selector import select_host
 from app.jobs.client import JobHostClient, JobHostClientError
 from app.jobs.router import _translate_payload, _resolve_train_input
@@ -509,6 +512,105 @@ async def test_job_db_update_status():
         mock_session.commit.assert_awaited_once()
 
 
+@pytest.mark.anyio
+async def test_job_db_update_step():
+    """Should persist the current pipeline step, including index 0."""
+    db = JobDB()
+
+    with patch.object(db, "_session") as mock_session_ctx:
+        mock_session = AsyncMock()
+        mock_session_ctx.return_value.__aenter__.return_value = mock_session
+        mock_execute_result = AsyncMock()
+        mock_execute_result.rowcount = 1
+        mock_session.execute.return_value = mock_execute_result
+
+        assert await db.update_job_step("job-1", step_name="train", step_index=0)
+
+    values = mock_session.execute.await_args.args[0].compile().params
+    assert values["current_step_name"] == "train"
+    assert values["current_step_index"] == 0
+
+
+async def _capture_active_by_host_stmt(db: JobDB, **kwargs):
+    """Run get_active_by_host against a mocked session, return the SELECT."""
+    with patch.object(db, "_session") as mock_session_ctx:
+        mock_session = AsyncMock()
+        mock_session_ctx.return_value.__aenter__.return_value = mock_session
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = []
+        mock_session.execute.return_value = mock_result
+
+        await db.get_active_by_host("host-1", **kwargs)
+
+    return mock_session.execute.await_args.args[0]
+
+
+@pytest.mark.anyio
+async def test_job_db_active_by_host_is_bounded():
+    """The result feeds every host_status broadcast, so it must have a LIMIT."""
+    stmt = await _capture_active_by_host_stmt(JobDB())
+    compiled = stmt.compile(dialect=postgresql.dialect())
+
+    assert "LIMIT" in str(compiled)
+    assert _ACTIVE_JOB_LIMIT in compiled.params.values()
+
+
+@pytest.mark.anyio
+async def test_job_db_active_by_host_limit_is_overridable():
+    stmt = await _capture_active_by_host_stmt(JobDB(), limit=7)
+    compiled = stmt.compile(dialect=postgresql.dialect())
+
+    assert 7 in compiled.params.values()
+
+
+@pytest.mark.anyio
+async def test_job_db_active_by_host_orders_active_before_terminal():
+    """A long-running job must not be pushed past the limit by newer rows."""
+    stmt = await _capture_active_by_host_stmt(JobDB())
+    order_by = str(stmt.compile(dialect=postgresql.dialect())).split("ORDER BY", 1)[1]
+
+    assert order_by.index("jobs.status IN") < order_by.index("jobs.created_at DESC")
+
+
+@pytest.mark.anyio
+async def test_job_db_active_by_host_retention_cutoff():
+    """Terminal jobs are filtered against a completed_at cutoff."""
+    stmt = await _capture_active_by_host_stmt(JobDB(), terminal_retention_minutes=30)
+    params = stmt.compile(dialect=postgresql.dialect()).params
+
+    cutoff = next(v for v in params.values() if isinstance(v, datetime))
+    delta = datetime.now(timezone.utc) - cutoff
+    assert timedelta(minutes=29) < delta < timedelta(minutes=31)
+
+
+def test_job_db_row_mapping_includes_step_tracking():
+    """The new step columns round-trip through both row mappers."""
+    now = datetime.now(timezone.utc)
+    row = SimpleNamespace(
+        id="job-1",
+        host_id="host-1",
+        status="running",
+        payload={"name": "j"},
+        result=None,
+        error_message=None,
+        correlation_id="corr-1",
+        submission_id="sub-1",
+        current_step_name="train",
+        current_step_index=0,
+        created_at=now,
+        updated_at=now,
+        completed_at=None,
+    )
+
+    job = JobDB()._row_to_job(row)
+    assert job.current_step_name == "train"
+    assert job.current_step_index == 0
+
+    as_dict = JobDB()._job_to_dict(job)
+    assert as_dict["current_step_name"] == "train"
+    assert as_dict["current_step_index"] == 0
+
+
 def test_job_status_from_host():
     """Host status strings map to JobStatus; unknowns return None."""
     assert JobStatus.from_host("running") is JobStatus.RUNNING
@@ -766,6 +868,60 @@ async def test_host_lifecycle_step_event_does_not_change_status(online_training_
     emit_calls = [c for c in mock_emit.call_args_list if c[0][0] == "host_status"]
     assert len(emit_calls) == 1
     assert emit_calls[0][0][1]["host_id"] == "host-1"
+
+
+@pytest.mark.anyio
+async def test_host_lifecycle_step_completed_does_not_rebroadcast_host_status(
+    online_training_host,
+):
+    """step_completed persists nothing, so the host_status payload is unchanged."""
+    from app.socketio_app import host_handlers, webui_handlers
+
+    event = {
+        "job_id": "job-1",
+        "step_name": "train",
+        "step_index": 2,
+        "status": "completed",
+        "duration_s": 12.5,
+        "exit_code": 0,
+    }
+
+    with (
+        patch.object(
+            host_handlers.host_store,
+            "get_host_id_for_sid",
+            AsyncMock(return_value="host-1"),
+        ),
+        patch.object(
+            host_handlers.host_db,
+            "get_host",
+            AsyncMock(return_value=online_training_host),
+        ),
+        patch.object(
+            host_handlers.job_db,
+            "get_job",
+            AsyncMock(return_value=Job(id="job-1", host_id="host-1")),
+        ),
+        patch.object(host_handlers.job_db, "update_job_status", AsyncMock()),
+        patch.object(
+            host_handlers.job_db, "update_job_step", AsyncMock()
+        ) as mock_update_step,
+        patch.object(
+            host_handlers.job_db,
+            "get_active_by_host",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            webui_handlers, "broadcast_job_lifecycle", AsyncMock()
+        ) as mock_broadcast,
+        patch.object(host_handlers.sio, "emit", AsyncMock()) as mock_emit,
+    ):
+        await host_handlers._handle_job_lifecycle("step_completed", "sid-1", event)
+
+    # The lifecycle event itself is still forwarded to WebUI.
+    mock_broadcast.assert_awaited_once()
+    mock_update_step.assert_not_called()
+    assert [c for c in mock_emit.call_args_list if c[0][0] == "host_status"] == []
 
 
 # ── WebUI Filter Tests ───────────────────────────────────────

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -691,7 +691,7 @@ async def test_host_lifecycle_updates_status_and_forwards(online_training_host):
         patch.object(
             webui_handlers, "broadcast_job_lifecycle", AsyncMock()
         ) as mock_broadcast,
-        patch.object(host_handlers.sio, "emit", AsyncMock()),
+        patch.object(host_handlers.sio, "emit", AsyncMock()) as mock_emit,
     ):
         await host_handlers._handle_job_lifecycle("job_completed", "sid-1", event)
 
@@ -706,6 +706,12 @@ async def test_host_lifecycle_updates_status_and_forwards(online_training_host):
     assert payload["correlation_id"] == "corr-1"
     # Non-normalized extras are preserved under `data`.
     assert payload["data"]["workspace_path"] == "/jobs/job-1"
+
+    # A host_status broadcast is emitted so WebUI sees updated active_jobs.
+    emit_calls = [c for c in mock_emit.call_args_list if c[0][0] == "host_status"]
+    assert len(emit_calls) == 1
+    assert emit_calls[0][0][1]["host_id"] == "host-1"
+    assert emit_calls[0][0][1]["active_jobs"] == []
 
 
 @pytest.mark.anyio
@@ -749,12 +755,17 @@ async def test_host_lifecycle_step_event_does_not_change_status(online_training_
             AsyncMock(return_value=[]),
         ),
         patch.object(webui_handlers, "broadcast_job_lifecycle", AsyncMock()),
-        patch.object(host_handlers.sio, "emit", AsyncMock()),
+        patch.object(host_handlers.sio, "emit", AsyncMock()) as mock_emit,
     ):
         await host_handlers._handle_job_lifecycle("step_started", "sid-1", event)
 
     mock_update.assert_not_called()
     mock_update_step.assert_awaited_once_with("job-1", step_name="train", step_index=2)
+
+    # A host_status broadcast is emitted so WebUI sees updated active_jobs.
+    emit_calls = [c for c in mock_emit.call_args_list if c[0][0] == "host_status"]
+    assert len(emit_calls) == 1
+    assert emit_calls[0][0][1]["host_id"] == "host-1"
 
 
 # ── WebUI Filter Tests ───────────────────────────────────────

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -684,8 +684,14 @@ async def test_host_lifecycle_updates_status_and_forwards(online_training_host):
             AsyncMock(return_value=True),
         ) as mock_update,
         patch.object(
+            host_handlers.job_db,
+            "get_active_by_host",
+            AsyncMock(return_value=[]),
+        ),
+        patch.object(
             webui_handlers, "broadcast_job_lifecycle", AsyncMock()
         ) as mock_broadcast,
+        patch.object(host_handlers.sio, "emit", AsyncMock()),
     ):
         await host_handlers._handle_job_lifecycle("job_completed", "sid-1", event)
 
@@ -734,11 +740,21 @@ async def test_host_lifecycle_step_event_does_not_change_status(online_training_
         patch.object(
             host_handlers.job_db, "update_job_status", AsyncMock()
         ) as mock_update,
+        patch.object(
+            host_handlers.job_db, "update_job_step", AsyncMock(return_value=True)
+        ) as mock_update_step,
+        patch.object(
+            host_handlers.job_db,
+            "get_active_by_host",
+            AsyncMock(return_value=[]),
+        ),
         patch.object(webui_handlers, "broadcast_job_lifecycle", AsyncMock()),
+        patch.object(host_handlers.sio, "emit", AsyncMock()),
     ):
         await host_handlers._handle_job_lifecycle("step_started", "sid-1", event)
 
     mock_update.assert_not_called()
+    mock_update_step.assert_awaited_once_with("job-1", step_name="train", step_index=2)
 
 
 # ── WebUI Filter Tests ───────────────────────────────────────

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,12 +5,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.database.jobs import job_db
 from app.models import (
     Host,
     HostStatus,
     HostResourceSnapshot,
     AggregatedResourceResponse,
 )
+from app.models.job import Job, JobStatus
 from app.routes.management.resources import _fetch_host_resource_snapshot
 
 
@@ -38,6 +40,20 @@ def mock_host_offline():
         gpu_type="A10-24GB",
         roles=["inference"],
     )
+
+
+@pytest.fixture(autouse=True)
+def no_active_jobs():
+    """Stub the jobs table for snapshot tests.
+
+    Without this the aggregation hits an uninitialized session factory and
+    silently degrades to an empty list, so these tests would only ever
+    exercise the failure path.
+    """
+    with patch.object(
+        job_db, "get_active_by_host", AsyncMock(return_value=[])
+    ) as mock_get:
+        yield mock_get
 
 
 @pytest.fixture
@@ -123,6 +139,46 @@ async def test_fetch_host_resource_snapshot_success(
         assert snap.reservation_vram_total_gb == 20.0
         assert snap.reservation_ram_total_gb == 64.0
         assert snap.reservation_disk_total_gb == 50.0
+        assert snap.active_jobs == []
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_includes_active_jobs(
+    mock_host_online, live_resource_payload, no_active_jobs
+):
+    """Job workloads are aggregated alongside inference instances (S-033)."""
+    no_active_jobs.return_value = [
+        Job(
+            id="job-1",
+            host_id="host-1",
+            status=JobStatus.RUNNING,
+            payload={
+                "name": "retrain",
+                "steps": [{"name": "train", "gpu": {"count": 2}}],
+            },
+            current_step_name="train",
+            current_step_index=0,
+        )
+    ]
+
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=live_resource_payload)
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+    assert len(snap.active_jobs) == 1
+    job = snap.active_jobs[0]
+    assert job.job_id == "job-1"
+    assert job.name == "retrain"
+    assert job.current_step_name == "train"
+    assert job.resource_hints["peak_gpu_count"] == 2
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Description

Extends Solar Control's host status model and aggregation to surface active job step workloads alongside inference instances. Operators and scheduling logic can now see what training pipelines each host is running in a single aggregated view.

- Adds `ActiveJobSummary` model with job ID, current pipeline step, status, resource hints, start/completion timestamps, and terminal error state.
- Extends `HostStatusPayload` (Socket.IO → WebUI) and `HostResourceSnapshot` (REST API → SuperNova scheduler) with an `active_jobs` field.
- Tracks the currently executing pipeline step (`current_step_name`/`current_step_index`) on the `Job` model, persisted via lifecycle events.
- Broadcasts updated `host_status` to WebUI clients whenever a job lifecycle event occurs (started, step advanced, completed, failed, cancelled).
- Includes Alembic migration `0005` for the new database columns.
- Backward compatible — `active_jobs` defaults to an empty list for existing consumers.

## Changes

- `app/models/job.py` — Added `current_step_name` and `current_step_index` fields to the `Job` model.
- `app/models/host.py` — Added `ActiveJobSummary` Pydantic model; added `active_jobs` field to `HostResourceSnapshot`.
- `app/models/socketio.py` — Added `active_jobs` field to `HostStatusPayload`; updated `from_host` factory to accept the new data.
- `app/models/__init__.py` — Exported `ActiveJobSummary`.
- `app/database/tables.py` — Added `current_step_name` (Text) and `current_step_index` (Integer) columns to `JobRow`.
- `app/database/jobs.py` — Added `update_job_step` and `get_active_by_host` methods; updated `_row_to_job`/`_job_to_dict` mappings.
- `app/database/migrations/versions/0005_add_job_step_tracking.py` — New Alembic migration for the schema change.
- `app/socketio_app/host_handlers.py` — Added `_job_to_active_summary` and `_get_host_active_jobs` helpers; updated `_emit_host_status` to include active jobs; extended `_handle_job_lifecycle` to persist step info and broadcast host status on lifecycle events.
- `app/routes/management/resources.py` — Added `_job_to_active_summary` helper; integrated active jobs aggregation into `_fetch_host_resource_snapshot`.
- `tests/test_jobs.py` — Updated lifecycle event tests with mocks for the new `update_job_step`, `get_active_by_host`, and `sio.emit` calls.

## Related Issues

Closes #35