### PR TITLE
feat(resources): expose finer-grained details in /api/resources (U-004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Hosts connect via Socket.IO to the `/hosts` namespace; they appear in pending un
 
 ### Resource Queries
 
-- `GET /api/resources` - Aggregated cluster-wide view of host capacity, workloads, and reservations. Supports filters: `role`, `gpu_type`, `min_available_vram_gb`, `min_available_ram_gb`
+- `GET /api/resources` - Aggregated cluster-wide view of host capacity, workloads, and reservations. Supports filters: `role`, `gpu_type`, `min_available_vram_gb`, `min_available_ram_gb`. Each host entry includes finer details for the resource dashboard (U-004): `instances` (inference workload list with aliases), `reservations` (per-reservation details with owner `job_id`, requested vs actual), and `*_training_used_gb` (the portion of in-use capacity consumed by active training job steps)
 
 ### Instance Proxy (via solar-control to host)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,8 @@ from .host import (
     AggregatedResourceResponse as AggregatedResourceResponse,
     Host as Host,
     HostCreate as HostCreate,
+    HostInstanceSummary as HostInstanceSummary,
+    HostReservationSummary as HostReservationSummary,
     HostResourceSnapshot as HostResourceSnapshot,
     HostResponse as HostResponse,
     HostStatus as HostStatus,

--- a/app/models/host.py
+++ b/app/models/host.py
@@ -132,6 +132,44 @@ class ActiveJobSummary(BaseModel):
     )
 
 
+class HostInstanceSummary(BaseModel):
+    """Lightweight view of an inference instance on a host (S-035 detail).
+
+    Mirrors the WS ``instances_update`` shape cached in Redis, so the
+    WebUI can list instance aliases behind the "in use" bar segment
+    without a second API call.
+    """
+
+    id: str
+    alias: str | None = None
+    status: str | None = None
+    backend_type: str | None = None
+    port: int | None = None
+    supported_endpoints: list[str] = Field(default_factory=list)
+
+
+class HostReservationSummary(BaseModel):
+    """Per-reservation detail passed through from solar-host (S-035 detail).
+
+    Mirrors solar-host's ``ReservationView`` so consumers can attribute
+    reserved-but-not-running capacity to its owner (``job_id``) and
+    distinguish pending reservations from running ones. ``actual_*`` is
+    set for running reservations only (``None`` while pending).
+    """
+
+    id: str
+    job_id: str
+    workload_type: str
+    status: str = "pending"
+    vram_gb: float = 0.0
+    ram_gb: float = 0.0
+    disk_gb: float | None = None
+    actual_vram_gb: float | None = None
+    actual_ram_gb: float | None = None
+    actual_disk_gb: float | None = None
+    expires_at: str | None = None
+
+
 class HostResourceSnapshot(BaseModel):
     """Per-host resource snapshot in the aggregated cluster view (S-035).
 
@@ -141,6 +179,14 @@ class HostResourceSnapshot(BaseModel):
     Resource availability follows S-034 semantics:
     ``available = total - (system_used + reserved_headroom)`` where
     ``reserved_headroom = Σ max(reserved − actual, 0)`` per reservation.
+
+    Fine-grained breakdown (U-004): ``instances`` lists the inference
+    workloads behind ``system_used``, ``reservations`` carries the
+    per-reservation details (owner ``job_id``, requested vs actual), and
+    ``*_training_used_gb`` is the portion of ``system_used`` consumed by
+    active training job steps (Σ actuals of running reservations). The
+    remaining in-use capacity (``system_used - *_training_used_gb``) is
+    inference instances + OS.
     """
 
     host_id: str
@@ -184,6 +230,9 @@ class HostResourceSnapshot(BaseModel):
     instance_count: int = 0
     running_instance_count: int = 0
 
