### PR TITLE
fix(resolvers): forward backend_type to host pulls for gguf selection

### DIFF
--- a/app/model_resolvers/dispatcher.py
+++ b/app/model_resolvers/dispatcher.py
@@ -3,10 +3,20 @@ from .huggingface import resolve_huggingface
 from .repo import resolve_repo
 
 
-async def resolve(uri_str: str, host_url: str, host_api_key: str) -> str:
+async def resolve(
+    uri_str: str,
+    host_url: str,
+    host_api_key: str,
+    backend_type: str | None = None,
+) -> str:
     """
     Parses a URI and dispatches to the correct resolver.
     Returns a resolved local:// URI.
+
+    ``backend_type`` is forwarded to the host pull for ``repo://`` URIs so
+    llama.cpp artifacts resolve to their largest ``*.gguf`` (the host needs
+    a file, not a directory).  ``local://`` and ``huggingface://`` are never
+    affected.
     """
     parsed = parse(uri_str)
 
@@ -18,7 +28,7 @@ async def resolve(uri_str: str, host_url: str, host_api_key: str) -> str:
         return await resolve_huggingface(parsed, uri_str, host_url, host_api_key)
 
     elif isinstance(parsed, RepoURI):
-        return await resolve_repo(uri_str, host_url, host_api_key)
+        return await resolve_repo(uri_str, host_url, host_api_key, backend_type)
 
     else:
         # Should not happen if parser is correct

