### PR TITLE
feat(api): add model catalog endpoint with Data Repository proxy and Solar enrichment (D-018)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Install Ruff
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          # Pinned: ruff 0.16 changed the default rule set and flags the
+          # codebase's existing style (170 errors). See PR #60.
+          pip install ruff==0.15.14
 
       - name: Lint with Ruff
         run: ruff check app

--- a/app/main.py
+++ b/app/main.py
@@ -173,6 +173,7 @@ async def root():
                 "/api/resources/reservations",
                 "/api/intents",
                 "/api/intents/{id}",
+                "/api/catalog/models",
             ],
             "realtime": [
                 "Socket.IO /hosts (host connections)",

--- a/app/routes/management/__init__.py
+++ b/app/routes/management/__init__.py
@@ -9,6 +9,7 @@ from . import (
     instances,
     reservations,
     intents,
+    catalog,
 )
 
 router = APIRouter(prefix="/api", tags=["management"])
@@ -21,3 +22,4 @@ router.include_router(resources.router)
 router.include_router(instances.router)
 router.include_router(reservations.router)
 router.include_router(intents.router)
+router.include_router(catalog.router)

--- a/app/routes/management/catalog.py
+++ b/app/routes/management/catalog.py
@@ -1,0 +1,379 @@
+"""Model catalog API routes (under /api/catalog) — D-018.
+
+``GET /api/catalog/models`` proxies Data Repository's D-013 model list
+(``GET /api/models``) and enriches each model with Solar runtime context:
+
+* **deployed hosts** — hosts where the model files are present, using the
+  same per-host ``GET /models`` mechanism as S-020
+  (``GET /api/models/availability``). Entries are joined on the
+  authoritative ``model_name`` recorded in the host manifest since D-016,
+  falling back to the manifest ``name`` for legacy entries.
+* **running instances** — instances currently serving the model, joined
+  through their ``model_source`` (e.g. ``repo://name:version`` or
+  ``huggingface://org/model``) against the host instance cache.
+
+Data Repository remains the authority for catalog metadata and versions;
+Solar Control only adds runtime context. Enrichment is best-effort: a
+failed host poll never fails the whole request — it degrades
+``meta.enrichment`` and the per-model ``solar.status`` derivation so the
+WebUI never sees a misleading "unavailable" when the availability source
+itself is down.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Literal
+
+import aiohttp
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.config import settings
+from app.database.hosts import host_db
+from app.model_resolvers.parser import HuggingFaceURI, RepoURI, parse
+from app.models import Host
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/catalog", tags=["catalog"])
+
+
+# ── Response models ───────────────────────────────────────────
+
+
+class DeployedHostInfo(BaseModel):
+    """A host where the model's files are present (S-020 availability)."""
+
+    host_id: str
+    host_name: str
+    size_bytes: int = 0
+    path: str = ""
+
+
+class RunningInstanceInfo(BaseModel):
+    """A running instance of the model (host instance state)."""
+
+    host_id: str
+    host_name: str
+    instance_id: str
+
+
+class SolarRuntimeInfo(BaseModel):
+    """Solar runtime context added by Solar Control (D-018).
+
+    ``status`` is derived per model:
+    * ``available`` — at least one running instance exists.
+    * ``deployed`` — on at least one host, but no instance running.
+    * ``unavailable`` — not on any host and no instance running.
+    * ``unknown`` — no deployment evidence and the availability source
+      itself could not be reached, so absence cannot be proven.
+    """
+
+    status: Literal["available", "deployed", "unavailable", "unknown"]
+    running_instances: int
+    deployed_hosts: list[DeployedHostInfo] = Field(default_factory=list)
+    instances: list[RunningInstanceInfo] = Field(default_factory=list)
+
+
+class CatalogModelItem(BaseModel):
+    """One catalog entry: Data Repository metadata + Solar runtime context."""
+
+    name: str
+    category: str
+    description: str | None = None
+    versions_count: int
+    latest_version: str | None = None
+    created_at: datetime
+    solar: SolarRuntimeInfo
+
+
+class CatalogMeta(BaseModel):
+    """Health of the Solar-side enrichment sources for this response.
+
+    ``ok`` — every host answered; ``partial`` — some hosts failed;
+    ``unavailable`` — no host answered (enrichment is degraded, per-model
+    statuses fall back to ``unknown`` unless instance evidence exists).
+    """
+
+    enrichment: Literal["ok", "partial", "unavailable"]
+
+
+class CatalogResponse(BaseModel):
+    total: int
+    items: list[CatalogModelItem]
+    meta: CatalogMeta
+
+
+# ── Data Repository proxy (D-013) ─────────────────────────────
+
+
+async def _list_data_repository_models(
+    search: str | None, limit: int, offset: int
+) -> dict[str, Any]:
+    """Call Data Repository ``GET /api/models`` and return its body.
+
+    Error mapping (mirrors ``app.model_resolvers.repo``):
+      * 500 if ``DATA_REPOSITORY_URL`` is unset
+      * 404/422 propagated verbatim from Data Repository
+      * 502 for all other upstream errors and transport failures
+    """
+    if not settings.data_repository_url:
+        raise HTTPException(
+            status_code=500,
+            detail="DATA_REPOSITORY_URL is not configured",
+        )
+
+    url = f"{settings.data_repository_url.rstrip('/')}/api/models"
+    headers = {"Content-Type": "application/json"}
+    if settings.data_repository_api_key:
+        headers["X-API-Key"] = settings.data_repository_api_key
+
+    params: dict[str, Any] = {"limit": limit, "offset": offset}
+    if search:
+        params["search"] = search
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                params=params,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=settings.data_repository_timeout_s),
+            ) as response:
+                if response.status == 200:
+                    return await response.json()
+
+                try:
+                    err = await response.json()
+                    detail = err.get("detail") or err.get("error")
+                except Exception:
+                    detail = await response.text()
+
+                if response.status in {404, 422}:
+                    raise HTTPException(
+                        status_code=response.status,
+                        detail=detail or "Data Repository model list failed",
+                    )
+
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        "Data Repository model list failed "
+                        f"[{response.status}]: {detail}"
+                    ),
+                )
+    except HTTPException:
+        raise
+    except (
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientConnectorError,
+        asyncio.TimeoutError,
+    ) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Data Repository is unreachable: {exc}",
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Unexpected error during Data Repository model list: {exc}",
+        )
+
+
+# ── Solar enrichment ──────────────────────────────────────────
+
+
+async def _fetch_models_from_host(host: Host) -> tuple[list[dict], bool]:
+    """Fetch ``GET {host.url}/models`` like S-020, reporting reachability.
+
+    Returns ``(models, ok)``; ``ok`` is False when the host did not
+    answer with 200 (unreachable, timeout, or error status).
+    """
+    url = f"{host.url.rstrip('/')}/models"
+    headers = {"X-API-Key": host.api_key}
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=5)
+            ) as resp:
+                if resp.status == 200:
+                    return await resp.json(), True
+                logger.warning(
+                    "Host %s (%s) returned %d for GET /models",
+                    host.id,
+                    host.url,
+                    resp.status,
+                )
+    except Exception as e:
+        logger.warning("Failed to fetch models from host %s: %s", host.id, e)
+    return [], False
+
+
+async def _collect_availability() -> (
+    tuple[dict[str, list[DeployedHostInfo]], Literal["ok", "partial", "unavailable"]]
+):
+    """Aggregate host-level model availability (same mechanism as S-020).
+
+    Returns ``(model_name -> [DeployedHostInfo], enrichment_status)``.
+    Host entries are keyed by the authoritative ``model_name`` recorded
+    at pull time (D-016), falling back to the manifest ``name`` for
+    legacy entries.
+    """
+    hosts = await host_db.get_all_hosts()
+    results = await asyncio.gather(*[_fetch_models_from_host(h) for h in hosts])
+
+    by_name: dict[str, list[DeployedHostInfo]] = {}
+    failed = 0
+    for host, (models, ok) in zip(hosts, results):
+        if not ok:
+            failed += 1
+            continue
+        for m in models:
+            key = m.get("model_name") or m.get("name")
+            if not key:
+                continue
+            by_name.setdefault(key, []).append(
+                DeployedHostInfo(
+                    host_id=host.id,
+                    host_name=host.name,
+                    size_bytes=m.get("size_bytes", 0),
+                    path=m.get("path", ""),
+                )
+            )
+
+    status: Literal["ok", "partial", "unavailable"]
+    if failed == 0:
+        status = "ok"
+    elif failed == len(hosts) and hosts:
+        status = "unavailable"
+    else:
+        status = "partial"
+    return by_name, status
+
+
+def _model_name_from_source(source_uri: str | None) -> str | None:
+    """Extract the Data Repository model name from a model source URI.
+
+    ``repo://name:version/...`` -> ``name``; ``huggingface://org/model``
+    -> ``org/model``; anything unparsable -> None.
+    """
+    if not source_uri:
+        return None
+    try:
+        parsed = parse(source_uri)
+    except HTTPException:
+        return None
+    if isinstance(parsed, RepoURI):
+        return parsed.name
+    if isinstance(parsed, HuggingFaceURI):
+        return parsed.model_id
+    return None
+
+
+async def _collect_running_instances() -> dict[str, list[RunningInstanceInfo]]:
+    """Aggregate running instances from each host's cached instance state.
+
+    Instances are joined to catalog models through their ``model_source``.
+    The cache is best-effort: hosts that never connected contribute
+    nothing, and a missing cache is indistinguishable from "no instances".
+    """
+    from app.socketio_app.host_handlers import get_host_instances
+
+    hosts = await host_db.get_all_hosts()
+    by_name: dict[str, list[RunningInstanceInfo]] = {}
+    for host in hosts:
+        instances = await get_host_instances(host.id)
+        for inst in instances:
+            if inst.get("status") != "running":
+                continue
+            config = inst.get("config") or {}
+            source = config.get("model_source") or inst.get("model_source")
+            name = _model_name_from_source(source)
+            if not name:
+                continue
+            by_name.setdefault(name, []).append(
+                RunningInstanceInfo(
+                    host_id=host.id,
+                    host_name=host.name,
+                    instance_id=str(inst.get("id", "")),
+                )
+            )
+    return by_name
+
+
+def _derive_status(
+    running: list[RunningInstanceInfo],
+    deployed: list[DeployedHostInfo],
+    availability_ok: bool,
+) -> Literal["available", "deployed", "unavailable", "unknown"]:
+    """Derive the WebUI-facing deployment status for a catalog model.
+
+    Evidence-based, never misleading: running instances prove
+    availability and deployed hosts prove deployment. When the
+    availability source itself is down and no instance evidence exists,
+    the status is ``unknown`` instead of a false ``unavailable``.
+    """
+    if running:
+        return "available"
+    if deployed:
+        return "deployed"
+    return "unavailable" if availability_ok else "unknown"
+
+
+# ── Route ─────────────────────────────────────────────────────
+
+
+@router.get("/models", response_model=CatalogResponse)
+async def get_catalog_models(
+    search: str | None = Query(
+        None, description="Search string forwarded to Data Repository"
+    ),
+    limit: int = Query(50, ge=1, le=1000, description="Results per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+) -> CatalogResponse:
+    """List Data Repository models enriched with Solar deployment context.
+
+    Pagination and ``search`` are forwarded verbatim to Data Repository
+    (D-013); the response keeps its ``total``/``items`` shape. Each item
+    carries a ``solar`` block with the derived deployment status, running
+    instance count, deployed hosts, and running instances.
+    """
+    repo_listing = await _list_data_repository_models(search, limit, offset)
+    raw_items = repo_listing.get("items", [])
+    total = repo_listing.get("total", len(raw_items))
+
+    # Enrichment is best-effort; failures degrade metadata, never the response.
+    availability, enrichment_status = await _collect_availability()
+    running = await _collect_running_instances()
+    availability_ok = enrichment_status == "ok"
+
+    items: list[CatalogModelItem] = []
+    for raw in raw_items:
+        name = raw.get("name")
+        if not name:
+            continue
+        deployed = availability.get(name, [])
+        instances = running.get(name, [])
+        items.append(
+            CatalogModelItem(
+                name=name,
+                category=raw.get("category", "model"),
+                description=raw.get("description"),
+                versions_count=raw.get("versions_count", 0),
+                latest_version=raw.get("latest_version"),
+                created_at=raw.get("created_at"),
+                solar=SolarRuntimeInfo(
+                    status=_derive_status(instances, deployed, availability_ok),
+                    running_instances=len(instances),
+                    deployed_hosts=deployed,
+                    instances=instances,
+                ),
+            )
+        )
+
+    return CatalogResponse(
+        total=total,
+        items=items,
+        meta=CatalogMeta(enrichment=enrichment_status),
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,9 @@ services:
       - PORT=${PORT:-8000}
       - DATABASE_URL=postgresql://solar:solar@postgres:5432/solar_gateway
       - REDIS_URL=redis://redis:6379/0
+      - DATA_REPOSITORY_URL=${DATA_REPOSITORY_URL:-}
+      - DATA_REPOSITORY_API_KEY=${DATA_REPOSITORY_API_KEY:-}
+      - DATA_REPOSITORY_TIMEOUT_S=${DATA_REPOSITORY_TIMEOUT_S:-10}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 # CI-only tools (lint/format/test). App runtime deps: requirements.txt
 -r requirements.txt
 pytest>=8.0
-ruff>=0.8.0
+ruff==0.15.14
 black>=24.0

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,497 @@
+"""Tests for the D-018 model catalog endpoint (GET /api/catalog/models)."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+from fastapi import HTTPException
+
+from app.models import Host, HostStatus
+from app.routes.management.catalog import (
+    _collect_availability,
+    _collect_running_instances,
+    _derive_status,
+    _model_name_from_source,
+    get_catalog_models,
+)
+
+REPO_MODELS = [
+    {
+        "name": "llama-3.1-8b",
+        "category": "model",
+        "description": "Meta Llama 3.1 8B",
+        "versions_count": 2,
+        "latest_version": "v2",
+        "created_at": "2026-01-01T00:00:00Z",
+    },
+    {
+        "name": "qwen-7b",
+        "category": "model",
+        "description": "Qwen 7B",
+        "versions_count": 1,
+        "latest_version": "v1",
+        "created_at": "2026-02-01T00:00:00Z",
+    },
+    {
+        "name": "mistral-7b",
+        "category": "model",
+        "description": "Mistral 7B",
+        "versions_count": 3,
+        "latest_version": "v3",
+        "created_at": "2026-03-01T00:00:00Z",
+    },
+]
+
+
+def _cm_response(status: int, payload):
+    """AsyncMock context manager whose __aenter__ yields an HTTP response."""
+    resp = AsyncMock()
+    resp.status = status
+    resp.json.return_value = payload
+    cm = AsyncMock()
+    cm.__aenter__.return_value = resp
+    return cm
+
+
+@pytest.fixture
+def catalog_settings():
+    with patch("app.routes.management.catalog.settings") as mock_settings:
+        mock_settings.data_repository_url = "http://data-repo:8000"
+        mock_settings.data_repository_api_key = ""
+        mock_settings.data_repository_timeout_s = 10.0
+        yield mock_settings
+
+
+@pytest.fixture
+def mock_host():
+    return Host(
+        id="host-1",
+        name="Test Host",
+        url="http://test-host:8000",
+        api_key="test-key",
+        status=HostStatus.ONLINE,
+    )
+
+
+@pytest.fixture
+def mock_host_2():
+    return Host(
+        id="host-2",
+        name="Test Host 2",
+        url="http://test-host-2:8000",
+        api_key="test-key-2",
+        status=HostStatus.ONLINE,
+    )
+
+
+# ── Proxy behaviour (D-013 passthrough) ───────────────────────
+
+
+@pytest.mark.anyio
+async def test_catalog_proxies_pagination_and_search(catalog_settings):
+    listing = {"total": 2, "items": REPO_MODELS[:2]}
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=[]),
+    ):
+        mock_get.return_value = _cm_response(200, listing)
+
+        resp = await get_catalog_models(search="llama", limit=10, offset=20)
+
+    call = mock_get.call_args
+    assert call.args[0] == "http://data-repo:8000/api/models"
+    assert call.kwargs["params"] == {"limit": 10, "offset": 20, "search": "llama"}
+
+    assert resp.total == 2
+    assert len(resp.items) == 2
+    assert resp.items[0].name == "llama-3.1-8b"
+    assert resp.items[0].versions_count == 2
+    assert resp.items[0].latest_version == "v2"
+    assert resp.items[0].description == "Meta Llama 3.1 8B"
+    assert resp.items[1].name == "qwen-7b"
+    # No hosts configured -> every model is truly unavailable, enrichment ok.
+    assert resp.items[0].solar.status == "unavailable"
+    assert resp.items[0].solar.running_instances == 0
+    assert resp.items[0].solar.deployed_hosts == []
+    assert resp.meta.enrichment == "ok"
+
+
+@pytest.mark.anyio
+async def test_catalog_proxies_default_pagination(catalog_settings):
+    listing = {"total": 0, "items": []}
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=[]),
+    ):
+        mock_get.return_value = _cm_response(200, listing)
+
+        resp = await get_catalog_models(search=None, limit=50, offset=0)
+
+    call = mock_get.call_args
+    assert call.kwargs["params"] == {"limit": 50, "offset": 0}
+    assert "search" not in call.kwargs["params"]
+    assert resp.total == 0
+    assert resp.items == []
+
+
+@pytest.mark.anyio
+async def test_catalog_forwards_data_repository_api_key(catalog_settings):
+    catalog_settings.data_repository_api_key = "repo-key"
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=[]),
+    ):
+        mock_get.return_value = _cm_response(200, {"total": 0, "items": []})
+        await get_catalog_models()
+
+    assert mock_get.call_args.kwargs["headers"]["X-API-Key"] == "repo-key"
+
+
+# ── Enrichment ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_catalog_enriches_with_deployment_and_running_instances(
+    catalog_settings, mock_host, mock_host_2
+):
+    """Repo models joined to host availability (model_name) and instances."""
+    hosts = [mock_host, mock_host_2]
+    listing = {"total": 3, "items": REPO_MODELS}
+    host1_models = [
+        {
+            "name": "repo--llama-3.1-8b--v2",
+            "model_name": "llama-3.1-8b",
+            "size_bytes": 1000,
+            "path": "/models/repo--llama-3.1-8b--v2",
+        },
+        {
+            "name": "repo--qwen-7b--v1",
+            "model_name": "qwen-7b",
+            "size_bytes": 2000,
+            "path": "/models/repo--qwen-7b--v1",
+        },
+    ]
+    host2_models = [
+        {
+            "name": "repo--llama-3.1-8b--v2",
+            "model_name": "llama-3.1-8b",
+            "size_bytes": 1000,
+            "path": "/models/repo--llama-3.1-8b--v2",
+        }
+    ]
+    instances = [
+        {"id": "i1", "status": "running", "model_source": "repo://llama-3.1-8b:v2"},
+        {"id": "i2", "status": "stopped", "model_source": "repo://qwen-7b:v1"},
+    ]
+
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch(
+            "app.socketio_app.host_handlers.get_host_instances",
+            side_effect=[instances, []],
+        ),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, listing),
+            _cm_response(200, host1_models),
+            _cm_response(200, host2_models),
+        ]
+
+        resp = await get_catalog_models()
+
+    by_name = {item.name: item for item in resp.items}
+
+    # llama: deployed on both hosts, one running instance
+    llama = by_name["llama-3.1-8b"]
+    assert llama.solar.status == "available"
+    assert llama.solar.running_instances == 1
+    assert len(llama.solar.deployed_hosts) == 2
+    assert {h.host_id for h in llama.solar.deployed_hosts} == {"host-1", "host-2"}
+    assert llama.solar.deployed_hosts[0].host_name == "Test Host"
+    assert llama.solar.instances[0].instance_id == "i1"
+    assert llama.solar.instances[0].host_id == "host-1"
+
+    # qwen: deployed on host-1 only, nothing running
+    qwen = by_name["qwen-7b"]
+    assert qwen.solar.status == "deployed"
+    assert qwen.solar.running_instances == 0
+    assert len(qwen.solar.deployed_hosts) == 1
+    assert qwen.solar.deployed_hosts[0].host_id == "host-1"
+
+    # mistral: nowhere
+    mistral = by_name["mistral-7b"]
+    assert mistral.solar.status == "unavailable"
+    assert mistral.solar.running_instances == 0
+    assert mistral.solar.deployed_hosts == []
+    assert mistral.solar.instances == []
+
+    assert resp.meta.enrichment == "ok"
+
+
+@pytest.mark.anyio
+async def test_catalog_joins_legacy_host_entries_by_name(catalog_settings, mock_host):
+    """Pre-D-016 host entries (no model_name) join on the manifest name."""
+    listing = {"total": 1, "items": [REPO_MODELS[0]]}
+    host_models = [
+        {
+            "name": "llama-3.1-8b",
+            "size_bytes": 1000,
+            "path": "/models/llama-3.1-8b",
+        }
+    ]
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=[mock_host]),
+        patch("app.socketio_app.host_handlers.get_host_instances", return_value=[]),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, listing),
+            _cm_response(200, host_models),
+        ]
+
+        resp = await get_catalog_models()
+
+    assert len(resp.items) == 1
+    assert resp.items[0].solar.status == "deployed"
+    assert resp.items[0].solar.deployed_hosts[0].host_id == "host-1"
+
+
+@pytest.mark.anyio
+async def test_catalog_counts_running_instances_from_source_variants(
+    catalog_settings, mock_host, mock_host_2
+):
+    """Instances joined via config-nested and top-level model_source."""
+    hosts = [mock_host, mock_host_2]
+    qwen_repo = {
+        "name": "org/qwen-7b",
+        "category": "model",
+        "description": "Qwen 7B",
+        "versions_count": 1,
+        "latest_version": "v1",
+        "created_at": "2026-02-01T00:00:00Z",
+    }
+    listing = {"total": 2, "items": [REPO_MODELS[0], qwen_repo]}
+    host1_instances = [
+        # config-nested model_source (raw solar-host REST shape)
+        {
+            "id": "i1",
+            "status": "running",
+            "config": {"model_source": "repo://llama-3.1-8b:v2"},
+        },
+        # non-running instances are not counted
+        {"id": "i2", "status": "stopped", "model_source": "repo://llama-3.1-8b:v2"},
+        # top-level model_source, huggingface scheme
+        {"id": "i3", "status": "running", "model_source": "huggingface://org/qwen-7b"},
+        # unparsable source is ignored
+        {"id": "i4", "status": "running", "model_source": "local:///tmp/x"},
+    ]
+    host2_instances = [
+        {"id": "i5", "status": "running", "model_source": "repo://llama-3.1-8b:v1"}
+    ]
+
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("app.database.hosts.host_db.get_all_hosts", return_value=hosts),
+        patch(
+            "app.socketio_app.host_handlers.get_host_instances",
+            side_effect=[host1_instances, host2_instances],
+        ),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, listing),
+            _cm_response(200, []),
+            _cm_response(200, []),
+        ]
+
+        resp = await get_catalog_models()
+
+    by_name = {item.name: item for item in resp.items}
+    llama = by_name["llama-3.1-8b"]
+    assert llama.solar.status == "available"
+    assert llama.solar.running_instances == 2
+    assert {i.instance_id for i in llama.solar.instances} == {"i1", "i5"}
+
+    qwen = by_name["org/qwen-7b"]
+    assert qwen.solar.status == "available"
+    assert qwen.solar.running_instances == 1
+    assert qwen.solar.instances[0].instance_id == "i3"
+
+
+# ── Data Repository failures ──────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_catalog_data_repository_unreachable(catalog_settings):
+    with patch(
+        "aiohttp.ClientSession.get",
+        side_effect=aiohttp.ClientConnectionError("Refused"),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await get_catalog_models()
+    assert exc.value.status_code == 502
+    assert "unreachable" in str(exc.value.detail)
+
+
+@pytest.mark.anyio
+async def test_catalog_data_repository_not_configured(catalog_settings):
+    catalog_settings.data_repository_url = ""
+    with pytest.raises(HTTPException) as exc:
+        await get_catalog_models()
+    assert exc.value.status_code == 500
+    assert "DATA_REPOSITORY_URL" in str(exc.value.detail)
+
+
+@pytest.mark.anyio
+async def test_catalog_data_repository_upstream_error(catalog_settings):
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_get.return_value = _cm_response(500, {"detail": "boom"})
+        with pytest.raises(HTTPException) as exc:
+            await get_catalog_models()
+    assert exc.value.status_code == 502
+    assert "boom" in str(exc.value.detail)
+
+
+# ── Missing/unavailable S-020 enrichment ──────────────────────
+
+
+@pytest.mark.anyio
+async def test_catalog_availability_source_down_marks_unknown(
+    catalog_settings, mock_host, mock_host_2
+):
+    """All hosts unreachable -> no false 'unavailable'; statuses stay unknown."""
+    listing = {"total": 1, "items": [REPO_MODELS[0]]}
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch(
+            "app.database.hosts.host_db.get_all_hosts",
+            return_value=[mock_host, mock_host_2],
+        ),
+        patch("app.socketio_app.host_handlers.get_host_instances", return_value=[]),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, listing),
+            aiohttp.ClientConnectionError("down"),
+            aiohttp.ClientConnectionError("down"),
+        ]
+
+        resp = await get_catalog_models()
+
+    assert resp.meta.enrichment == "unavailable"
+    item = resp.items[0]
+    assert item.solar.status == "unknown"
+    assert item.solar.deployed_hosts == []
+    assert item.solar.running_instances == 0
+
+
+@pytest.mark.anyio
+async def test_catalog_availability_partial_failure(
+    catalog_settings, mock_host, mock_host_2
+):
+    """Some hosts down -> partial meta; seen evidence still reported."""
+    listing = {"total": 2, "items": REPO_MODELS[:2]}
+    host2_models = [
+        {
+            "name": "repo--llama-3.1-8b--v2",
+            "model_name": "llama-3.1-8b",
+            "size_bytes": 1000,
+            "path": "/models/repo--llama-3.1-8b--v2",
+        }
+    ]
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch(
+            "app.database.hosts.host_db.get_all_hosts",
+            return_value=[mock_host, mock_host_2],
+        ),
+        patch("app.socketio_app.host_handlers.get_host_instances", return_value=[]),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, listing),
+            aiohttp.ClientConnectionError("down"),
+            _cm_response(200, host2_models),
+        ]
+
+        resp = await get_catalog_models()
+
+    assert resp.meta.enrichment == "partial"
+    by_name = {item.name: item for item in resp.items}
+    # Deployment evidence on the surviving host is still reported.
+    assert by_name["llama-3.1-8b"].solar.status == "deployed"
+    assert len(by_name["llama-3.1-8b"].solar.deployed_hosts) == 1
+    # No evidence + partial source -> unknown, not unavailable.
+    assert by_name["qwen-7b"].solar.status == "unknown"
+
+
+# ── Unit-level helpers ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_collect_availability_reports_failures(
+    catalog_settings, mock_host, mock_host_2
+):
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch(
+            "app.database.hosts.host_db.get_all_hosts",
+            return_value=[mock_host, mock_host_2],
+        ),
+    ):
+        mock_get.side_effect = [
+            _cm_response(200, []),
+            aiohttp.ClientConnectionError("down"),
+        ]
+        by_name, status = await _collect_availability()
+    assert by_name == {}
+    assert status == "partial"
+
+
+@pytest.mark.anyio
+async def test_collect_running_instances_skips_non_running(mock_host, mock_host_2):
+    with (
+        patch(
+            "app.database.hosts.host_db.get_all_hosts",
+            return_value=[mock_host, mock_host_2],
+        ),
+        patch(
+            "app.socketio_app.host_handlers.get_host_instances",
+            side_effect=[
+                [{"id": "i1", "status": "running", "model_source": "repo://a:v1"}],
+                [{"id": "i2", "status": "stopped", "model_source": "repo://a:v1"}],
+            ],
+        ),
+    ):
+        by_name = await _collect_running_instances()
+    assert len(by_name["a"]) == 1
+    assert by_name["a"][0].instance_id == "i1"
+
+
+def test_model_name_from_source():
+    assert (
+        _model_name_from_source("repo://llama-3.1-8b:v2/model.gguf") == "llama-3.1-8b"
+    )
+    assert _model_name_from_source("huggingface://org/qwen-7b") == "org/qwen-7b"
+    assert _model_name_from_source("local:///tmp/x") is None
+    assert _model_name_from_source("not-a-uri") is None
+    assert _model_name_from_source(None) is None
+    assert _model_name_from_source("") is None
+
+
+def test_derive_status_evidence_based():
+    from app.routes.management.catalog import DeployedHostInfo, RunningInstanceInfo
+
+    running = [RunningInstanceInfo(host_id="h", host_name="H", instance_id="i")]
+    deployed = [DeployedHostInfo(host_id="h", host_name="H")]
+
+    assert (
+        _derive_status(running=[], deployed=[], availability_ok=True) == "unavailable"
+    )
+    assert _derive_status(running=[], deployed=[], availability_ok=False) == "unknown"
+    assert (
+        _derive_status(running=[], deployed=deployed, availability_ok=False)
+        == "deployed"
+    )
+    assert (
+        _derive_status(running=running, deployed=[], availability_ok=False)
+        == "available"
+    )

--- a/tests_integration/repo_path/test_catalog.py
+++ b/tests_integration/repo_path/test_catalog.py
@@ -1,0 +1,177 @@
+"""repo_path: D-018 model catalog (marker: repo_path).
+
+Proves ``GET /api/catalog/models`` through the live stack (data-repo +
+control + host-a + host-b):
+
+* the D-013 listing is proxied faithfully — totals match data-repo's own
+  ``GET /api/models``, pagination (``limit``) and ``search`` are
+  forwarded, and Data Repository remains the metadata authority;
+* Solar enrichment reflects real deployment state — after a distribute
+  the model appears in ``solar.deployed_hosts`` (joined on the host
+  manifest's authoritative ``model_name``), and a running instance
+  drives ``solar.status == "available"`` with ``running_instances``
+  counted from the WS-pushed instance cache.
+
+Unit-level failure modes (Data Repository unreachable, S-020 source down)
+are covered in ``tests/test_catalog.py`` — killing hosts here would
+disturb the session-scoped stack for every later module.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fixtures.constants import MODEL_ALIAS, MODEL_NAME, MODEL_SOURCE_URI
+from fixtures.helpers import wait_for
+
+pytestmark = pytest.mark.repo_path
+
+
+async def _host_a(http_control):
+    hosts = (await http_control.get("/api/hosts")).json()
+    return next(h for h in hosts if h["name"] == "host-a")
+
+
+def _instance_payload(alias: str = MODEL_ALIAS) -> dict:
+    """Imperative instance payload (same shape as repo_path/test_inference)."""
+    return {
+        "config": {
+            "backend_type": "huggingface_classification",
+            "alias": alias,
+            "model_source": MODEL_SOURCE_URI,
+            "device": "cpu",
+            "dtype": "float32",
+            "max_length": 128,
+            "labels": [f"LABEL_{i}" for i in range(5)],
+        },
+        "priority": "staging",
+    }
+
+
+async def _catalog_item(http_control, name: str) -> dict | None:
+    """Return one catalog item by name (None when missing/unreachable)."""
+    resp = await http_control.get("/api/catalog/models")
+    if resp.status_code != 200:
+        return None
+    for item in resp.json()["items"]:
+        if item["name"] == name:
+            return item
+    return None
+
+
+async def _running_instances_for(http_control, name: str) -> bool:
+    """True once the catalog reports >=1 running instance for the model."""
+    item = await _catalog_item(http_control, name)
+    if item is None:
+        return False
+    return item["solar"]["running_instances"] >= 1
+
+
+async def test_catalog_proxies_data_repository_listing(
+    http_control, http_data_repo, stack, clean_state
+):
+    """D-013 passthrough: totals match, metadata round-trips, enrichment ok."""
+    repo_resp = await http_data_repo.get("/api/models")
+    assert repo_resp.status_code == 200, repo_resp.text
+    repo_total = repo_resp.json()["total"]
+
+    resp = await http_control.get("/api/catalog/models")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == repo_total
+    assert len(body["items"]) == repo_total
+
+    item = next((i for i in body["items"] if i["name"] == MODEL_NAME), None)
+    assert item is not None, f"fixture model missing from catalog: {body}"
+    assert item["category"] == "model"
+    assert item["versions_count"] >= 1
+    assert item["latest_version"] == "v1"
+
+    # Clean state: hosts hold no models and no instances -> the model is
+    # honestly unavailable and the availability source answered (ok).
+    assert item["solar"]["status"] == "unavailable"
+    assert item["solar"]["running_instances"] == 0
+    assert item["solar"]["deployed_hosts"] == []
+    assert item["solar"]["instances"] == []
+    assert body["meta"]["enrichment"] == "ok"
+
+
+async def test_catalog_pagination_and_search_passthrough(
+    http_control, http_data_repo, stack, clean_state
+):
+    """limit/offset and search are forwarded to data-repo, not re-implemented."""
+    repo_resp = await http_data_repo.get("/api/models")
+    assert repo_resp.status_code == 200, repo_resp.text
+    repo_total = repo_resp.json()["total"]
+
+    resp = await http_control.get("/api/catalog/models", params={"limit": 1})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == repo_total
+    assert len(body["items"]) == 1
+
+    resp = await http_control.get("/api/catalog/models", params={"search": MODEL_NAME})
+    assert resp.status_code == 200, resp.text
+    names = [i["name"] for i in resp.json()["items"]]
+    assert (
+        MODEL_NAME in names
+    ), f"search={MODEL_NAME!r} missed the fixture model: {names}"
+
+
+async def test_catalog_reports_deployed_hosts_after_distribute(
+    http_control, stack, clean_state
+):
+    """A distributed model appears in deployed_hosts with status deployed."""
+    host = await _host_a(http_control)
+    resp = await http_control.post(
+        "/api/models/distribute",
+        json={"target_host_id": host["id"], "source_uri": MODEL_SOURCE_URI},
+    )
+    assert resp.status_code == 200, resp.text
+    assert len(resp.json()) == 1
+
+    item = await _catalog_item(http_control, MODEL_NAME)
+    assert item is not None, "catalog missing the just-distributed model"
+    assert item["solar"]["status"] == "deployed"
+    assert item["solar"]["running_instances"] == 0
+
+    deployed = item["solar"]["deployed_hosts"]
+    assert len(deployed) == 1, f"expected host-a only: {deployed}"
+    assert deployed[0]["host_id"] == host["id"]
+    assert deployed[0]["host_name"] == "host-a"
+    # Join went through the manifest's authoritative model_name: the slug
+    # dir path proves it is the repo pull, not a name-collision.
+    assert deployed[0]["path"].endswith(f"repo--{MODEL_NAME}--v1"), deployed[0]["path"]
+
+
+async def test_catalog_reports_running_instance(http_control, stack, clean_state):
+    """A running instance drives status=available + running_instances=1."""
+    host = await _host_a(http_control)
+    resp = await http_control.post(
+        f"/api/hosts/{host['id']}/instances", json=_instance_payload()
+    )
+    assert resp.status_code == 200, resp.text
+    instance_id = resp.json()["instance"]["id"]
+    resp = await http_control.post(
+        f"/api/hosts/{host['id']}/instances/{instance_id}/start"
+    )
+    assert resp.status_code == 200, resp.text
+
+    # The catalog counts instances from the WS-pushed host cache; the host
+    # flips to running once the backend process is alive (a few seconds).
+    await wait_for(
+        lambda: _running_instances_for(http_control, MODEL_NAME),
+        timeout=60.0,
+        interval=0.5,
+        description=f"catalog shows a running instance for {MODEL_NAME}",
+    )
+
+    item = await _catalog_item(http_control, MODEL_NAME)
+    assert item is not None
+    assert item["solar"]["status"] == "available"
+    assert item["solar"]["running_instances"] == 1
+    assert len(item["solar"]["instances"]) == 1
+    assert item["solar"]["instances"][0]["host_id"] == host["id"]
+    assert item["solar"]["instances"][0]["instance_id"] == instance_id
+    # The instance was created via control -> host pulled the model too.
+    assert item["solar"]["deployed_hosts"], "expected the model on host-a"


### PR DESCRIPTION
## Description
D-018: model catalog endpoint for Solar WebUI. `GET /api/catalog/models` proxies Data Repository's D-013 model list (`search`/`limit`/`offset` passthrough, `{total, items}` shape preserved) and enriches each model with Solar runtime context: running instance count, deployed hosts (availability on hosts), and a derived deployment status (`available` / `deployed` / `unavailable` / `unknown`). Data Repository stays the authority for catalog metadata and versions; Solar Control adds runtime context only. Enrichment is best-effort — host polling failures degrade `meta.enrichment` (`ok`/`partial`/`unavailable`) and fall back to honest `unknown` statuses instead of misleading operators.

## Changes
- **New endpoint** `GET /api/catalog/models` (`app/routes/management/catalog.py`): D-013 proxy with clear error mapping — 502 Data Repository unreachable/upstream, 500 not configured, 404/422 propagated, 422 invalid query params (FastAPI validation)
- **Availability enrichment**: per-host `GET /models` polling (same mechanism as S-020), joined on the authoritative host manifest `model_name` (D-016) with legacy `name` fallback
- **Running instance enrichment**: instances counted from the WS-pushed host instance cache, joined via `model_source` (`repo://name:version`, `huggingface://org/model`)
- **Status derivation**: `available` (running instances) / `deployed` (on hosts) / `unavailable` / `unknown` (availability source down — never a false negative); `meta.enrichment` response metadata for partial failures
- **Env prerequisites**: `DATA_REPOSITORY_URL` / `DATA_REPOSITORY_API_KEY` / `DATA_REPOSITORY_TIMEOUT_S` passthrough in `docker-compose.yml` (k8s values already configure the URL)
- **Tests**:
  - Unit (`tests/test_catalog.py`, 15 tests): proxy pagination/search forwarding, successful enrichment, Data Repository failure (502/500/upstream), missing/unavailable S-020 enrichment behavior, legacy host entries, instance source variants
  - Integration (`tests_integration/repo_path/test_catalog.py`, 4 tests on the live stack): catalog total matches data-repo, `limit`/`search` passthrough, `deployed_hosts` after distribute, `status=available` with `running_instances=1` after instance start

## Related Issues
Fixes #45