+    # Inference workload details (U-004 — from Redis instance cache)
+    instances: list[HostInstanceSummary] = Field(default_factory=list)
+
     # Active job workloads (from jobs table — training pipelines etc.)
     active_jobs: list[ActiveJobSummary] = Field(
         default_factory=list,
@@ -195,6 +244,14 @@ class HostResourceSnapshot(BaseModel):
     reservation_vram_total_gb: float = 0.0
     reservation_ram_total_gb: float = 0.0
     reservation_disk_total_gb: float = 0.0
+
+    # Per-reservation details (U-004 — passed through from solar-host)
+    reservations: list[HostReservationSummary] = Field(default_factory=list)
+
+    # Active training job-step consumption (Σ actuals of running reservations)
+    vram_training_used_gb: float = 0.0
+    ram_training_used_gb: float = 0.0
+    disk_training_used_gb: float = 0.0
 
     # Timestamps
     snapshot_timestamp: str | None = None

--- a/app/routes/management/resources.py
+++ b/app/routes/management/resources.py
@@ -11,7 +11,13 @@ import aiohttp
 from fastapi import APIRouter, HTTPException, Query
 
 from app.database.hosts import host_db
-from app.models import Host, HostResourceSnapshot, AggregatedResourceResponse
+from app.models import (
+    AggregatedResourceResponse,
+    Host,
+    HostInstanceSummary,
+    HostReservationSummary,
+    HostResourceSnapshot,
+)
 from app.redis_state import host_store
 from app.services.host_status import get_host_active_jobs
 
@@ -53,6 +59,18 @@ async def _fetch_host_resource_snapshot(
         base.running_instance_count = sum(
             1 for i in instances if i.get("status") == "running"
         )
+        base.instances = [
+            HostInstanceSummary(
+                id=i["id"],
+                alias=i.get("alias"),
+                status=i.get("status"),
+                backend_type=i.get("backend_type"),
+                port=i.get("port"),
+                supported_endpoints=list(i.get("supported_endpoints") or []),
+            )
+            for i in instances
+            if i.get("id")
+        ]
     except Exception:
         logger.warning(
             "Failed to fetch instances from Redis for host %s",
@@ -106,7 +124,7 @@ async def _fetch_host_resource_snapshot(
         setattr(base, f"{dim_name}_reported_used_gb", dim.get("reported_used_gb"))
         setattr(base, f"{dim_name}_available_gb", dim.get("available_gb"))
 
-    # Merge reservation summary
+    # Merge reservation details + totals
     reservations = data.get("reservations", [])
     base.reservation_count = len(reservations)
     base.reservation_vram_total_gb = sum(
@@ -115,6 +133,48 @@ async def _fetch_host_resource_snapshot(
     base.reservation_ram_total_gb = sum(float(r.get("ram_gb", 0)) for r in reservations)
     base.reservation_disk_total_gb = sum(
         float(r.get("disk_gb") or 0) for r in reservations
+    )
+    base.reservations = [
+        HostReservationSummary(
+            id=r["id"],
+            job_id=str(r.get("job_id", "")),
+            workload_type=str(r.get("workload_type", "training")),
+            status=str(r.get("status", "pending")),
+            vram_gb=float(r.get("vram_gb") or 0),
+            ram_gb=float(r.get("ram_gb") or 0),
+            disk_gb=float(r["disk_gb"]) if r.get("disk_gb") is not None else None,
+            actual_vram_gb=(
+                float(r["actual_vram_gb"])
+                if r.get("actual_vram_gb") is not None
+                else None
+            ),
+            actual_ram_gb=(
+                float(r["actual_ram_gb"])
+                if r.get("actual_ram_gb") is not None
+                else None
+            ),
+            actual_disk_gb=(
+                float(r["actual_disk_gb"])
+                if r.get("actual_disk_gb") is not None
+                else None
+            ),
+            expires_at=r.get("expires_at"),
+        )
+        for r in reservations
+        if r.get("id")
+    ]
+
+    # Active training job-step consumption: Σ actual usage of running
+    # reservations (pending reservations have no actuals yet — their full
+    # requested amount is already captured in reserved_headroom).
+    base.vram_training_used_gb = sum(
+        float(r.get("actual_vram_gb") or 0) for r in reservations
+    )
+    base.ram_training_used_gb = sum(
+        float(r.get("actual_ram_gb") or 0) for r in reservations
+    )
+    base.disk_training_used_gb = sum(
+        float(r.get("actual_disk_gb") or 0) for r in reservations
     )
 
     return base
@@ -148,6 +208,13 @@ async def get_resources(
     ``reserved_headroom = Σ max(reserved − actual, 0)`` per reservation.
     This correctly implements ``effective = max(actual, requested)`` —
     real consumption is never double-counted.
+
+    Per-host finer details (U-004): ``instances`` lists the inference
+    workloads (with aliases) behind ``system_used``; ``reservations``
+    carries per-reservation details (owner ``job_id``, requested vs
+    actual per dimension); ``*_training_used_gb`` is the portion of
+    ``system_used`` consumed by active training job steps (Σ actuals of
+    running reservations).
     """
     if isinstance(host_id, str):
         host = await host_db.get_host(host_id)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -91,7 +91,21 @@ def live_resource_payload():
                 "vram_gb": 20.0,
                 "ram_gb": 64.0,
                 "disk_gb": 50.0,
-            }
+                "expires_at": "2026-08-05T00:00:00Z",
+            },
+            {
+                "id": "res-2",
+                "job_id": "job-2",
+                "workload_type": "training",
+                "status": "running",
+                "vram_gb": 10.0,
+                "ram_gb": 32.0,
+                "disk_gb": 25.0,
+                "actual_vram_gb": 6.0,
+                "actual_ram_gb": 16.0,
+                "actual_disk_gb": 10.0,
+                "expires_at": "2026-08-06T00:00:00Z",
+            },
         ],
     }
 
@@ -110,7 +124,14 @@ async def test_fetch_host_resource_snapshot_success(
     ):
         mock_store.get_host_instances = AsyncMock(
             return_value=[
-                {"id": "inst-1", "status": "running"},
+                {
+                    "id": "inst-1",
+                    "alias": "llama-3-8b",
+                    "status": "running",
+                    "backend_type": "llamacpp",
+                    "port": 8081,
+                    "supported_endpoints": ["chat", "completion"],
+                },
                 {"id": "inst-2", "status": "stopped"},
             ]
         )
@@ -135,11 +156,120 @@ async def test_fetch_host_resource_snapshot_success(
         assert snap.disk_available_gb == 750.0
         assert snap.instance_count == 2
         assert snap.running_instance_count == 1
-        assert snap.reservation_count == 1
-        assert snap.reservation_vram_total_gb == 20.0
-        assert snap.reservation_ram_total_gb == 64.0
-        assert snap.reservation_disk_total_gb == 50.0
+        assert snap.reservation_count == 2
+        assert snap.reservation_vram_total_gb == 30.0
+        assert snap.reservation_ram_total_gb == 96.0
+        assert snap.reservation_disk_total_gb == 75.0
         assert snap.active_jobs == []
+
+        # Instance details passed through from the Redis cache (U-004)
+        assert len(snap.instances) == 2
+        first = snap.instances[0]
+        assert first.id == "inst-1"
+        assert first.alias == "llama-3-8b"
+        assert first.status == "running"
+        assert first.backend_type == "llamacpp"
+        assert first.port == 8081
+        assert first.supported_endpoints == ["chat", "completion"]
+        assert snap.instances[1].alias is None
+
+        # Reservation details passed through from solar-host (U-004)
+        assert len(snap.reservations) == 2
+        pending = snap.reservations[0]
+        assert pending.id == "res-1"
+        assert pending.job_id == "job-1"
+        assert pending.status == "pending"
+        assert pending.vram_gb == 20.0
+        assert pending.actual_vram_gb is None
+        running = snap.reservations[1]
+        assert running.job_id == "job-2"
+        assert running.status == "running"
+        assert running.actual_vram_gb == 6.0
+        assert running.actual_ram_gb == 16.0
+        assert running.actual_disk_gb == 10.0
+        assert running.expires_at == "2026-08-06T00:00:00Z"
+
+        # Training usage = Σ actuals of running reservations; pending
+        # reservations contribute 0 (their requested amount is headroom).
+        assert snap.vram_training_used_gb == 6.0
+        assert snap.ram_training_used_gb == 16.0
+        assert snap.disk_training_used_gb == 10.0
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_training_usage(mock_host_online):
+    """Pending reservations contribute 0 to training usage; running ones
+    contribute their actuals (S-034 effective semantics, U-004)."""
+    payload = {
+        "vram": {"total_gb": 80.0, "system_used_gb": 30.0},
+        "ram": {"total_gb": 256.0, "system_used_gb": 64.0},
+        "disk": {"total_gb": 1000.0, "system_used_gb": 200.0},
+        "reservations": [
+            {
+                "id": "res-pending",
+                "job_id": "job-p",
+                "status": "pending",
+                "vram_gb": 20.0,
+                "ram_gb": 40.0,
+                "disk_gb": 50.0,
+            },
+            {
+                "id": "res-running",
+                "job_id": "job-r",
+                "status": "running",
+                "vram_gb": 10.0,
+                "ram_gb": 20.0,
+                "disk_gb": 25.0,
+                "actual_vram_gb": 7.0,
+                "actual_ram_gb": 0.0,
+                # no actual_disk_gb: treated as 0
+            },
+        ],
+    }
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=payload)
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+    assert snap.reservation_count == 2
+    assert snap.vram_training_used_gb == 7.0
+    assert snap.ram_training_used_gb == 0.0
+    assert snap.disk_training_used_gb == 0.0
+    pending = snap.reservations[0]
+    assert pending.job_id == "job-p"
+    assert pending.actual_vram_gb is None
+
+
+@pytest.mark.anyio
+async def test_fetch_host_resource_snapshot_no_reservations(mock_host_online):
+    """A host payload without a reservations key yields empty details."""
+    payload = {
+        "vram": {"total_gb": 80.0, "system_used_gb": 10.0},
+    }
+    with (
+        patch("app.routes.management.resources.host_store") as mock_store,
+        patch("aiohttp.ClientSession.get") as mock_get,
+    ):
+        mock_store.get_host_instances = AsyncMock(return_value=[])
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=payload)
+        mock_get.return_value.__aenter__.return_value = mock_resp
+
+        snap = await _fetch_host_resource_snapshot(mock_host_online)
+
+    assert snap.reservation_count == 0
+    assert snap.reservations == []
+    assert snap.vram_training_used_gb == 0.0
+    assert snap.ram_training_used_gb == 0.0
+    assert snap.disk_training_used_gb == 0.0
 
 
 @pytest.mark.anyio

--- a/tests_integration/infrastructure/test_host_channel.py
+++ b/tests_integration/infrastructure/test_host_channel.py
@@ -113,6 +113,85 @@ async def test_instances_update_populates_redis(
         description="instance running in control's view",
     )
 
+    # The finer-detail snapshot lists the instance with its alias (U-004).
+    resp = await http_control.get("/api/resources")
+    assert resp.status_code == 200, resp.text
+    snap = next(h for h in resp.json()["hosts"] if h["host_id"] == host_a["id"])
+    assert any(
+        inst.get("id") == instance_id and inst.get("alias") == alias
+        for inst in snap.get("instances", [])
+    )
+
+
+async def test_resources_snapshot_exposes_reservation_details(
+    http_control, http_host, clean_state
+):
+    """Per-reservation details (owner job_id, status, requested vs actual)
+    pass through solar-host -> control -> /api/resources (U-004)."""
+    hosts = {h["name"]: h for h in (await http_control.get("/api/hosts")).json()}
+    host_a = hosts["host-a"]
+
+    # Baseline: every reachable host entry exposes the finer-detail fields.
+    resp = await http_control.get("/api/resources")
+    assert resp.status_code == 200, resp.text
+    snap = next(h for h in resp.json()["hosts"] if h["host_id"] == host_a["id"])
+    assert snap["reachable"] is True
+    assert isinstance(snap["instances"], list)
+    assert isinstance(snap["reservations"], list)
+    for key in (
+        "vram_training_used_gb",
+        "ram_training_used_gb",
+        "disk_training_used_gb",
+    ):
+        assert key in snap
+
+    # Create a reservation directly on the host (bypasses the S-038
+    # coordinator; a pending reservation has no actuals yet).
+    job_id = f"job-{uuid.uuid4().hex[:8]}"
+    resp = await http_host.post(
+        "/resources/reservations",
+        json={
+            "job_id": job_id,
+            "requester": "integration-test",
+            "workload_type": "training",
+            "vram_gb": 0.0,
+            "ram_gb": 1.0,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    reservation = resp.json()
+
+    async def visible() -> bool:
+        r = await http_control.get("/api/resources")
+        if r.status_code != 200:
+            return False
+        snap = next(
+            (h for h in r.json()["hosts"] if h["host_id"] == host_a["id"]),
+            None,
+        )
+        if not snap:
+            return False
+        return any(
+            x.get("id") == reservation["id"] for x in snap.get("reservations", [])
+        )
+
+    await wait_for(
+        visible,
+        timeout=60.0,
+        interval=0.5,
+        description="reservation visible in /api/resources",
+    )
+
+    resp = await http_control.get("/api/resources")
+    snap = next(h for h in resp.json()["hosts"] if h["host_id"] == host_a["id"])
+    entry = next(x for x in snap["reservations"] if x["id"] == reservation["id"])
+    assert entry["job_id"] == job_id
+    assert entry["status"] == "pending"
+    assert entry["workload_type"] == "training"
+    assert entry["ram_gb"] == 1.0
+    assert entry["actual_ram_gb"] is None
+    assert snap["reservation_count"] >= 1
+
 
 async def _running(http_control, host_id: str, instance_id: str) -> bool:
     return await _instance_status(http_control, host_id, instance_id) == "running"


### PR DESCRIPTION
## Description

Extends `GET /api/resources` (S-035) with the finer-grained per-host details the Solar WebUI resource dashboard (U-004, DamitDev/solar-webui#24) needs to render per-consumer allocation bars and workload lists — all sourced from data Solar Control already has (Redis instance cache + the solar-host reservation payload), with no changes to availability semantics.

## Changes

- `app/models/host.py`: new `HostInstanceSummary` and `HostReservationSummary` models; `HostResourceSnapshot` gains `instances`, `reservations`, and `vram/ram/disk_training_used_gb` fields (existing totals remain, backward compatible).
- `app/routes/management/resources.py`: passes through the inference instance list (with aliases) from the Redis cache and per-reservation details from solar-host (owner `job_id`, workload_type, status, requested vs actual per dimension); computes `*_training_used_gb` as Σ actuals of running reservations, so the inference/training split of `system_used` is served by the API instead of being derived client-side.
- `tests/test_resources.py`: unit coverage for instance/reservation passthrough, training-usage semantics (pending → 0, running → actuals), and the missing-reservations edge case.
- `tests_integration/infrastructure/test_host_channel.py`: end-to-end coverage — a live host's instance appears in the snapshot with its alias, and a reservation created on the host surfaces through control with its `job_id`.
- `README.md`: documents the new fields.

## Related Issues

Supports DamitDev/solar-webui#24 (U-004) · extends S-035 (#36)