--- a/app/model_resolvers/repo.py
+++ b/app/model_resolvers/repo.py
@@ -119,19 +119,23 @@ def validate_resolved_model(payload: dict[str, Any], source_uri: str) -> None:
         raise HTTPException(
             status_code=422,
             detail=(
-                "Data Repository response missing harbor_ref for "
-                f"URI '{source_uri}'."
+                f"Data Repository response missing harbor_ref for URI '{source_uri}'."
             ),
         )
 
 
 def build_harbor_pull_payload(
-    resolved: dict[str, Any], source_uri: str
+    resolved: dict[str, Any], source_uri: str, backend_type: str | None = None
 ) -> dict[str, Any]:
     """Build the ``POST /models/pull`` body for a resolved Harbor artifact.
 
     Centralised so the dispatcher resolver and the /distribute route stay in
     lockstep on what gets forwarded to solar-host.
+
+    ``backend_type`` (e.g. ``"llamacpp"`` from an intent) is forwarded when
+    known so solar-host can resolve a ``repo://`` artifact to its largest
+    ``*.gguf`` instead of the directory.  Distribution does not declare a
+    backend (None) and therefore never triggers selection.
     """
     payload: dict[str, Any] = {
         "source": "harbor",
@@ -143,6 +147,7 @@ def build_harbor_pull_payload(
         "size_bytes": resolved.get("size_bytes"),
         "checksum": resolved.get("checksum"),
         "metadata": resolved.get("metadata"),
+        "backend_type": backend_type,
     }
     digest = resolved.get("checksum")
     if digest:
@@ -224,7 +229,12 @@ async def post_harbor_pull(
         )
 
 
-async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str:
+async def resolve_repo(
+    source_uri: str,
+    host_url: str,
+    host_api_key: str,
+    backend_type: str | None = None,
+) -> str:
     """Resolve a ``repo://`` URI end-to-end.
 
     Calls Data Repository for metadata, validates the result, then asks the
@@ -236,6 +246,10 @@ async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str
     selector: Data Repository is queried with ``repo://name:version`` only,
     while the full URI — subpath included — is forwarded to the host pull
     so the returned path resolves to the file.
+
+    ``backend_type`` is forwarded to the host pull: when it is ``"llamacpp"``
+    and the URI carries no subpath, the host resolves the artifact to its
+    largest ``*.gguf`` so llama-server receives a file, not a directory.
     """
     from app.model_resolvers.parser import RepoURI, parse
 
@@ -247,7 +261,7 @@ async def resolve_repo(source_uri: str, host_url: str, host_api_key: str) -> str
     resolved = await resolve_from_data_repository(repo_lookup_uri)
     validate_resolved_model(resolved, repo_lookup_uri)
 
-    payload = build_harbor_pull_payload(resolved, source_uri)
+    payload = build_harbor_pull_payload(resolved, source_uri, backend_type)
     path, _cached = await post_harbor_pull(
         payload=payload,
         host_url=host_url,

--- a/app/services/migration.py
+++ b/app/services/migration.py
@@ -59,13 +59,17 @@ async def create_instance_on_host(
     config = instance_data.get("config", instance_data)
     model_source = config.get("model_source")
     if model_source and not config.get("model") and not config.get("model_id"):
-        resolved = await resolve(model_source, host.url, host.api_key)
+        backend_type = config.get("backend_type", "llamacpp")
+        # Forward the backend so repo:// pulls for llama.cpp resolve to the
+        # largest *.gguf in the artifact instead of the directory.
+        resolved = await resolve(
+            model_source, host.url, host.api_key, backend_type=backend_type
+        )
         # Extract filesystem path from local:// URI (scheme is 8 chars)
         if resolved.startswith("local://"):
             model_path = resolved[8:]
         else:
             model_path = resolved
-        backend_type = config.get("backend_type", "llamacpp")
         if backend_type.startswith("huggingface"):
             config["model_id"] = model_path
         else:
@@ -170,8 +174,7 @@ async def capture_instance_config(
         raise HTTPException(
             status_code=502,
             detail=(
-                f"Source host '{source_host.name}' is unreachable "
-                f"at {source_host.url}"
+                f"Source host '{source_host.name}' is unreachable at {source_host.url}"
             ),
         )
     except Exception as e:  # noqa: BLE001
@@ -183,8 +186,7 @@ async def capture_instance_config(
     raise HTTPException(
         status_code=404,
         detail=(
-            f"Instance '{instance_id}' not found on source host "
-            f"'{source_host.name}'"
+            f"Instance '{instance_id}' not found on source host '{source_host.name}'"
         ),
     )
 
@@ -385,7 +387,7 @@ async def check_no_active_training(host: Host) -> None:
                     return
 
         active_ids: list[str] = []
-        for job in (jobs if isinstance(jobs, list) else []):
+        for job in jobs if isinstance(jobs, list) else []:
             status = job.get("status") or job.get("state", "")
             if status not in TERMINAL_STATES:
                 job_id = job.get("job_id") or job.get("id", "unknown")
@@ -469,8 +471,7 @@ async def disown_source_instance(
         raise HTTPException(
             status_code=502,
             detail=(
-                f"Source host '{source_host.name}' is unreachable "
-                f"at {source_host.url}"
+                f"Source host '{source_host.name}' is unreachable at {source_host.url}"
             ),
         )
     except Exception as e:  # noqa: BLE001
@@ -542,8 +543,7 @@ async def stop_source_instance(source_host: Host, instance_id: str) -> dict[str,
         raise HTTPException(
             status_code=502,
             detail=(
-                f"Source host '{source_host.name}' is unreachable "
-                f"at {source_host.url}"
+                f"Source host '{source_host.name}' is unreachable at {source_host.url}"
             ),
         )
     except Exception as e:  # noqa: BLE001

--- a/tests/test_model_resolvers.py
+++ b/tests/test_model_resolvers.py
@@ -270,6 +270,65 @@ async def test_resolve_repo_success(repo_settings):
 
 
 @pytest.mark.anyio
+async def test_resolve_repo_forwards_backend_type(repo_settings):
+    """llamacpp backend is forwarded in the pull payload for GGUF selection."""
+    uri = "repo://iris-osl:v3"
+    host_url = "http://host:8000"
+
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = _repo_resolve_payload()
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        pull_resp = AsyncMock()
+        pull_resp.status = 200
+        pull_resp.json.return_value = {
+            "path": "/opt/solar/models/repo--iris-osl--v3/model.gguf",
+            "cached": True,
+        }
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        resolved = await resolve(uri, host_url, "key", backend_type="llamacpp")
+
+        assert resolved == "local:///opt/solar/models/repo--iris-osl--v3/model.gguf"
+        _, post_kwargs = mock_post.call_args
+        assert post_kwargs["json"]["backend_type"] == "llamacpp"
+
+
+@pytest.mark.anyio
+async def test_resolve_repo_default_backend_type_is_none(repo_settings):
+    """No backend declared -> payload carries None (no GGUF selection)."""
+    uri = "repo://iris-osl:v3"
+    host_url = "http://host:8000"
+
+    with (
+        patch("aiohttp.ClientSession.get") as mock_get,
+        patch("aiohttp.ClientSession.post") as mock_post,
+    ):
+        resolve_resp = AsyncMock()
+        resolve_resp.status = 200
+        resolve_resp.json.return_value = _repo_resolve_payload()
+        mock_get.return_value.__aenter__.return_value = resolve_resp
+
+        pull_resp = AsyncMock()
+        pull_resp.status = 200
+        pull_resp.json.return_value = {
+            "path": "/opt/solar/models/repo--iris-osl--v3",
+            "cached": True,
+        }
+        mock_post.return_value.__aenter__.return_value = pull_resp
+
+        await resolve(uri, host_url, "key")
+
+        _, post_kwargs = mock_post.call_args
+        assert post_kwargs["json"]["backend_type"] is None
+
+
+@pytest.mark.anyio
 async def test_resolve_repo_invalid_missing_version():
     # Dispatcher calls parse first, which raises 400
     uri = "repo://iris-osl"


### PR DESCRIPTION
## Description
The GGUF auto-selection in solar-host is keyed off the intent's backend, which only solar-control knows. `create_instance_on_host` now forwards the config's `backend_type` through `resolve()` into the harbor pull payload, so llama.cpp `repo://` intents resolve to the largest `*.gguf` in the artifact instead of the directory. Flows without a backend (model distribution, imperative `local://` usage) send `None` and behave exactly as before.

## Changes
- `app/model_resolvers/dispatcher.py`: `resolve()` accepts optional `backend_type`, forwarded to `resolve_repo()`
- `app/model_resolvers/repo.py`: `resolve_repo()` and `build_harbor_pull_payload()` carry optional `backend_type`
- `app/services/migration.py`: `create_instance_on_host` passes the config `backend_type` when resolving `model_source`
- `tests/test_model_resolvers.py`: 2 new tests (`backend_type` forwarded; default `None`)

## Related Issues
N/A
